### PR TITLE
Patch 25.50b-d: auto-merge trigger fix

### DIFF
--- a/.github/workflows/auto-merge-patch.yml
+++ b/.github/workflows/auto-merge-patch.yml
@@ -2,7 +2,7 @@ name: Auto Merge Patch PRs
 
 on:
   pull_request:
-    types: [labeled, opened]
+    types: [labeled, opened, synchronize]
 
 jobs:
   label-and-merge:


### PR DESCRIPTION
## Summary
- trigger the auto-merge workflow when patch PRs update

## Testing
- `cargo test`