### PR TITLE
Add runtime plugin host and spotlight triggers

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,16 +1,31 @@
-use std::fs;
+use crate::plugins::{PluginFrame, PluginRender, PomodoroPlugin, CountdownPlugin};
+use ratatui::layout::Rect;
+use std::collections::VecDeque;
+use std::time::{Duration, SystemTime};
 
-pub fn load_all_plugins() -> Result<(), Box<dyn std::error::Error>> {
-    let plugins = vec!["gemx", "dashboard", "mindtrace"];
-    for plugin in plugins {
-        let path = format!("plugins/{}/lineage.trace.json", plugin);
-        match fs::read_to_string(&path) {
-            Ok(lineage) => println!("[PLUGIN] Loaded: {} → {}", plugin, lineage.trim()),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                println!("[PLUGIN] {} missing lineage file. Skipping.", plugin);
-            }
-            Err(e) => return Err(Box::new(e)),
+pub struct PluginHost {
+    pub active: VecDeque<Box<dyn PluginRender>>,
+}
+
+impl PluginHost {
+    pub fn new() -> Self {
+        Self { active: VecDeque::new() }
+    }
+
+    pub fn start_pomodoro(&mut self) {
+        self.active.push_back(Box::new(PomodoroPlugin::default()));
+    }
+
+    pub fn add_countdown(&mut self, label: String, delta_days: u64) {
+        let target = SystemTime::now() + Duration::from_secs(86400 * delta_days);
+        self.active.push_back(Box::new(CountdownPlugin { label, target }));
+    }
+
+    pub fn render_all(&mut self, f: &mut PluginFrame<'_>, area: Rect) {
+        let mut y_offset = 0;
+        for plugin in &mut self.active {
+            plugin.render(f, Rect::new(area.x, area.y + y_offset, area.width, 3));
+            y_offset += 3;
         }
     }
-    Ok(())
 }

--- a/src/plugins/countdown/mod.rs
+++ b/src/plugins/countdown/mod.rs
@@ -1,5 +1,5 @@
-use super::PluginRender;
-use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, Frame};
+use super::{PluginFrame, PluginRender};
+use ratatui::{layout::Rect, widgets::Paragraph};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct CountdownPlugin {
@@ -8,7 +8,7 @@ pub struct CountdownPlugin {
 }
 
 impl PluginRender for CountdownPlugin {
-    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+    fn render(&mut self, f: &mut PluginFrame<'_>, area: Rect) {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
         let target = self.target.duration_since(UNIX_EPOCH).unwrap().as_secs();
         let remaining = target.saturating_sub(now);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,7 +1,10 @@
-use ratatui::{backend::Backend, layout::Rect, Frame};
+use ratatui::{backend::CrosstermBackend, layout::Rect, Frame};
+use std::io::Stdout;
+
+pub type PluginFrame<'a> = Frame<'a, CrosstermBackend<Stdout>>;
 
 pub trait PluginRender {
-    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect);
+    fn render(&mut self, f: &mut PluginFrame<'_>, area: Rect);
 }
 
 pub mod countdown;

--- a/src/plugins/pomodoro/mod.rs
+++ b/src/plugins/pomodoro/mod.rs
@@ -1,5 +1,5 @@
-use super::PluginRender;
-use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, Frame};
+use super::{PluginFrame, PluginRender};
+use ratatui::{layout::Rect, widgets::Paragraph};
 use std::time::SystemTime;
 
 #[derive(Copy, Clone)]
@@ -14,8 +14,17 @@ pub struct PomodoroPlugin {
     pub start_time: Option<SystemTime>,
 }
 
+impl Default for PomodoroPlugin {
+    fn default() -> Self {
+        Self {
+            state: PomodoroState::Idle,
+            start_time: None,
+        }
+    }
+}
+
 impl PluginRender for PomodoroPlugin {
-    fn render<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+    fn render(&mut self, f: &mut PluginFrame<'_>, area: Rect) {
         let label = match self.state {
             PomodoroState::Focus => "Focus Session",
             PomodoroState::Break => "Break Time",

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    backend::Backend,
+    backend::CrosstermBackend,
     layout::Rect,
     Frame,
     widgets::{Block, Borders, Paragraph},
@@ -7,12 +7,14 @@ use ratatui::{
 };
 use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
-use crate::plugins::pomodoro::{PomodoroPlugin, PomodoroState};
-use crate::plugins::PluginRender;
+use crate::state::AppState;
+use std::io::Stdout;
+
+type PluginFrame<'a> = Frame<'a, CrosstermBackend<Stdout>>;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
+pub fn render_triage_panel(f: &mut PluginFrame<'_>, area: Rect, state: &mut AppState) {
     let style = style_for_mode("triage");
     let tasks = vec![
         Line::from("[ ] Design new node engine"),
@@ -38,10 +40,6 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect) {
     };
     beamx.render(f, area);
 
-    // Temporary plugin render for validation
-    let mut plugin = PomodoroPlugin {
-        state: PomodoroState::Idle,
-        start_time: None,
-    };
-    plugin.render(f, area);
+    let plugin_area = Rect::new(area.x + 1, area.y + 1, area.width - 2, area.height - 4);
+    state.plugin_host.render_all(f, plugin_area);
 }


### PR DESCRIPTION
## Summary
- implement `PluginHost` with dynamic plugin queue
- allow AppState to manage PluginHost and parse plugin spotlight commands
- render active plugins in RoutineForge panel
- support rendering of Pomodoro and Countdown plugins

## Testing
- `cargo check`
- `cargo test`
