### PR TITLE
Patch 25.45x-b zoom draw bounds

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -59,7 +59,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             .round()
             .max(0.0) as u16;
 
-        if draw_y >= area.height {
+        if draw_x >= area.width || draw_y >= area.height {
+            #[cfg(debug_assertions)]
+            eprintln!("[debug] clamp node ({},{})", draw_x, draw_y);
             continue;
         }
 
@@ -113,10 +115,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
                     let arrow = if sx < tx { "→" } else { "←" };
                     let mid = ((sxp + txp) / 2.0).round().max(0.0) as u16;
                     let draw_sy = syp.max(0.0) as u16;
-                    if draw_sy < area.height && mid < area.width {
-                        let para = Paragraph::new(arrow);
-                        f.render_widget(para, Rect::new(mid, draw_sy, 1, 1));
+                    if mid >= area.width || draw_sy >= area.height {
+                        #[cfg(debug_assertions)]
+                        eprintln!("[debug] clamp arrow ({},{})", mid, draw_sy);
+                        continue;
                     }
+                    let para = Paragraph::new(arrow);
+                    f.render_widget(para, Rect::new(mid, draw_sy, 1, 1));
                 }
             }
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -343,7 +343,7 @@ impl AppState {
     }
 
     pub fn zoom_in(&mut self) {
-        self.zoom_scale = (self.zoom_scale + 0.1).min(2.0);
+        self.zoom_scale = (self.zoom_scale + 0.1).min(1.5);
         if let Some(id) = self.selected {
             crate::layout::zoom_to_anchor(self, id);
         }


### PR DESCRIPTION
## Summary
- clamp zoomed widget draw coordinates to avoid overflow
- tighten zoom upper limit to 150%

## Testing
- `cargo test`
- `grep -q "render_gemx" src/screen/gemx.rs`