### PR TITLE
Add beam styling and custom borders

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -1,28 +1,104 @@
-use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, text::{Spans, Span}, style::{Style, Color, Modifier}, Frame};
+use ratatui::{backend::Backend, layout::Rect, style::{Color, Style}, widgets::Paragraph, Frame};
 
-/// Render the PrismX beam logo at the given area.
-/// The logo is composed of unicode beam lines forming an X
-/// with the label centered in the middle.
-pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect) {
-    let label = "PrismX";
-    let width = label.len() as u16 + 6; // account for surrounding beams
+pub struct BeamStyle {
+    pub border_color: Color,
+    pub beam_left: Color,
+    pub beam_right: Color,
+    pub prism: Color,
+}
 
-    let cyan = Style::default().fg(Color::Cyan);
-    let magenta = Style::default().fg(Color::Magenta);
-    let white = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
+pub fn style_for_mode(mode: &str) -> BeamStyle {
+    match mode {
+        "gemx" => BeamStyle {
+            border_color: Color::Magenta,
+            beam_left: Color::Cyan,
+            beam_right: Color::Magenta,
+            prism: Color::Yellow,
+        },
+        "zen" => BeamStyle {
+            border_color: Color::White,
+            beam_left: Color::White,
+            beam_right: Color::White,
+            prism: Color::Gray,
+        },
+        "triage" => BeamStyle {
+            border_color: Color::Red,
+            beam_left: Color::Yellow,
+            beam_right: Color::Red,
+            prism: Color::White,
+        },
+        "settings" => BeamStyle {
+            border_color: Color::Blue,
+            beam_left: Color::Cyan,
+            beam_right: Color::Blue,
+            prism: Color::White,
+        },
+        _ => BeamStyle {
+            border_color: Color::Gray,
+            beam_left: Color::Gray,
+            beam_right: Color::Gray,
+            prism: Color::Gray,
+        },
+    }
+}
 
-    let top = Spans::from(Span::styled(format!("{:^width$}", "╱╲", width = width as usize), cyan));
-    let middle = Spans::from(vec![
-        Span::styled("╲━━", magenta),
-        Span::styled(label, white),
-        Span::styled("━━╱", magenta),
-    ]);
-    let bottom = Spans::from(Span::styled(format!("{:^width$}", "╲╱", width = width as usize), cyan));
+/// Render a beam logo using custom colors.
+pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
+    let mid_x = area.x + area.width.saturating_sub(3) / 2;
+    let style_left = Style::default().fg(style.beam_left);
+    let style_right = Style::default().fg(style.beam_right);
+    let style_prism = Style::default().fg(style.prism);
 
-    let x = area.x + area.width.saturating_sub(width) / 2;
-    let logo_area = Rect::new(x, area.y, width, 3);
-    let para = Paragraph::new(vec![top, middle, bottom]);
-    f.render_widget(para, logo_area);
+    // Top row
+    let para = Paragraph::new("╱").style(style_right);
+    f.render_widget(para, Rect::new(mid_x, area.y, 1, 1));
+    let para = Paragraph::new("╲").style(style_left);
+    f.render_widget(para, Rect::new(mid_x + 1, area.y, 1, 1));
+
+    // Middle row with the prism symbol
+    let para = Paragraph::new("╲").style(style_left);
+    f.render_widget(para, Rect::new(mid_x.saturating_sub(1), area.y + 1, 1, 1));
+    let para = Paragraph::new("◉").style(style_prism);
+    f.render_widget(para, Rect::new(mid_x, area.y + 1, 1, 1));
+    let para = Paragraph::new("╱").style(style_right);
+    f.render_widget(para, Rect::new(mid_x + 1, area.y + 1, 1, 1));
+
+    // Bottom row
+    let para = Paragraph::new("╲").style(style_left);
+    f.render_widget(para, Rect::new(mid_x.saturating_sub(1), area.y + 2, 1, 1));
+    let para = Paragraph::new("╱").style(style_right);
+    f.render_widget(para, Rect::new(mid_x, area.y + 2, 1, 1));
+}
+
+pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
+    let fg = Style::default().fg(style.border_color);
+    let right = area.x + area.width - 1;
+    let bottom = area.y + area.height - 1;
+
+    let tl = Paragraph::new("┏").style(fg);
+    f.render_widget(tl, Rect::new(area.x, area.y, 1, 1));
+    for x in area.x + 1..right {
+        let p = Paragraph::new("━").style(fg);
+        f.render_widget(p, Rect::new(x, area.y, 1, 1));
+    }
+    let tr = Paragraph::new("┓").style(fg);
+    f.render_widget(tr, Rect::new(right, area.y, 1, 1));
+
+    for y in area.y + 1..bottom {
+        let p = Paragraph::new("┃").style(fg);
+        f.render_widget(p, Rect::new(area.x, y, 1, 1));
+        let p2 = Paragraph::new("┃").style(fg);
+        f.render_widget(p2, Rect::new(right, y, 1, 1));
+    }
+
+    let bl = Paragraph::new("┗").style(fg);
+    f.render_widget(bl, Rect::new(area.x, bottom, 1, 1));
+    for x in area.x + 1..right {
+        let p = Paragraph::new("━").style(fg);
+        f.render_widget(p, Rect::new(x, bottom, 1, 1));
+    }
+    let br = Paragraph::new("┛").style(fg);
+    f.render_widget(br, Rect::new(right, bottom, 1, 1));
 }
 
 

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -1,7 +1,9 @@
 use ratatui::{backend::Backend, layout::Rect, style::Style, widgets::{Block, Borders, Paragraph}, Frame};
