### PR TITLE
Patch 25.45i: layout fixes

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -49,17 +49,21 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 /// Begin dragging the specified node from mouse coords.
 pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
     state.dragging = Some(id);
-    state.last_mouse = Some((x, y));
+    let wx = x as i16 + state.scroll_x;
+    let wy = y as i16 + state.scroll_y;
+    state.last_mouse = Some((wx, wy));
     state.selected = Some(id);
 }
 
 /// Update dragging node position based on new mouse coords.
 pub fn drag_update(state: &mut AppState, x: u16, y: u16) {
+    let wx = x as i16 + state.scroll_x;
+    let wy = y as i16 + state.scroll_y;
     if let (Some(id), Some((lx, ly))) = (state.dragging, state.last_mouse) {
-        let dx = x as i16 - lx as i16;
-        let dy = y as i16 - ly as i16;
+        let dx = wx - lx;
+        let dy = wy - ly;
         drag_recursive(id, dx, dy, &mut state.nodes, state.snap_to_grid);
-        state.last_mouse = Some((x, y));
+        state.last_mouse = Some((wx, wy));
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -8,7 +8,7 @@ pub struct Coords {
 }
 
 pub const SIBLING_SPACING_X: i16 = 3;
-pub const CHILD_SPACING_Y: i16 = 2;
+pub const CHILD_SPACING_Y: i16 = 1;
 pub const MAX_LAYOUT_DEPTH: usize = 50;
 
 /// Public layout function
@@ -59,11 +59,11 @@ fn layout_recursive_safe(
     }
 
     let child_count = node.children.len();
-    let mid_index = child_count as i16 / 2;
+    let mid = child_count / 2;
     let mut max_y = y;
 
     for (i, child_id) in node.children.iter().enumerate() {
-        let offset_x = (i as i16 - mid_index) * SIBLING_SPACING_X;
+        let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
         let child_x = x + offset_x;
         let child_y = y + CHILD_SPACING_Y;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -29,7 +29,7 @@ pub struct AppState {
     pub snap_to_grid: bool,
     pub drawing_root: Option<NodeID>,
     pub dragging: Option<NodeID>,
-    pub last_mouse: Option<(u16, u16)>,
+    pub last_mouse: Option<(i16, i16)>,
     pub debug_input_mode: bool,
     pub status_message: String,
     pub status_message_last_updated: Option<std::time::Instant>,
@@ -110,6 +110,25 @@ impl AppState {
         }
 
         result
+    }
+
+    /// Ensure nodes have unique positions when auto-arrange is disabled.
+    pub fn ensure_grid_positions(&mut self) {
+        if self.auto_arrange {
+            return;
+        }
+
+        let ids: Vec<NodeID> = self.nodes.keys().copied().collect();
+        let mut index = 0;
+        for id in ids {
+            if let Some(node) = self.nodes.get_mut(&id) {
+                if node.x == 0 && node.y == 0 {
+                    node.x = ((index % 4) * 6) as i16;
+                    node.y = ((index / 4) * 2) as i16;
+                    index += 1;
+                }
+            }
+        }
     }
 
     pub fn move_focus_up(&mut self) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,6 +27,10 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
     use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::widgets::{Block, Borders, Paragraph};
 
+    if !state.auto_arrange {
+        state.ensure_grid_positions();
+    }
+
     terminal.draw(|f| {
         let full = f.size();
         let layout_chunks = if state.show_keymap {


### PR DESCRIPTION
## Summary
- tighten child spacing and rework sibling offset
- track drag positions with signed coordinates
- add fallback grid placement for manual layout
- adjust draw() to call fallback placement

## Testing
- `cargo test --locked`