### PR TITLE
Patch 25.43 Link Arrows & macOS Scroll Fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Alt + Spacebar                # open Spotlight command bar
 Enter / Tab / Ctrl+N         # create mindmap nodes
 Ctrl + .                     # toggle Zen Mode
 Ctrl + Q                     # quit
+Ctrl + ← / → (Cmd on macOS)    # horizontal scroll
 🧱 Architecture
 
 src/

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -14,6 +14,8 @@
 | `Ctrl + D`       | Delete node                  |
 | `Alt + ↑ / ↓`    | Move node among siblings     |
 | `Ctrl + Shift + M` | Move/Drag node             |
+| `Ctrl + ← / →`   | Horizontal scroll            |
+| `Cmd + ← / →` (macOS) | Horizontal scroll       |
 
 ---
 

--- a/src/input/mac_fallback.rs
+++ b/src/input/mac_fallback.rs
@@ -1,0 +1,24 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+use crate::state::AppState;
+
+/// Handle Cmd+Left/Right scrolling on macOS.
+/// Returns true if the event was handled.
+pub fn handle_cmd_arrows(code: KeyCode, modifiers: KeyModifiers, state: &mut AppState) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if modifiers.contains(KeyModifiers::SUPER) && state.mode == "gemx" {
+            match code {
+                KeyCode::Left => {
+                    state.scroll_x = state.scroll_x.saturating_sub(4);
+                    return true;
+                }
+                KeyCode::Right => {
+                    state.scroll_x = state.scroll_x.saturating_add(4);
+                    return true;
+                }
+                _ => {}
+            }
+        }
+    }
+    false
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,0 +1,1 @@
+pub mod mac_fallback;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod keymap;
 pub mod spotlight;
 pub mod theme;
 pub mod clipboard;
+pub mod input;
 pub mod dashboard;
 pub mod render;
 pub mod gemx;

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -95,4 +95,21 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         let para = Paragraph::new(label).style(style);
         f.render_widget(para, Rect::new(x.saturating_sub(scroll_x), y, width as u16, 1));
     }
+
+    // Draw link arrows between nodes (horizontal layout)
+    for (source, targets) in &state.link_map {
+        for target in targets {
+            if let (Some(&Coords { x: sx, y: sy }), Some(&Coords { x: tx, y: ty })) = (drawn_at.get(source), drawn_at.get(target)) {
+                if sy == ty && sy < area.height {
+                    let arrow = if sx < tx { "→" } else { "←" };
+                    let mid = (sx + tx) / 2;
+                    let scroll_x = state.scroll_x.max(0) as u16;
+                    if mid >= scroll_x && mid < scroll_x + area.width {
+                        let para = Paragraph::new(arrow);
+                        f.render_widget(para, Rect::new(mid.saturating_sub(scroll_x), sy, 1, 1));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -195,6 +195,12 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.mode = "settings".into();
                 }
 
+                // 🍎 macOS fallback for Cmd+Arrow scrolling
+                if crate::input::mac_fallback::handle_cmd_arrows(code, modifiers, &mut state) {
+                    draw(&mut terminal, &mut state, &last_key)?;
+                    continue;
+                }
+
                 // ⌨️ Navigation + Typing
                 match code {
                     KeyCode::Esc => {


### PR DESCRIPTION
## Summary
- draw directional link arrows in GemX view
- add macOS Cmd+Left/Right fallback for horizontal scrolling
- document macOS fallback keys in README and cheatsheet

## Testing
- `bash patches/patch-25.43-link-arrows-mac-scroll/test_plan.sh` *(fails: could not download crates)*
- `cargo build --offline` *(fails: could not fetch chrono crate)*