### PR TITLE
Fix BeamX border corner overlap

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -115,7 +115,12 @@ pub fn render_beam_logo<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamSt
     render_beamx(f, area, style, BeamXStyle::Split);
 }
 
-pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &BeamStyle) {
+pub fn render_full_border<B: Backend>(
+    f: &mut Frame<B>,
+    area: Rect,
+    style: &BeamStyle,
+    beamx_enabled: bool,
+) {
     let fg = Style::default().fg(style.border_color);
     let right = area.x + area.width - 1;
     let bottom = area.y + area.height - 1;
@@ -125,13 +130,16 @@ pub fn render_full_border<B: Backend>(f: &mut Frame<B>, area: Rect, style: &Beam
     let beam_start = area.right().saturating_sub(5);
     let beam_end = beam_start + 4;
     for x in area.x + 1..right {
-        if x >= beam_start && x <= beam_end {
+        if beamx_enabled && x >= beam_start && x <= beam_end {
             continue;
         }
         let p = Paragraph::new("━").style(fg);
         f.render_widget(p, Rect::new(x, area.y, 1, 1));
     }
-    // Skip top-right corner so the beam can cut through
+    if !beamx_enabled {
+        let tr = Paragraph::new("┓").style(fg);
+        f.render_widget(tr, Rect::new(right, area.y, 1, 1));
+    }
 
     for y in area.y + 1..bottom {
         let p = Paragraph::new("┃").style(fg);

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -15,6 +15,6 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     f.render_widget(block, area);
     f.render_widget(content, Rect::new(area.x + 2, area.y + 1, area.width - 4, area.height - 2));
-    render_full_border(f, area, &style);
+    render_full_border(f, area, &style, true);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -34,7 +34,7 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
         .wrap(Wrap { trim: false });
 
     f.render_widget(widget, area);
-    render_full_border(f, area, &style);
+    render_full_border(f, area, &style, true);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }
 

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -21,6 +21,6 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
 
     let paragraph = Paragraph::new(tasks).block(block);
     f.render_widget(paragraph, area);
-    render_full_border(f, area, &style);
+    render_full_border(f, area, &style, true);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -165,6 +165,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         }
     }
 
-    render_full_border(f, area, &style);
+    render_full_border(f, area, &style, true);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,6 +28,6 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let paragraph = Paragraph::new(lines)
         .alignment(Alignment::Left);
     f.render_widget(paragraph, inner);
-    render_full_border(f, area, &style);
+    render_full_border(f, area, &style, true);
     render_beamx(f, area, &style, BeamXStyle::Split);
 }


### PR DESCRIPTION
## Summary
- allow render_full_border() to skip the upper‑right corner when the BeamX logo is present
- update module screens to pass `beamx_enabled` flag

## Testing
- `cargo check`