### PR TITLE
Finalize BeamX logo alignment

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -12,25 +12,25 @@ pub fn style_for_mode(mode: &str) -> BeamStyle {
         "gemx" => BeamStyle {
             border_color: Color::Magenta,
             beam_left: Color::Cyan,
-            beam_right: Color::Magenta,
-            prism: Color::Yellow,
+            beam_right: Color::White,
+            prism: Color::White,
         },
         "zen" => BeamStyle {
             border_color: Color::White,
-            beam_left: Color::White,
-            beam_right: Color::White,
-            prism: Color::Gray,
+            beam_left: Color::Green,
+            beam_right: Color::Green,
+            prism: Color::White,
         },
         "triage" => BeamStyle {
             border_color: Color::Red,
-            beam_left: Color::Yellow,
-            beam_right: Color::Red,
-            prism: Color::White,
+            beam_left: Color::White,
+            beam_right: Color::White,
+            prism: Color::Cyan,
         },
         "settings" => BeamStyle {
             border_color: Color::Blue,
-            beam_left: Color::Cyan,
-            beam_right: Color::Blue,
+            beam_left: Color::Gray,
+            beam_right: Color::Gray,
             prism: Color::White,
         },
         _ => BeamStyle {
@@ -44,30 +44,28 @@ pub fn style_for_mode(mode: &str) -> BeamStyle {
 
 /// Render a beam logo using custom colors.
 pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
-    let mid_x = area.x + area.width.saturating_sub(3) / 2;
+    let x_offset = area.width.saturating_sub(6);
+    let y_offset = area.y + 1;
+
     let style_left = Style::default().fg(style.beam_left);
     let style_right = Style::default().fg(style.beam_right);
     let style_prism = Style::default().fg(style.prism);
 
-    // Top row
-    let para = Paragraph::new("╱").style(style_right);
-    f.render_widget(para, Rect::new(mid_x, area.y, 1, 1));
-    let para = Paragraph::new("╲").style(style_left);
-    f.render_widget(para, Rect::new(mid_x + 1, area.y, 1, 1));
+    // Line 0
+    let para = Paragraph::new("\\").style(style_left);
+    f.render_widget(para, Rect::new(x_offset, y_offset, 1, 1));
+    let para = Paragraph::new("/").style(style_right);
+    f.render_widget(para, Rect::new(x_offset + 3, y_offset, 1, 1));
 
-    // Middle row with the prism symbol
-    let para = Paragraph::new("╲").style(style_left);
-    f.render_widget(para, Rect::new(mid_x.saturating_sub(1), area.y + 1, 1, 1));
-    let para = Paragraph::new("◉").style(style_prism);
-    f.render_widget(para, Rect::new(mid_x, area.y + 1, 1, 1));
-    let para = Paragraph::new("╱").style(style_right);
-    f.render_widget(para, Rect::new(mid_x + 1, area.y + 1, 1, 1));
+    // Line 1 (prism center)
+    let para = Paragraph::new("*").style(style_prism);
+    f.render_widget(para, Rect::new(x_offset + 2, y_offset + 1, 1, 1));
 
-    // Bottom row
-    let para = Paragraph::new("╲").style(style_left);
-    f.render_widget(para, Rect::new(mid_x.saturating_sub(1), area.y + 2, 1, 1));
-    let para = Paragraph::new("╱").style(style_right);
-    f.render_widget(para, Rect::new(mid_x, area.y + 2, 1, 1));
+    // Line 2
+    let para = Paragraph::new("/").style(style_left);
+    f.render_widget(para, Rect::new(x_offset, y_offset + 2, 1, 1));
+    let para = Paragraph::new("\\").style(style_right);
+    f.render_widget(para, Rect::new(x_offset + 3, y_offset + 2, 1, 1));
 }
 
 pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -15,6 +15,6 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     f.render_widget(block, area);
     f.render_widget(content, Rect::new(area.x + 2, area.y + 1, area.width - 4, area.height - 2));
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
     render_full_border(f, area, &style);
+    render_beam_logo(f, area, &style);
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -34,8 +34,8 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
         .wrap(Wrap { trim: false });
 
     f.render_widget(widget, area);
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
     render_full_border(f, area, &style);
+    render_beam_logo(f, area, &style);
 }
 
 fn parse_markdown_line(input: &str) -> Line {

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -21,6 +21,6 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     let paragraph = Paragraph::new(tasks).block(block);
     f.render_widget(paragraph, area);
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
     render_full_border(f, area, &style);
+    render_beam_logo(f, area, &style);
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -16,8 +16,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         .borders(Borders::NONE);
     f.render_widget(block, area);
 
-    // BeamX logo at the top center
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
 
     // // ✅ Always print the structure for diagnostics
     // println!("=== NODES AND CHILDREN ===");
@@ -168,4 +166,5 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     }
 
     render_full_border(f, area, &style);
+    render_beam_logo(f, area, &style);
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
 
-pub fn render_settings_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
+pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let style = style_for_mode("settings");
     let lines = vec![
         Line::from("PrismX Settings"),
@@ -24,6 +24,6 @@ pub fn render_settings_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, area);
-    render_beam_logo(f, Rect::new(area.x, area.y + 1, area.width, 3), &style);
     render_full_border(f, area, &style);
+    render_beam_logo(f, area, &style);
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,6 +17,7 @@ use crate::render::{
     render_module_switcher,
 };
 use crate::screen::render_gemx;
+use crate::settings::render_settings;
 
 mod hotkeys;
 use hotkeys::match_hotkey;
@@ -49,11 +50,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
         match state.mode.as_str() {
             "zen" => render_zen_journal(f, vertical[0], state),
             "gemx" => render_gemx(f, vertical[0], &state),
-            "settings" => {
-                let fallback = Paragraph::new("Settings panel coming soon...")
-                    .block(Block::default().title("Settings").borders(Borders::ALL));
-                f.render_widget(fallback, vertical[0]);
-            }
+            "settings" => render_settings(f, vertical[0]),
             "triage" => render_triage(f, vertical[0]),
             _ => {
                 let fallback = Paragraph::new("Unknown mode");


### PR DESCRIPTION
## Summary
- style BeamX logo per active module
- draw logo to the top-right corner
- move logo rendering to the end of modules
- add Settings panel renderer and hook it into the UI

## Testing
- `cargo check`
- `bash patches/patch-25.50a-d-beamx-final-alignment/test_plan.sh`