### PR TITLE
Implement void-style tree layout

### DIFF
--- a/src/gemx.rs
+++ b/src/gemx.rs
@@ -1,3 +1,4 @@
 pub mod nodes;
 pub mod state;
 pub mod interaction;
+pub mod layout;

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -17,23 +17,23 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
         } else {
             state.root_nodes.clone()
         };
-        let mut row = 1;
+        let mut row: i16 = 1;
         for &root_id in &roots {
             let l = layout_nodes(&state.nodes, root_id, 2, row);
             let max_y = l.values().map(|c| c.y).max().unwrap_or(row);
             layout.extend(l);
-            row = max_y.saturating_add(3);
+            row = max_y + 3;
         }
     } else {
         for (id, node) in &state.nodes {
-            layout.insert(*id, Coords { x: node.x as u16, y: node.y as u16 });
+            layout.insert(*id, Coords { x: node.x, y: node.y });
         }
     }
 
     for (&id, &Coords { x: nx, y: ny }) in &layout {
-        if ny == y {
+        if ny == y as i16 {
             let node = &state.nodes[&id];
-            let start_x = nx.saturating_sub(state.scroll_x.max(0) as u16);
+            let start_x = (nx - state.scroll_x).max(0) as u16;
             let end_x = start_x + node.label.len() as u16 + 2;
             if x >= start_x && x < end_x {
                 return Some(id);

--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -1,0 +1,20 @@
+use crate::node::{NodeID, NodeMap};
+
+pub const SIBLING_SPACING_X: i16 = 3;
+pub const CHILD_SPACING_Y: i16 = 2;
+
+#[allow(dead_code)]
+pub fn apply_layout(nodes: &mut NodeMap, parent_id: NodeID) {
+    if let Some(parent) = nodes.get(&parent_id).cloned() {
+        let sibling_count = parent.children.len();
+        let mid = sibling_count / 2;
+        for (i, &child_id) in parent.children.iter().enumerate() {
+            if let Some(child) = nodes.get_mut(&child_id) {
+                let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
+                child.x = parent.x + offset_x;
+                child.y = parent.y + CHILD_SPACING_Y;
+            }
+        }
+    }
+}
+

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,18 +1,19 @@
 use std::collections::HashMap;
 use crate::node::{NodeID, NodeMap};
+use crate::gemx::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Coords {
-    pub x: u16,
-    pub y: u16,
+    pub x: i16,
+    pub y: i16,
 }
 
 /// Recursively assigns (x, y) positions to nodes based on depth
 pub fn layout_nodes(
     nodes: &NodeMap,
     root_id: NodeID,
-    start_x: u16,
-    start_y: u16,
+    start_x: i16,
+    start_y: i16,
 ) -> HashMap<NodeID, Coords> {
     let mut map = HashMap::new();
     layout_recursive(nodes, root_id, start_x, start_y, &mut map);
@@ -23,26 +24,28 @@ pub fn layout_nodes(
 fn layout_recursive(
     nodes: &NodeMap,
     node_id: NodeID,
-    x: u16,
-    y: u16,
+    x: i16,
+    y: i16,
     out: &mut HashMap<NodeID, Coords>,
-) -> u16 {
+) {
     out.insert(node_id, Coords { x, y });
 
     let node = match nodes.get(&node_id) {
         Some(n) => n,
-        None => return y,
+        None => return,
     };
 
     if node.collapsed || node.children.is_empty() {
-        return y;
+        return;
     }
 
-    let mut current_y = y + 1;
+    let sibling_count = node.children.len();
+    let mid = sibling_count / 2;
 
-    for child_id in &node.children {
-        current_y = layout_recursive(nodes, *child_id, x + 10, current_y, out) + 1;
+    for (i, &child_id) in node.children.iter().enumerate() {
+        let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
+        let child_x = x + offset_x;
+        let child_y = y + CHILD_SPACING_Y;
+        layout_recursive(nodes, child_id, child_x, child_y, out);
     }
-
-    current_y - 1
 }


### PR DESCRIPTION
## Summary
- replace layout algorithm with void-style sibling centering
- propagate i16 coordinates through rendering helpers
- adjust node hit testing for new coordinate type

## Testing
- `cargo check`
- `bash patches/patch-25.45f-void-layout/test_plan.sh`
