### PR TITLE
Fix manual grid spacing and free-node placement

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -1,11 +1,34 @@
 use crate::state::AppState;
-use crate::node::{NodeID, NodeMap};
-use crate::layout::{layout_nodes, Coords};
+use crate::node::{Node, NodeID, NodeMap};
+use crate::layout::{layout_nodes, Coords, SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS};
 use std::collections::HashMap;
 
 /// Toggle snap-to-grid mode
 pub fn toggle_snap(state: &mut AppState) {
     state.toggle_snap_grid();
+}
+
+/// Create a new free node using the fallback grid spacing when manual mode is active.
+pub fn spawn_free_node(state: &mut AppState) {
+    let new_id = state
+        .nodes
+        .keys()
+        .max()
+        .copied()
+        .unwrap_or(100)
+        + 1;
+
+    let mut node = Node::new(new_id, "Free Node", None);
+
+    if !state.auto_arrange {
+        let index = state.root_nodes.len();
+        node.x = ((index % FREE_GRID_COLUMNS) as i16) * SIBLING_SPACING_X * 2;
+        node.y = ((index / FREE_GRID_COLUMNS) as i16) * CHILD_SPACING_Y * 2;
+    }
+
+    state.nodes.insert(new_id, node);
+    state.root_nodes.push(new_id);
+    state.selected = Some(new_id);
 }
 
 /// Determine which node is at the given coordinates considering current layout.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -9,6 +9,7 @@ pub struct Coords {
 
 pub const SIBLING_SPACING_X: i16 = 3;
 pub const CHILD_SPACING_Y: i16 = 1;
+pub const FREE_GRID_COLUMNS: usize = 4;
 pub const MAX_LAYOUT_DEPTH: usize = 50;
 
 /// Public layout function

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use crate::node::{Node, NodeID, NodeMap};
+use crate::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS};
 
 mod hotkeys;
 pub use hotkeys::*;
@@ -123,8 +124,12 @@ impl AppState {
         for id in ids {
             if let Some(node) = self.nodes.get_mut(&id) {
                 if node.x == 0 && node.y == 0 {
-                    node.x = ((index % 4) * 6) as i16;
-                    node.y = ((index / 4) * 2) as i16;
+                    node.x = ((index % FREE_GRID_COLUMNS) as i16)
+                        * SIBLING_SPACING_X
+                        * 2;
+                    node.y = ((index / FREE_GRID_COLUMNS) as i16)
+                        * CHILD_SPACING_Y
+                        * 2;
                     index += 1;
                 }
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,7 +181,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                 } else if match_hotkey("create_sibling", code, modifiers, &state) && state.mode == "gemx" {
                     state.push_undo(); state.add_sibling();
                 } else if match_hotkey("add_free_node", code, modifiers, &state) {
-                    state.push_undo(); state.add_free_node();
+                    state.push_undo();
+                    crate::gemx::interaction::spawn_free_node(&mut state);
                 } else if match_hotkey("create_branch", code, modifiers, &state) {
                     state.push_undo(); /* placeholder for create_branch() */
                 } else if match_hotkey("delete", code, modifiers, &state) && state.mode == "gemx" {


### PR DESCRIPTION
## Summary
- define `FREE_GRID_COLUMNS`
- use spacing constants when generating grid fallback positions
- spawn new free nodes into the next grid slot instead of (0,0)

## Testing
- `bash patches/patch-25.45j-sibling-grid-fix/test_plan.sh`
- `cargo check`