### PR TITLE
Implement patch 25.50a-i BeamX identity pass

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -1,4 +1,5 @@
 use ratatui::{backend::Backend, layout::Rect, style::{Color, Style}, widgets::Paragraph, Frame};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct BeamStyle {
     pub border_color: Color,
@@ -58,29 +59,48 @@ pub fn render_beamx<B: Backend>(
     variant: BeamXStyle,
 ) {
     let x_offset = area.right().saturating_sub(6);
-    let base_x = x_offset + 1;
     let y_offset = area.top();
 
     let style_border = Style::default().fg(style.border_color);
     let style_status = Style::default().fg(style.status_color);
     let style_prism = Style::default().fg(style.prism_color);
 
+    // simple time-based tick for prism animation
+    let tick = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() / 300;
+    let prism_glyph = match tick % 3 {
+        0 => "◆",
+        1 => "✦",
+        _ => "·",
+    };
+
     match variant {
         BeamXStyle::Split => {
-            let left = Paragraph::new("⇆").style(style_status);
-            f.render_widget(left, Rect::new(base_x, y_offset, 1, 1));
-            let prism = Paragraph::new(style.center_glyph).style(style_prism);
-            f.render_widget(prism, Rect::new(base_x + 1, y_offset, 1, 1));
-            let right = Paragraph::new("⇉").style(style_border);
-            f.render_widget(right, Rect::new(base_x + 2, y_offset, 1, 1));
+            // top row
+            let tl = Paragraph::new("⇘").style(style_border);
+            f.render_widget(tl, Rect::new(x_offset, y_offset, 1, 1));
+            let tr = Paragraph::new("⇖").style(style_status);
+            f.render_widget(tr, Rect::new(x_offset + 5, y_offset, 1, 1));
+
+            // center prism
+            let center = Paragraph::new(prism_glyph).style(style_prism);
+            f.render_widget(center, Rect::new(x_offset + 3, y_offset + 1, 1, 1));
+
+            // bottom row
+            let bl = Paragraph::new("⇖").style(style_status);
+            f.render_widget(bl, Rect::new(x_offset, y_offset + 2, 1, 1));
+            let br = Paragraph::new("⇘").style(style_border);
+            f.render_widget(br, Rect::new(x_offset + 5, y_offset + 2, 1, 1));
         }
         BeamXStyle::Cross => {
             let left = Paragraph::new("⨯").style(style_status);
-            f.render_widget(left, Rect::new(base_x, y_offset, 1, 1));
-            let prism = Paragraph::new(style.center_glyph).style(style_prism);
-            f.render_widget(prism, Rect::new(base_x + 1, y_offset, 1, 1));
+            f.render_widget(left, Rect::new(x_offset + 1, y_offset + 1, 1, 1));
+            let prism = Paragraph::new(prism_glyph).style(style_prism);
+            f.render_widget(prism, Rect::new(x_offset + 3, y_offset + 1, 1, 1));
             let right = Paragraph::new("⨯").style(style_border);
-            f.render_widget(right, Rect::new(base_x + 2, y_offset, 1, 1));
+            f.render_widget(right, Rect::new(x_offset + 5, y_offset + 1, 1, 1));
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     backend::Backend,
-    layout::Rect,
+    layout::{Rect, Alignment},
     Frame,
     widgets::{Block, Borders, Paragraph},
     text::Line,
@@ -21,9 +21,13 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let block = Block::default()
         .title("Settings")
         .borders(Borders::NONE);
+    // Draw title first so the text area can be precisely positioned
+    f.render_widget(block, area);
 
-    let paragraph = Paragraph::new(lines).block(block);
-    f.render_widget(paragraph, area);
+    let inner = Rect::new(area.x + 1, area.y + 1, area.width.saturating_sub(2), area.height.saturating_sub(2));
+    let paragraph = Paragraph::new(lines)
+        .alignment(Alignment::Left);
+    f.render_widget(paragraph, inner);
     render_full_border(f, area, &style);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }


### PR DESCRIPTION
## Summary
- fix clipping on Settings screen
- animate prism glyph and draw BeamX symmetrically

## Testing
- `cargo check`