### PR TITLE
Patch 25.51h – refine gemx node layout

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -2,8 +2,8 @@ use crate::state::AppState;
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{
     layout_nodes, Coords, SIBLING_SPACING_X, CHILD_SPACING_Y, FREE_GRID_COLUMNS,
-    GEMX_HEADER_HEIGHT, BASE_SPACING_X, BASE_SPACING_Y, PackRegion, subtree_span,
-    subtree_depth,
+    GEMX_HEADER_HEIGHT, PackRegion, subtree_span,
+    subtree_depth, spacing_for_zoom,
 };
 use std::collections::HashMap;
 
@@ -66,10 +66,11 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 
     for (&id, &Coords { x: nx, y: ny }) in &layout {
         let zoom = state.zoom_scale as f32;
-        let draw_x = ((nx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom)
+        let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+        let draw_x = ((nx as f32 - state.scroll_x as f32) * bsx as f32 * zoom)
             .round()
             .max(0.0) as u16;
-        let draw_y = ((ny as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom)
+        let draw_y = ((ny as f32 - state.scroll_y as f32) * bsy as f32 * zoom)
             .round()
             .max(0.0) as u16;
 
@@ -89,8 +90,9 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
     state.dragging = Some(id);
     let zoom = state.zoom_scale as f32;
-    let wx = (state.scroll_x as f32 + (x as f32 / (BASE_SPACING_X as f32 * zoom))).round() as i16;
-    let wy = (state.scroll_y as f32 + (y as f32 / (BASE_SPACING_Y as f32 * zoom))).round() as i16;
+    let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+    let wx = (state.scroll_x as f32 + (x as f32 / (bsx as f32 * zoom))).round() as i16;
+    let wy = (state.scroll_y as f32 + (y as f32 / (bsy as f32 * zoom))).round() as i16;
     state.last_mouse = Some((wx, wy));
     state.selected = Some(id);
 }
@@ -98,8 +100,9 @@ pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
 /// Update dragging node position based on new mouse coords.
 pub fn drag_update(state: &mut AppState, x: u16, y: u16) {
     let zoom = state.zoom_scale as f32;
-    let wx = (state.scroll_x as f32 + (x as f32 / (BASE_SPACING_X as f32 * zoom))).round() as i16;
-    let wy = (state.scroll_y as f32 + (y as f32 / (BASE_SPACING_Y as f32 * zoom))).round() as i16;
+    let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+    let wx = (state.scroll_x as f32 + (x as f32 / (bsx as f32 * zoom))).round() as i16;
+    let wy = (state.scroll_y as f32 + (y as f32 / (bsy as f32 * zoom))).round() as i16;
     if let (Some(id), Some((lx, ly))) = (state.dragging, state.last_mouse) {
         let dx = wx - lx;
         let dy = wy - ly;

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -2,7 +2,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::layout::{
     layout_nodes, Coords, LayoutRole, PackRegion, GEMX_HEADER_HEIGHT,
-    BASE_SPACING_X, BASE_SPACING_Y, CHILD_SPACING_Y, subtree_span, subtree_depth,
+    CHILD_SPACING_Y, subtree_span, subtree_depth, spacing_for_zoom,
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
@@ -76,10 +76,11 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             continue;
         }
         let zoom = state.zoom_scale as f32;
-        let draw_x = ((x as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom)
+        let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+        let draw_x = ((x as f32 - state.scroll_x as f32) * bsx as f32 * zoom)
             .round()
             .max(0.0) as u16;
-        let draw_y = ((y as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom)
+        let draw_y = ((y as f32 - state.scroll_y as f32) * bsy as f32 * zoom)
             .round()
             .max(0.0) as u16;
 
@@ -149,9 +150,10 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             {
                 if sy == ty {
                     let zoom = state.zoom_scale as f32;
-                    let sxp = ((sx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom).round();
-                    let txp = ((tx as f32 - state.scroll_x as f32) * BASE_SPACING_X as f32 * zoom).round();
-                    let syp = ((sy as f32 - state.scroll_y as f32) * BASE_SPACING_Y as f32 * zoom).round();
+                    let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+                    let sxp = ((sx as f32 - state.scroll_x as f32) * bsx as f32 * zoom).round();
+                    let txp = ((tx as f32 - state.scroll_x as f32) * bsx as f32 * zoom).round();
+                    let syp = ((sy as f32 - state.scroll_y as f32) * bsy as f32 * zoom).round();
                     let arrow = if sx < tx { "→" } else { "←" };
                     let mid = ((sxp + txp) / 2.0).round().max(0.0) as u16;
                     let draw_sy = syp.max(0.0) as u16;


### PR DESCRIPTION
## Summary
- update layout algorithm so children appear below parents
- adjust sibling positioning using base spacing constant
- scale grid spacing based on zoom level to keep layout readable

## Testing
- `cargo test --quiet`