### PR TITLE
Implement true sibling layout & freeze manual positions

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -62,11 +62,12 @@ fn layout_recursive_safe(
     let child_count = node.children.len();
     let mid = child_count / 2;
     let mut max_y = y;
+    let mut next_y = y + CHILD_SPACING_Y;
 
     for (i, child_id) in node.children.iter().enumerate() {
         let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
         let child_x = x + offset_x;
-        let child_y = y + CHILD_SPACING_Y;
+        let child_y = next_y;
 
         // println!(
         //     "├── child {} of {} at x={}, y={}",
@@ -84,6 +85,7 @@ fn layout_recursive_safe(
         );
 
         max_y = max_y.max(branch_max_y);
+        next_y = branch_max_y + CHILD_SPACING_Y;
     }
 
     max_y

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,9 +27,6 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
     use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::widgets::{Block, Borders, Paragraph};
 
-    if !state.auto_arrange {
-        state.ensure_grid_positions();
-    }
 
     terminal.draw(|f| {
         let full = f.size();


### PR DESCRIPTION
## Summary
- update layout engine so siblings stack vertically and center horizontally
- remove grid fallback repositioning when auto-arrange is off

## Testing
- `cargo test --quiet`
- `bash patches/patch-25.45l-true-sibling-layout/test_plan.sh`
