### PR TITLE
patch 25.50b-a plugin system boot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod screen;
 pub mod bootstrap;
 pub mod config;
 pub mod plugin;
+pub mod plugins;
 pub mod tui;
 pub mod trust;
 pub mod federation;

--- a/src/plugins/countdown/mod.rs
+++ b/src/plugins/countdown/mod.rs
@@ -1,0 +1,19 @@
+use super::PluginRender;
+use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, Frame};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct CountdownPlugin {
+    pub label: String,
+    pub target: SystemTime,
+}
+
+impl PluginRender for CountdownPlugin {
+    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let target = self.target.duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let remaining = target.saturating_sub(now);
+        let days = remaining / 86400;
+        let para = Paragraph::new(format!("D-{}: {}", days, self.label));
+        f.render_widget(para, area);
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,11 @@
+use ratatui::{backend::Backend, layout::Rect, Frame};
+
+pub trait PluginRender {
+    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect);
+}
+
+pub mod countdown;
+pub mod pomodoro;
+
+pub use countdown::CountdownPlugin;
+pub use pomodoro::PomodoroPlugin;

--- a/src/plugins/pomodoro/mod.rs
+++ b/src/plugins/pomodoro/mod.rs
@@ -1,0 +1,27 @@
+use super::PluginRender;
+use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, Frame};
+use std::time::SystemTime;
+
+#[derive(Copy, Clone)]
+pub enum PomodoroState {
+    Idle,
+    Focus,
+    Break,
+}
+
+pub struct PomodoroPlugin {
+    pub state: PomodoroState,
+    pub start_time: Option<SystemTime>,
+}
+
+impl PluginRender for PomodoroPlugin {
+    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+        let label = match self.state {
+            PomodoroState::Focus => "Focus Session",
+            PomodoroState::Break => "Break Time",
+            PomodoroState::Idle => "Pomodoro Idle",
+        };
+        let para = Paragraph::new(label);
+        f.render_widget(para, area);
+    }
+}

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -7,6 +7,8 @@ use ratatui::{
 };
 use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::plugins::pomodoro::{PomodoroPlugin, PomodoroState};
+use crate::plugins::PluginRender;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -35,4 +37,11 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
         style: BeamXStyle::from(BeamXMode::Triage),
     };
     beamx.render(f, area);
+
+    // Temporary plugin render for validation
+    let mut plugin = PomodoroPlugin {
+        state: PomodoroState::Idle,
+        start_time: None,
+    };
+    plugin.render(f, area);
 }


### PR DESCRIPTION
## Summary
- scaffold plugin modules under `src/plugins`
- implement `PluginRender` trait with Countdown and Pomodoro plugins
- expose the plugins through `plugins` module and use in `RoutineForge`

## Testing
- `cargo test --quiet`
