### PR TITLE
Implement dual-colored BeamX logo with corner control

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -2,69 +2,69 @@ use ratatui::{backend::Backend, layout::Rect, style::{Color, Style}, widgets::Pa
 
 pub struct BeamStyle {
     pub border_color: Color,
-    pub beam_left: Color,
-    pub beam_right: Color,
-    pub prism: Color,
+    pub status_color: Color,
+    pub prism_color: Color,
+    pub center_glyph: &'static str,
 }
 
 pub fn style_for_mode(mode: &str) -> BeamStyle {
     match mode {
         "gemx" => BeamStyle {
-            border_color: Color::Magenta,
-            beam_left: Color::Cyan,
-            beam_right: Color::White,
-            prism: Color::White,
+            border_color: Color::Cyan,
+            status_color: Color::White,
+            prism_color: Color::White,
+            center_glyph: "✦",
         },
         "zen" => BeamStyle {
-            border_color: Color::White,
-            beam_left: Color::Green,
-            beam_right: Color::Green,
-            prism: Color::White,
+            border_color: Color::Green,
+            status_color: Color::Gray,
+            prism_color: Color::White,
+            center_glyph: "✦",
         },
         "triage" => BeamStyle {
-            border_color: Color::Red,
-            beam_left: Color::White,
-            beam_right: Color::White,
-            prism: Color::Cyan,
+            border_color: Color::White,
+            status_color: Color::Red,
+            prism_color: Color::Cyan,
+            center_glyph: "✦",
         },
         "settings" => BeamStyle {
-            border_color: Color::Blue,
-            beam_left: Color::Gray,
-            beam_right: Color::Gray,
-            prism: Color::White,
+            border_color: Color::Gray,
+            status_color: Color::Gray,
+            prism_color: Color::White,
+            center_glyph: "✦",
         },
         _ => BeamStyle {
             border_color: Color::Gray,
-            beam_left: Color::Gray,
-            beam_right: Color::Gray,
-            prism: Color::Gray,
+            status_color: Color::Gray,
+            prism_color: Color::Gray,
+            center_glyph: "✦",
         },
     }
 }
 
 /// Render a beam logo using custom colors.
 pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
-    let x_offset = area.width.saturating_sub(6);
-    let y_offset = area.y + 1;
+    let x_offset = area.x + area.width.saturating_sub(6);
+    let y_offset = area.y;
 
-    let style_left = Style::default().fg(style.beam_left);
-    let style_right = Style::default().fg(style.beam_right);
-    let style_prism = Style::default().fg(style.prism);
+    let style_border = Style::default().fg(style.border_color);
+    let style_status = Style::default().fg(style.status_color);
+    let style_prism = Style::default().fg(style.prism_color);
 
     // Line 0
-    let para = Paragraph::new("\\").style(style_left);
+    let para = Paragraph::new("╱").style(style_border);
     f.render_widget(para, Rect::new(x_offset, y_offset, 1, 1));
-    let para = Paragraph::new("/").style(style_right);
+    let para = Paragraph::new("/").style(style_status);
     f.render_widget(para, Rect::new(x_offset + 3, y_offset, 1, 1));
 
-    // Line 1 (prism center)
-    let para = Paragraph::new("*").style(style_prism);
+    // Line 1 (center glyph)
+    let para = Paragraph::new(style.center_glyph).style(style_prism);
     f.render_widget(para, Rect::new(x_offset + 2, y_offset + 1, 1, 1));
 
     // Line 2
-    let para = Paragraph::new("/").style(style_left);
+    let para = Paragraph::new("/").style(style_status);
     f.render_widget(para, Rect::new(x_offset, y_offset + 2, 1, 1));
-    let para = Paragraph::new("\\").style(style_right);
+    let para = Paragraph::new("╲").style(style_border);
     f.render_widget(para, Rect::new(x_offset + 3, y_offset + 2, 1, 1));
 }
 
@@ -79,8 +79,7 @@ pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &Beam
         let p = Paragraph::new("━").style(fg);
         f.render_widget(p, Rect::new(x, area.y, 1, 1));
     }
-    let tr = Paragraph::new("┓").style(fg);
-    f.render_widget(tr, Rect::new(right, area.y, 1, 1));
+    // Skip top-right corner so the beam can cut through
 
     for y in area.y + 1..bottom {
         let p = Paragraph::new("┃").style(fg);


### PR DESCRIPTION
## Summary
- adjust `BeamStyle` to support dual-beam colors and center glyph
- update `style_for_mode` with new color mappings
- render BeamX logo using border/status/prism colors
- skip top-right corner in `render_full_border`

## Testing
- `cargo check`
- `bash patches/patch-25.50a-e-beamx-dual-beam-x/test_plan.sh`