### PR TITLE
Implement patch 25.45e layout collision fix

### DIFF
--- a/src/gemx.rs
+++ b/src/gemx.rs
@@ -1,3 +1,4 @@
 pub mod nodes;
 pub mod state;
 pub mod interaction;
+pub mod layout;

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -19,7 +19,7 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
         };
         let mut row = 1;
         for &root_id in &roots {
-            let l = layout_nodes(&state.nodes, root_id, 2, row);
+            let l = layout_nodes(&state.nodes, root_id, 2, row as i16);
             let max_y = l.values().map(|c| c.y).max().unwrap_or(row);
             layout.extend(l);
             row = max_y.saturating_add(3);

--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -1,0 +1,3 @@
+// child.x = parent.x + offset_x
+// child.y = parent.y + CHILD_SPACING_Y
+pub use crate::layout::{layout_nodes, Coords, SIBLING_SPACING_X, CHILD_SPACING_Y};

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
 use crate::node::{NodeID, NodeMap};
 
+/// Horizontal spacing applied between siblings when auto-arranging.
+pub const SIBLING_SPACING_X: i16 = 3;
+/// Vertical spacing applied from parent to its children.
+pub const CHILD_SPACING_Y: i16 = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Coords {
     pub x: u16,
@@ -11,8 +16,8 @@ pub struct Coords {
 pub fn layout_nodes(
     nodes: &NodeMap,
     root_id: NodeID,
-    start_x: u16,
-    start_y: u16,
+    start_x: i16,
+    start_y: i16,
 ) -> HashMap<NodeID, Coords> {
     let mut map = HashMap::new();
     layout_recursive(nodes, root_id, start_x, start_y, &mut map);
@@ -23,26 +28,34 @@ pub fn layout_nodes(
 fn layout_recursive(
     nodes: &NodeMap,
     node_id: NodeID,
-    x: u16,
-    y: u16,
+    x: i16,
+    y: i16,
     out: &mut HashMap<NodeID, Coords>,
-) -> u16 {
-    out.insert(node_id, Coords { x, y });
+) {
+    out.insert(
+        node_id,
+        Coords {
+            x: x.max(0) as u16,
+            y: y.max(0) as u16,
+        },
+    );
 
     let node = match nodes.get(&node_id) {
         Some(n) => n,
-        None => return y,
+        None => return,
     };
 
-    if node.collapsed || node.children.is_empty() {
-        return y;
+    if node.collapsed {
+        return;
     }
 
-    let mut current_y = y + 1;
+    let sibling_count = node.children.len();
+    let mid = sibling_count / 2;
 
-    for child_id in &node.children {
-        current_y = layout_recursive(nodes, *child_id, x + 10, current_y, out) + 1;
+    for (i, &child_id) in node.children.iter().enumerate() {
+        let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
+        let child_x = x + offset_x;
+        let child_y = y + CHILD_SPACING_Y;
+        layout_recursive(nodes, child_id, child_x, child_y, out);
     }
-
-    current_y - 1
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -22,7 +22,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
 
     if state.auto_arrange {
         for &root_id in &roots {
-            let layout = layout_nodes(&state.nodes, root_id, 2, y);
+            let layout = layout_nodes(&state.nodes, root_id, 2, y as i16);
             let max_y = layout.values().map(|c| c.y).max().unwrap_or(y);
             drawn_at.extend(layout);
             y = max_y.saturating_add(3);


### PR DESCRIPTION
## Summary
- define sibling and child spacing constants
- update automatic layout algorithm for spacing
- expose layout module under gemx module and add stub file
- update render and interaction logic for new layout signature

## Testing
- `bash patches/patch-25.45e-layout-collision-fix/test_plan.sh`