### PR TITLE
Implement BeamX split logo variant

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -7,6 +7,14 @@ pub struct BeamStyle {
     pub center_glyph: &'static str,
 }
 
+#[derive(Copy, Clone)]
+pub enum BeamXStyle {
+    /// Beam hits prism then splits out
+    Split,
+    /// Stylized X beam
+    Cross,
+}
+
 pub fn style_for_mode(mode: &str) -> BeamStyle {
     match mode {
         "gemx" => BeamStyle {
@@ -43,29 +51,43 @@ pub fn style_for_mode(mode: &str) -> BeamStyle {
 }
 
 /// Render a beam logo using custom colors.
-pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
+pub fn render_beamx<B: Backend>(
+    f: &mut Frame<B>,
+    area: Rect,
+    style: &BeamStyle,
+    variant: BeamXStyle,
+) {
     let x_offset = area.width - 6;
+    let base_x = x_offset + 1;
     let y_offset = area.y;
 
     let style_border = Style::default().fg(style.border_color);
     let style_status = Style::default().fg(style.status_color);
     let style_prism = Style::default().fg(style.prism_color);
 
-    // Line 0
-    let para = Paragraph::new("\\").style(style_border);
-    f.render_widget(para, Rect::new(x_offset, y_offset, 1, 1));
-    let para = Paragraph::new("/").style(style_status);
-    f.render_widget(para, Rect::new(x_offset + 3, y_offset, 1, 1));
+    match variant {
+        BeamXStyle::Split => {
+            let left = Paragraph::new("⇆").style(style_status);
+            f.render_widget(left, Rect::new(base_x, y_offset, 1, 1));
+            let prism = Paragraph::new(style.center_glyph).style(style_prism);
+            f.render_widget(prism, Rect::new(base_x + 1, y_offset, 1, 1));
+            let right = Paragraph::new("⇉").style(style_border);
+            f.render_widget(right, Rect::new(base_x + 2, y_offset, 1, 1));
+        }
+        BeamXStyle::Cross => {
+            let left = Paragraph::new("⨯").style(style_status);
+            f.render_widget(left, Rect::new(base_x, y_offset, 1, 1));
+            let prism = Paragraph::new(style.center_glyph).style(style_prism);
+            f.render_widget(prism, Rect::new(base_x + 1, y_offset, 1, 1));
+            let right = Paragraph::new("⨯").style(style_border);
+            f.render_widget(right, Rect::new(base_x + 2, y_offset, 1, 1));
+        }
+    }
+}
 
-    // Line 1 (center glyph)
-    let para = Paragraph::new(style.center_glyph).style(style_prism);
-    f.render_widget(para, Rect::new(x_offset + 2, y_offset + 1, 1, 1));
-
-    // Line 2
-    let para = Paragraph::new("/").style(style_status);
-    f.render_widget(para, Rect::new(x_offset, y_offset + 2, 1, 1));
-    let para = Paragraph::new("\\").style(style_border);
-    f.render_widget(para, Rect::new(x_offset + 3, y_offset + 2, 1, 1));
+/// Legacy alias for default logo
+pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
+    render_beamx(f, area, style, BeamXStyle::Split);
 }
 
 pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -1,5 +1,5 @@
 use ratatui::{backend::Backend, layout::Rect, style::Style, widgets::{Block, Borders, Paragraph}, Frame};
-use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
+use crate::beamx::{render_beamx, render_full_border, style_for_mode, BeamXStyle};
 
 pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let style = style_for_mode("triage");
@@ -16,5 +16,5 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
     f.render_widget(block, area);
     f.render_widget(content, Rect::new(area.x + 2, area.y + 1, area.width - 4, area.height - 2));
     render_full_border(f, area, &style);
-    render_beam_logo(f, area, &style);
+    render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,6 +1,6 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph, Wrap}};
 use crate::state::AppState;
-use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
+use crate::beamx::{render_beamx, render_full_border, style_for_mode, BeamXStyle};
 
 pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     use ratatui::text::{Span, Line};
@@ -35,7 +35,7 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
 
     f.render_widget(widget, area);
     render_full_border(f, area, &style);
-    render_beam_logo(f, area, &style);
+    render_beamx(f, area, &style, BeamXStyle::Split);
 }
 
 fn parse_markdown_line(input: &str) -> Line {

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     text::Line,
 };
-use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
+use crate::beamx::{render_beamx, render_full_border, style_for_mode, BeamXStyle};
 
 pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let style = style_for_mode("triage");
@@ -22,5 +22,5 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let paragraph = Paragraph::new(tasks).block(block);
     f.render_widget(paragraph, area);
     render_full_border(f, area, &style);
-    render_beam_logo(f, area, &style);
+    render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -6,7 +6,7 @@ use crate::layout::{
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
-use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
+use crate::beamx::{render_beamx, render_full_border, style_for_mode, BeamXStyle};
 use std::collections::HashMap;
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -166,5 +166,5 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     }
 
     render_full_border(f, area, &style);
-    render_beam_logo(f, area, &style);
+    render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     text::Line,
 };
-use crate::beamx::{render_beam_logo, render_full_border, style_for_mode};
+use crate::beamx::{render_beamx, render_full_border, style_for_mode, BeamXStyle};
 
 pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let style = style_for_mode("settings");
@@ -25,5 +25,5 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let paragraph = Paragraph::new(lines).block(block);
     f.render_widget(paragraph, area);
     render_full_border(f, area, &style);
-    render_beam_logo(f, area, &style);
+    render_beamx(f, area, &style, BeamXStyle::Split);
 }


### PR DESCRIPTION
## Summary
- add `BeamXStyle` enum with Split and Cross variants
- implement new `render_beamx` to draw alternative beam logo
- update all render functions to call `render_beamx`

## Testing
- `cargo check`
- `cargo test`