### PR TITLE
Patch 25.51b: fix zoom scroll

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -66,10 +66,10 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 
     for (&id, &Coords { x: nx, y: ny }) in &layout {
         let zoom = state.zoom_scale as f32;
-        let draw_x = ((nx as f32 * BASE_SPACING_X as f32 * zoom) - state.scroll_x as f32)
+        let draw_x = ((nx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom)
             .round()
             .max(0.0) as u16;
-        let draw_y = ((ny as f32 * BASE_SPACING_Y as f32 * zoom) - state.scroll_y as f32)
+        let draw_y = ((ny as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom)
             .round()
             .max(0.0) as u16;
 
@@ -89,8 +89,8 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
     state.dragging = Some(id);
     let zoom = state.zoom_scale as f32;
-    let wx = ((x as f32 + state.scroll_x as f32) / (BASE_SPACING_X as f32 * zoom)).round() as i16;
-    let wy = ((y as f32 + state.scroll_y as f32) / (BASE_SPACING_Y as f32 * zoom)).round() as i16;
+    let wx = (state.scroll_x as f32 + (x as f32 / (BASE_SPACING_X as f32 * zoom))).round() as i16;
+    let wy = (state.scroll_y as f32 + (y as f32 / (BASE_SPACING_Y as f32 * zoom))).round() as i16;
     state.last_mouse = Some((wx, wy));
     state.selected = Some(id);
 }
@@ -98,8 +98,8 @@ pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
 /// Update dragging node position based on new mouse coords.
 pub fn drag_update(state: &mut AppState, x: u16, y: u16) {
     let zoom = state.zoom_scale as f32;
-    let wx = ((x as f32 + state.scroll_x as f32) / (BASE_SPACING_X as f32 * zoom)).round() as i16;
-    let wy = ((y as f32 + state.scroll_y as f32) / (BASE_SPACING_Y as f32 * zoom)).round() as i16;
+    let wx = (state.scroll_x as f32 + (x as f32 / (BASE_SPACING_X as f32 * zoom))).round() as i16;
+    let wy = (state.scroll_y as f32 + (y as f32 / (BASE_SPACING_Y as f32 * zoom))).round() as i16;
     if let (Some(id), Some((lx, ly))) = (state.dragging, state.last_mouse) {
         let dx = wx - lx;
         let dy = wy - ly;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -274,10 +274,8 @@ pub fn zoom_to_anchor(state: &mut crate::state::AppState, node_id: NodeID) {
     if let Some(node) = state.nodes.get(&node_id) {
         let (tw, th) = crossterm::terminal::size().unwrap_or((80, 20));
         let zoom = state.zoom_scale;
-        let anchor_x = node.x as f32 * crate::layout::BASE_SPACING_X as f32 * zoom;
-        let anchor_y = node.y as f32 * crate::layout::BASE_SPACING_Y as f32 * zoom;
-        state.scroll_x = (anchor_x - tw as f32 / 2.0).round() as i16;
-        state.scroll_y = (anchor_y - th as f32 / 2.0).round() as i16;
+        state.scroll_x = (node.x as f32 - (tw as f32 / 2.0) / (crate::layout::BASE_SPACING_X as f32 * zoom)).round() as i16;
+        state.scroll_y = (node.y as f32 - (th as f32 / 2.0) / (crate::layout::BASE_SPACING_Y as f32 * zoom)).round() as i16;
         clamp_scroll(state);
     }
 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -76,10 +76,10 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             continue;
         }
         let zoom = state.zoom_scale as f32;
-        let draw_x = ((x as f32 * BASE_SPACING_X as f32 * zoom) - state.scroll_x as f32)
+        let draw_x = ((x as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom)
             .round()
             .max(0.0) as u16;
-        let draw_y = ((y as f32 * BASE_SPACING_Y as f32 * zoom) - state.scroll_y as f32)
+        let draw_y = ((y as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom)
             .round()
             .max(0.0) as u16;
 
@@ -149,9 +149,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             {
                 if sy == ty {
                     let zoom = state.zoom_scale as f32;
-                    let sxp = ((sx as f32 * BASE_SPACING_X as f32 * zoom) - state.scroll_x as f32).round();
-                    let txp = ((tx as f32 * BASE_SPACING_X as f32 * zoom) - state.scroll_x as f32).round();
-                    let syp = ((sy as f32 * BASE_SPACING_Y as f32 * zoom) - state.scroll_y as f32).round();
+                    let sxp = ((sx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom).round();
+                    let txp = ((tx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom).round();
+                    let syp = ((sy as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom).round();
                     let arrow = if sx < tx { "→" } else { "←" };
                     let mid = ((sxp + txp) / 2.0).round().max(0.0) as u16;
                     let draw_sy = syp.max(0.0) as u16;


### PR DESCRIPTION
## Summary
- adjust GemX screen math for scroll offsets
- keep anchor centering logic in world units

## Testing
- `cargo test --quiet`
