### PR TITLE
Add layout role classification

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -48,7 +48,7 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
         let (tw, _) = crossterm::terminal::size().unwrap_or((80, 20));
         let mut row = GEMX_HEADER_HEIGHT + 1;
         for &root_id in &roots {
-            let l = layout_nodes(&state.nodes, root_id, row, tw as i16);
+            let (l, _roles) = layout_nodes(&state.nodes, root_id, row, tw as i16, state.auto_arrange);
             let max_y = l.values().map(|c| c.y).max().unwrap_or(row);
             layout.extend(l);
             row = max_y.saturating_add(3);

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -29,7 +29,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     if state.auto_arrange {
         let mut row = GEMX_HEADER_HEIGHT + 1;
         for &root_id in &roots {
-            let layout = layout_nodes(&state.nodes, root_id, row, area.width as i16);
+            let (layout, _roles) = layout_nodes(&state.nodes, root_id, row, area.width as i16, state.auto_arrange);
             let max_y = layout.values().map(|c| c.y).max().unwrap_or(row);
             drawn_at.extend(layout);
             row = max_y.saturating_add(3);


### PR DESCRIPTION
## Summary
- define `LayoutRole` enum
- return role information from `layout_nodes`
- tag nodes with their role during layout traversal
- adjust call sites in `interaction` and `screen`

## Testing
- `cargo check`
- `cargo test`
- `bash patches/patch-25.45n-i-layout-role-framework/test_plan.sh`
