### PR TITLE
Patch 25.47 workspace switching

### DIFF
--- a/src/input/hotkeys.rs
+++ b/src/input/hotkeys.rs
@@ -1,2 +1,5 @@
 /// Input hotkey definitions for PrismX
 pub const SNAP_GRID_TOGGLE: &str = "Ctrl+G";
+pub const WORKSPACE_SWITCH: &str = "Ctrl +Tab";
+pub const WORKSPACE_SAVE: &str = "Ctrl +Shift +S";
+pub const WORKSPACE_LOAD: &str = "Ctrl +Shift +O";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,4 @@ pub mod gemx;
 pub mod routineforge;
 pub mod settings;
 pub mod state;
+pub mod storage;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 pub type NodeID = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Node {
     pub id: NodeID,
     pub label: String,

--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -25,6 +25,9 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("start_link".into(), "ctrl-l".into());
     map.insert("redo".into(), "ctrl-shift-z".into());
     map.insert("toggle_snap_grid".into(), "ctrl-g".into());
+    map.insert("switch_workspace".into(), "ctrl-tab".into());
+    map.insert("save_workspace".into(), "ctrl+shift-s".into());
+    map.insert("load_workspace".into(), "ctrl+shift-o".into());
 
 
     map

--- a/src/state/workspace.rs
+++ b/src/state/workspace.rs
@@ -1,0 +1,47 @@
+use crate::node::{NodeMap, NodeID};
+use crate::storage::json_io::{WorkspaceData, save_workspace, load_workspace};
+
+pub struct WorkspaceSet {
+    pub spaces: Vec<WorkspaceData>,
+    pub current: usize,
+}
+
+impl WorkspaceSet {
+    pub fn new(initial: WorkspaceData) -> Self {
+        Self { spaces: vec![initial], current: 0 }
+    }
+
+    pub fn current_data(&self) -> WorkspaceData {
+        self.spaces.get(self.current).cloned().unwrap_or_default()
+    }
+
+    pub fn replace_current(&mut self, data: WorkspaceData) {
+        if self.current >= self.spaces.len() {
+            self.spaces.push(data);
+        } else {
+            self.spaces[self.current] = data;
+        }
+    }
+
+    pub fn switch_next(&mut self) {
+        if self.spaces.is_empty() {
+            return;
+        }
+        self.current = (self.current + 1) % self.spaces.len();
+    }
+
+    pub fn save_current(&self) {
+        let _ = save_workspace(&self.spaces[self.current]);
+    }
+
+    pub fn load_into_current(&mut self) {
+        if let Ok(data) = load_workspace() {
+            if self.current < self.spaces.len() {
+                self.spaces[self.current] = data;
+            } else {
+                self.spaces.push(data);
+                self.current = self.spaces.len() - 1;
+            }
+        }
+    }
+}

--- a/src/storage/json_io.rs
+++ b/src/storage/json_io.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::path::Path;
+use serde::{Serialize, Deserialize};
+use crate::node::{NodeMap, NodeID};
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct WorkspaceData {
+    pub nodes: NodeMap,
+    pub root_nodes: Vec<NodeID>,
+}
+
+pub fn save_workspace(data: &WorkspaceData) -> std::io::Result<()> {
+    let path = Path::new("./data/workspace.json");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(data).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    fs::write(path, json)
+}
+
+pub fn load_workspace() -> std::io::Result<WorkspaceData> {
+    let path = Path::new("./data/workspace.json");
+    let data = fs::read_to_string(path)?;
+    let ws: WorkspaceData = serde_json::from_str(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    Ok(ws)
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,1 @@
+pub mod json_io;

--- a/src/tui/hotkeys.rs
+++ b/src/tui/hotkeys.rs
@@ -53,6 +53,8 @@ pub fn match_hotkey(action: &str, code: KeyCode, mods: KeyModifiers, state: &App
             "r" => code == KeyCode::Char('r'),
             "l" => code == KeyCode::Char('l'),
             "g" => code == KeyCode::Char('g'),
+            "s" => code == KeyCode::Char('s'),
+            "o" => code == KeyCode::Char('o'),
 
 
             _ => false,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,6 +181,12 @@ pub fn launch_ui() -> std::io::Result<()> {
                     } else {
                         state.start_link();
                     }
+                } else if match_hotkey("switch_workspace", code, modifiers, &state) {
+                    state.switch_workspace();
+                } else if match_hotkey("save_workspace", code, modifiers, &state) {
+                    state.save_workspace();
+                } else if match_hotkey("load_workspace", code, modifiers, &state) {
+                    state.load_workspace();
                 } else if match_hotkey("save", code, modifiers, &state) {
                     state.export_zen_to_file();
                 } else if match_hotkey("mode_zen", code, modifiers, &state) {


### PR DESCRIPTION
## Summary
- add serde support to Node
- create JSON IO helpers for workspaces
- track and switch workspace data
- map new workspace hotkeys
- handle workspace hotkeys in the TUI

## Testing
- `bash patches/patch-25.47-workspace-load/test_plan.sh`
- `cargo check`