### PR TITLE
Patch 25.50a-v build fix and cleanup

### DIFF
--- a/bin/archive-patch.sh
+++ b/bin/archive-patch.sh
@@ -3,5 +3,10 @@ set -e
 
 patch_dir="\$1"
 [ -z "\$patch_dir" ] && echo "Usage: bin/archive-patch.sh patch-folder-name" && exit 1
+# Remove macOS and editor junk before zipping
+find patches/\$patch_dir -name .DS_Store -delete
+find patches/\$patch_dir \(
+    -name "*.swp" -o -name "*.swo" -o -name "*.tmp" -o -name "*.log" -o -name "*.orig"\
+\) -delete
 zip -r patches/\$patch_dir.zip patches/\$patch_dir
 echo "✅ Archived as patches/\$patch_dir.zip"

--- a/patches/patch-25.50a-v-ci-fix/CODE_CHANGES.md
+++ b/patches/patch-25.50a-v-ci-fix/CODE_CHANGES.md
@@ -26,9 +26,11 @@ use ratatui::widgets::Paragraph;
 - In `.github/workflows/prismx-patch-tests.yml`:
   Fix `env:` syntax in `Post Summary to PR` block
 
-- In all scripts (test, archive):
+- In all scripts (test plan and `bin/archive-patch.sh`):
   Add cleanup logic:
 ```bash
 find . -name .DS_Store -delete
-find . -name "*.swp" -o -name "*.tmp" -o -name "*.log" -o -name "*.swo" -o -name "*.orig" -delete
+find . \(
+  -name "*.swp" -o -name "*.swo" -o -name "*.tmp" -o -name "*.log" -o -name "*.orig"\
+\) -delete
 ```

--- a/patches/patch-25.50a-v-ci-fix/test_plan.sh
+++ b/patches/patch-25.50a-v-ci-fix/test_plan.sh
@@ -5,7 +5,9 @@ echo "🚪 Patch 25.50a-v CI Fix Test"
 
 echo "🗃️ Cleaning up junk files..."
 find . -name .DS_Store -delete
-find . -name "*.swp" -o -name "*.tmp" -o -name "*.log" -o -name "*.swo" -o -name "*.orig" -delete
+find . \(
+  -name "*.swp" -o -name "*.swo" -o -name "*.tmp" -o -name "*.log" -o -name "*.orig"\
+\) -delete
 
 echo "✅ settings.rs compiles with time imports"
 echo "✅ state/mod.rs no longer uses unnecessary mut"

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -201,7 +201,7 @@ impl AppState {
         if let Some(parent_id) = self.selected {
             let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
-            let mut child = Node::new(new_id, "New Child", Some(parent_id));
+            let child = Node::new(new_id, "New Child", Some(parent_id));
 
             if let Some(parent) = self.nodes.get_mut(&parent_id) {
                 parent.children.push(new_id);
@@ -217,7 +217,7 @@ impl AppState {
             let parent_id = self.nodes.get(&selected_id).and_then(|n| n.parent);
 
             let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
-            let mut sibling = Node::new(new_id, "New Sibling", parent_id);
+            let sibling = Node::new(new_id, "New Sibling", parent_id);
 
             match parent_id {
                 Some(p_id) => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_key: &str) -> std::io::Result<()> {
     use ratatui::layout::{Constraint, Direction, Layout};
-    use ratatui::widgets::{Block, Borders, Paragraph};
+    use ratatui::widgets::Paragraph;
 
     if !state.auto_arrange {
         state.ensure_grid_positions();


### PR DESCRIPTION
## Summary
- ensure child/sibling added without `mut`
- simplify draw import
- clean junk files before zipping patch
- update patch docs and cleanup step

## Testing
- `cargo build --release`