+use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 
 pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
-    let block = Block::default().title("Triage Panel").borders(Borders::ALL)
+    let style = style_for_mode("triage");
+    let block = Block::default().title("Triage Panel").borders(Borders::NONE)
         .style(Style::default().fg(ratatui::style::Color::Red));
 
     let content = Paragraph::new(
@@ -13,4 +15,6 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     f.render_widget(block, area);
     f.render_widget(content, Rect::new(area.x + 2, area.y + 1, area.width - 4, area.height - 2));
+    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
+    render_full_border(f, area, &style);
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,8 +1,10 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph, Wrap}};
 use crate::state::AppState;
+use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 
 pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     use ratatui::text::{Span, Line};
+    let style = style_for_mode(&state.mode);
 
     let total_height = area.height as usize;
     let total_width = area.width as usize;
@@ -27,11 +29,13 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
     }
 
     let widget = Paragraph::new(padded_lines)
-        .block(Block::default().title("Zen").borders(Borders::ALL))
+        .block(Block::default().title("Zen").borders(Borders::NONE))
         .style(Style::default().fg(Color::Green))
         .wrap(Wrap { trim: false });
 
     f.render_widget(widget, area);
+    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
+    render_full_border(f, area, &style);
 }
 
 fn parse_markdown_line(input: &str) -> Line {

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -5,8 +5,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     text::Line,
 };
+use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 
 pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    let style = style_for_mode("triage");
     let tasks = vec![
         Line::from("[ ] Design new node engine"),
         Line::from("[x] Fix dashboard overflow"),
@@ -15,8 +17,10 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     let block = Block::default()
         .title("RoutineForge – Inbox")
-        .borders(Borders::ALL);
+        .borders(Borders::NONE);
 
     let paragraph = Paragraph::new(tasks).block(block);
     f.render_widget(paragraph, area);
+    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
+    render_full_border(f, area, &style);
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -6,17 +6,18 @@ use crate::layout::{
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
-use crate::beamx::render_beam_logo;
+use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 use std::collections::HashMap;
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    let style = style_for_mode(&state.mode);
     let block = Block::default()
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })
-        .borders(Borders::ALL);
+        .borders(Borders::NONE);
     f.render_widget(block, area);
 
     // BeamX logo at the top center
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3));
+    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
 
     // // ✅ Always print the structure for diagnostics
     // println!("=== NODES AND CHILDREN ===");
@@ -165,4 +166,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             }
         }
     }
+
+    render_full_border(f, area, &style);
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,8 +5,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     text::Line,
 };
+use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 
 pub fn render_settings_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    let style = style_for_mode("settings");
     let lines = vec![
         Line::from("PrismX Settings"),
         Line::from("----------------"),
@@ -18,8 +20,10 @@ pub fn render_settings_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     let block = Block::default()
         .title("Settings")
-        .borders(Borders::ALL);
+        .borders(Borders::NONE);
 
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, area);
+    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
+    render_full_border(f, area, &style);
 }


### PR DESCRIPTION
## Summary
- add BeamStyle and style_for_mode for module colors
- render beam logo and border using styles
- apply new styling in GemX, Zen, Triage, Settings and RoutineForge panels

## Testing
- `cargo check`