### PR TITLE
Implement viewport aware layout

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -1,6 +1,9 @@
 use crate::state::AppState;
 use crate::node::{Node, NodeID, NodeMap};
-use crate::layout::{layout_nodes, Coords, SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS};
+use crate::layout::{
+    layout_nodes, Coords, SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS,
+    GEMX_HEADER_HEIGHT,
+};
 use std::collections::HashMap;
 
 /// Toggle snap-to-grid mode
@@ -22,8 +25,10 @@ pub fn spawn_free_node(state: &mut AppState) {
 
     if !state.auto_arrange {
         let index = state.root_nodes.len();
-        node.x = ((index % FREE_GRID_COLUMNS) as i16) * SIBLING_SPACING_X * 2;
-        node.y = ((index / FREE_GRID_COLUMNS) as i16) * CHILD_SPACING_Y * 2;
+        node.x = ((index % FREE_GRID_COLUMNS) as i16) * SIBLING_SPACING_X * 2 + 1;
+        node.y = ((index / FREE_GRID_COLUMNS) as i16) * CHILD_SPACING_Y * 2
+            + GEMX_HEADER_HEIGHT
+            + 1;
     }
 
     state.nodes.insert(new_id, node);
@@ -40,9 +45,10 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
         } else {
             state.root_nodes.clone()
         };
-        let mut row = 1;
+        let (tw, _) = crossterm::terminal::size().unwrap_or((80, 20));
+        let mut row = GEMX_HEADER_HEIGHT + 1;
         for &root_id in &roots {
-            let l = layout_nodes(&state.nodes, root_id, 2, row);
+            let l = layout_nodes(&state.nodes, root_id, row, tw as i16);
             let max_y = l.values().map(|c| c.y).max().unwrap_or(row);
             layout.extend(l);
             row = max_y.saturating_add(3);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -10,18 +10,30 @@ pub struct Coords {
 pub const SIBLING_SPACING_X: i16 = 3;
 pub const CHILD_SPACING_Y: i16 = 1;
 pub const FREE_GRID_COLUMNS: usize = 4;
+pub const GEMX_HEADER_HEIGHT: i16 = 2;
 pub const MAX_LAYOUT_DEPTH: usize = 50;
 
 /// Public layout function
 pub fn layout_nodes(
     nodes: &NodeMap,
     root_id: NodeID,
-    start_x: i16,
     start_y: i16,
+    term_width: i16,
 ) -> HashMap<NodeID, Coords> {
+    let start_y = start_y.max(GEMX_HEADER_HEIGHT + 1);
+    let start_x = term_width / 2;
     let mut coords = HashMap::new();
     let mut visited = HashSet::new();
-    layout_recursive_safe(nodes, root_id, start_x, start_y, &mut coords, &mut visited, 0);
+    layout_recursive_safe(
+        nodes,
+        root_id,
+        start_x,
+        start_y,
+        term_width,
+        &mut coords,
+        &mut visited,
+        0,
+    );
     coords
 }
 
@@ -30,6 +42,7 @@ fn layout_recursive_safe(
     node_id: NodeID,
     x: i16,
     y: i16,
+    term_width: i16,
     out: &mut HashMap<NodeID, Coords>,
     visited: &mut HashSet<NodeID>,
     depth: usize,
@@ -61,10 +74,17 @@ fn layout_recursive_safe(
 
     let child_count = node.children.len();
     let mid = child_count / 2;
+    let mut spacing_x = SIBLING_SPACING_X;
+    if child_count > 1 {
+        let needed = (child_count as i16 - 1) * spacing_x;
+        if needed > term_width {
+            spacing_x = (term_width / (child_count as i16)).max(1);
+        }
+    }
     let mut max_y = y;
 
     for (i, child_id) in node.children.iter().enumerate() {
-        let offset_x = (i as i16 - mid as i16) * SIBLING_SPACING_X;
+        let offset_x = (i as i16 - mid as i16) * spacing_x;
         let child_x = x + offset_x;
         let child_y = y + CHILD_SPACING_Y;
 
@@ -78,6 +98,7 @@ fn layout_recursive_safe(
             *child_id,
             child_x,
             child_y,
+            term_width,
             out,
             visited,
             depth + 1,

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -1,6 +1,6 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
-use crate::layout::{layout_nodes, Coords};
+use crate::layout::{layout_nodes, Coords, GEMX_HEADER_HEIGHT};
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
 use std::collections::HashMap;
@@ -25,10 +25,12 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
 
     let mut drawn_at = HashMap::new();
     if state.auto_arrange {
+        let mut row = GEMX_HEADER_HEIGHT + 1;
         for &root_id in &roots {
-            //println!("🔁 layout_nodes(root={})", root_id);
-            let layout = layout_nodes(&state.nodes, root_id, 2, 1); // 🧠 force y=1
+            let layout = layout_nodes(&state.nodes, root_id, row, area.width as i16);
+            let max_y = layout.values().map(|c| c.y).max().unwrap_or(row);
             drawn_at.extend(layout);
+            row = max_y.saturating_add(3);
         }
     } else {
         fn collect(nodes: &NodeMap, id: NodeID, out: &mut HashMap<NodeID, Coords>) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use crate::node::{Node, NodeID, NodeMap};
-use crate::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS};
+use crate::layout::{
+    SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS, GEMX_HEADER_HEIGHT,
+};
 
 mod hotkeys;
 pub use hotkeys::*;
@@ -126,10 +128,13 @@ impl AppState {
                 if node.x == 0 && node.y == 0 {
                     node.x = ((index % FREE_GRID_COLUMNS) as i16)
                         * SIBLING_SPACING_X
-                        * 2;
+                        * 2
+                        + 1;
                     node.y = ((index / FREE_GRID_COLUMNS) as i16)
                         * CHILD_SPACING_Y
-                        * 2;
+                        * 2
+                        + GEMX_HEADER_HEIGHT
+                        + 1;
                     index += 1;
                 }
             }


### PR DESCRIPTION
## Summary
- start all layouts after `GEMX_HEADER_HEIGHT`
- add viewport width parameter to `layout_nodes` and compress spacing
- offset manually placed nodes from the header
- ensure free nodes spawn below header

## Testing
- `cargo check`
- `bash patches/patch-25.45m-viewport-layout/test_plan.sh`