### PR TITLE
Fix sibling span clamping

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -141,7 +141,9 @@ fn layout_recursive_safe(
     let mut spans = Vec::new();
     for child_id in &node.children {
         let w = subtree_span(nodes, *child_id);
-        spans.push((*child_id, w));
+        let label_w = nodes[&child_id].label.len() as i16 + 2;
+        let span = w.max(label_w + MIN_NODE_GAP);
+        spans.push((*child_id, span));
     }
 
     let mut total_width: i16 = spans.iter().map(|(_, w)| *w).sum();


### PR DESCRIPTION
## Summary
- avoid node collisions by clamping sibling spans
- ensure spans use label width plus minimum gap

## Testing
- `cargo test`
- `bash patches/patch-25.45n-hb-span-clamp/test_plan.sh`