### PR TITLE
Patch 25.45e – layout collision fix

### DIFF
--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -1,1 +1,11 @@
-pub use crate::layout::{layout_nodes, Coords, CHILD_SPACING_Y, SIBLING_SPACING_X};
+pub use crate::layout::{
+    layout_nodes,
+    ensure_manual_positions,
+    Coords,
+    CHILD_SPACING_Y,
+    SIBLING_SPACING_X,
+};
+
+// Layout algorithm summary:
+// child.x = parent.x + (index - mid) * SIBLING_SPACING_X
+// child.y = parent.y + CHILD_SPACING_Y

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use crate::node::{Node, NodeID, NodeMap};
+use crate::layout::ensure_manual_positions;
 
 mod hotkeys;
 pub use hotkeys::*;
@@ -175,6 +176,9 @@ impl AppState {
                 parent.children.push(new_id);
             }
             self.selected = Some(new_id);
+            if !self.auto_arrange {
+                ensure_manual_positions(&mut self.nodes, &self.root_nodes);
+            }
         }
     }
 
@@ -198,6 +202,9 @@ impl AppState {
                 }
 
                 self.selected = Some(new_id);
+                if !self.auto_arrange {
+                    ensure_manual_positions(&mut self.nodes, &self.root_nodes);
+                }
             }
         }
     }
@@ -253,6 +260,9 @@ impl AppState {
         self.nodes.insert(new_id, node);
         self.root_nodes.push(new_id);
         self.selected = Some(new_id);
+        if !self.auto_arrange {
+            ensure_manual_positions(&mut self.nodes, &self.root_nodes);
+        }
     }
 
     pub fn drill_down(&mut self) {


### PR DESCRIPTION
## Summary
- export layout helpers in gemx module
- keep manual positions unique using ensure_manual_positions
- enforce sibling/child spacing in comments
- update state mutations to run ensure_manual_positions

## Testing
- `bash patches/patch-25.45e-layout-collision-fix/test_plan.sh`
- `cargo check`