### PR TITLE
Implement patch 25.44 drag-and-drop features

### DIFF
--- a/src/gemx.rs
+++ b/src/gemx.rs
@@ -1,2 +1,4 @@
 pub mod nodes;
 pub mod state;
+pub mod interaction;
+pub mod render;

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -1,0 +1,15 @@
+use crate::state::AppState;
+use crate::node::NodeID;
+
+/// Drag a node by a delta in pixels.
+/// When `snap_to_grid` is enabled on the state, the node will snap to
+/// 20px increments after movement.
+pub fn drag_node(state: &mut AppState, node_id: NodeID, dx: i16, dy: i16) {
+    state.drag_node_position(node_id, dx, dy);
+}
+
+/// Toggle the global snap-to-grid option.
+/// Bound to Ctrl+G via input hotkeys.
+pub fn toggle_snap(state: &mut AppState) {
+    state.toggle_snap_to_grid();
+}

--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -1,0 +1,27 @@
+use std::collections::HashMap;
+
+use crate::{layout, node::NodeID, state::AppState};
+use layout::Coords;
+
+/// Calculate drawing coordinates for nodes.
+/// When auto_arrange is enabled, uses the tree layout. Otherwise,
+/// returns the manually stored x/y positions on each node.
+pub fn calculate_positions(state: &AppState, root: NodeID) -> HashMap<NodeID, Coords> {
+    if state.auto_arrange {
+        layout::layout_nodes(&state.nodes, root, 2, 1)
+    } else {
+        state
+            .nodes
+            .iter()
+            .map(|(&id, n)| {
+                (
+                    id,
+                    Coords {
+                        x: n.x as u16,
+                        y: n.y as u16,
+                    },
+                )
+            })
+            .collect()
+    }
+}

--- a/src/input/hotkeys.rs
+++ b/src/input/hotkeys.rs
@@ -1,0 +1,9 @@
+/// Input hotkey definitions for the GemX module.
+/// Provides a binding for toggling snap-to-grid mode.
+///
+/// Currently only used for documentation/testing.
+const SNAP_TOGGLE: &str = "Ctrl+G";
+
+pub fn snap_toggle_key() -> &'static str {
+    SNAP_TOGGLE
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,1 +1,2 @@
 pub mod mac_fallback;
+pub mod hotkeys;

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,6 +9,10 @@ pub struct Node {
     pub parent: Option<NodeID>,
     pub children: Vec<NodeID>,
     pub collapsed: bool,
+    /// X coordinate when manually positioned
+    pub x: i32,
+    /// Y coordinate when manually positioned
+    pub y: i32,
 }
 
 impl Node {
@@ -19,6 +23,8 @@ impl Node {
             parent,
             children: vec![],
             collapsed: false,
+            x: 0,
+            y: 0,
         }
     }
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -1,7 +1,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
-use crate::layout::{layout_nodes, Coords};
+use crate::layout::Coords;
 use crate::state::AppState;
+use crate::gemx::render::calculate_positions;
 use std::collections::HashMap;
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -20,7 +21,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let mut y = 1;
 
     for &root_id in &roots {
-        let layout = layout_nodes(&state.nodes, root_id, 2, y);
+        let layout = calculate_positions(state, root_id);
         let max_y = layout.values().map(|c| c.y).max().unwrap_or(y);
         drawn_at.extend(layout);
         y = max_y.saturating_add(3);

--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -24,6 +24,7 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("start_drag".into(), "ctrl-r".into());
     map.insert("start_link".into(), "ctrl-l".into());
     map.insert("redo".into(), "ctrl-shift-z".into());
+    map.insert("toggle_snap".into(), "ctrl-g".into());
 
 
     map

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -26,6 +26,7 @@ pub struct AppState {
     pub auto_arrange: bool,
     pub scroll_x: i16,
     pub drawing_root: Option<NodeID>,
+    pub snap_to_grid: bool,
 
 }
 
@@ -60,6 +61,7 @@ impl Default for AppState {
             auto_arrange: true,
             scroll_x: 0,
             drawing_root: None,
+            snap_to_grid: false,
 
         }
     }
@@ -287,6 +289,23 @@ impl AppState {
             self.undo_stack.push(self.nodes.clone());
             self.nodes = next;
         }
+    }
+
+    /// Move a node by a delta, applying optional snap-to-grid.
+    pub fn drag_node_position(&mut self, node_id: NodeID, dx: i16, dy: i16) {
+        if let Some(node) = self.nodes.get_mut(&node_id) {
+            node.x = node.x.saturating_add(dx as i32);
+            node.y = node.y.saturating_add(dy as i32);
+            if self.snap_to_grid {
+                node.x = ((node.x + 10) / 20) * 20;
+                node.y = ((node.y + 10) / 20) * 20;
+            }
+        }
+    }
+
+    /// Toggle snap-to-grid behavior
+    pub fn toggle_snap_to_grid(&mut self) {
+        self.snap_to_grid = !self.snap_to_grid;
     }
 
     pub fn start_drag(&mut self) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -185,6 +185,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.export_zen_to_file();
                 } else if match_hotkey("mode_zen", code, modifiers, &state) {
                     state.mode = "zen".into();
+                } else if match_hotkey("toggle_snap", code, modifiers, &state) {
+                    state.toggle_snap_to_grid();
                 } else if match_hotkey("toggle_collapsed", code, modifiers, &state) && state.mode == "gemx" {
                     state.toggle_collapse();
                 } else if match_hotkey("drill_down", code, modifiers, &state) {


### PR DESCRIPTION
## Summary
- add X/Y coordinates to `Node` for manual positioning
- store `snap_to_grid` flag in `AppState`
- implement drag helpers and snap toggle in state and new modules
- register `Ctrl+G` snap toggle hotkey
- respect snap toggle in the TUI and layout logic

## Testing
- `cargo build -q`
- `bash patches/patch-25.44-drag-drop-snap/test_plan.sh`