### PR TITLE
Implement BeamX prism cycle

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -58,7 +58,7 @@ pub fn render_beamx<B: Backend>(
     style: &BeamStyle,
     variant: BeamXStyle,
 ) {
-    let x_offset = area.right().saturating_sub(7);
+    let x_offset = area.right().saturating_sub(5);
     let y_offset = area.top();
 
     let style_border = Style::default().fg(style.border_color);
@@ -70,13 +70,14 @@ pub fn render_beamx<B: Backend>(
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() / 300;
-    let prism_glyph = match tick % 24 {
-        0..=3 => "·",
-        4..=7 => "◆",
-        8..=11 => "✦",
-        12..=15 => "X",
-        16..=19 => "✦",
-        20..=23 => "◆",
+    let center = match tick % 48 {
+        0..=5 => "·",
+        6..=11 => "✦",
+        12..=23 => "❖",
+        24..=29 => "✦",
+        30..=35 => "X",
+        36..=41 => "✦",
+        42..=47 => "❖",
         _ => "·",
     };
 
@@ -84,31 +85,27 @@ pub fn render_beamx<B: Backend>(
         BeamXStyle::Split => {
             // top row corners
             let tl = Paragraph::new("⬊").style(style_border);
-            f.render_widget(tl, Rect::new(x_offset + 1, y_offset, 1, 1));
+            f.render_widget(tl, Rect::new(x_offset, y_offset, 1, 1));
             let tr = Paragraph::new("⬋").style(style_border);
-            f.render_widget(tr, Rect::new(x_offset + 5, y_offset, 1, 1));
+            f.render_widget(tr, Rect::new(x_offset + 4, y_offset, 1, 1));
 
-            // middle row with inward beams and pulsing prism
-            let left = Paragraph::new("⥤").style(style_status);
-            f.render_widget(left, Rect::new(x_offset, y_offset + 1, 1, 1));
-            let center = Paragraph::new(prism_glyph).style(style_prism);
-            f.render_widget(center, Rect::new(x_offset + 3, y_offset + 1, 1, 1));
-            let right = Paragraph::new("⥢").style(style_status);
-            f.render_widget(right, Rect::new(x_offset + 6, y_offset + 1, 1, 1));
+            // center glyph
+            let center_widget = Paragraph::new(center).style(style_prism);
+            f.render_widget(center_widget, Rect::new(x_offset + 2, y_offset + 1, 1, 1));
 
             // bottom row corners
             let bl = Paragraph::new("⬈").style(style_border);
-            f.render_widget(bl, Rect::new(x_offset + 1, y_offset + 2, 1, 1));
+            f.render_widget(bl, Rect::new(x_offset, y_offset + 2, 1, 1));
             let br = Paragraph::new("⬉").style(style_border);
-            f.render_widget(br, Rect::new(x_offset + 5, y_offset + 2, 1, 1));
+            f.render_widget(br, Rect::new(x_offset + 4, y_offset + 2, 1, 1));
         }
         BeamXStyle::Cross => {
             let left = Paragraph::new("⨯").style(style_status);
             f.render_widget(left, Rect::new(x_offset + 1, y_offset + 1, 1, 1));
-            let prism = Paragraph::new(prism_glyph).style(style_prism);
-            f.render_widget(prism, Rect::new(x_offset + 3, y_offset + 1, 1, 1));
+            let prism = Paragraph::new(center).style(style_prism);
+            f.render_widget(prism, Rect::new(x_offset + 2, y_offset + 1, 1, 1));
             let right = Paragraph::new("⨯").style(style_border);
-            f.render_widget(right, Rect::new(x_offset + 5, y_offset + 1, 1, 1));
+            f.render_widget(right, Rect::new(x_offset + 3, y_offset + 1, 1, 1));
         }
     }
 }
@@ -125,7 +122,7 @@ pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &Beam
 
     let tl = Paragraph::new("┏").style(fg);
     f.render_widget(tl, Rect::new(area.x, area.y, 1, 1));
-    let beam_start = area.right().saturating_sub(7);
+    let beam_start = area.right().saturating_sub(5);
     let beam_end = beam_start + 4;
     for x in area.x + 1..right {
         if x >= beam_start && x <= beam_end {


### PR DESCRIPTION
## Summary
- update BeamX logo animation to show only diagonals and animated center glyph
- shrink logo width and adjust border skipping
- keep BeamX rendered last in GemX, Zen, Triage and Settings modules

## Testing
- `cargo test`