### PR TITLE
Patch 25.51l – BeamX PulseEntryRadiate

### DIFF
--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -1,6 +1,6 @@
 use ratatui::{backend::Backend, layout::Rect, style::Style, widgets::{Block, Borders, Paragraph}, Frame};
 use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
@@ -26,6 +26,7 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
         tick,
         enabled: true,
         style: BeamXStyle::from(BeamXMode::Triage),
+        animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,7 +1,7 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph, Wrap}};
 use crate::state::AppState;
 use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -46,6 +46,7 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
         tick,
         enabled: true,
         style: BeamXStyle::from(BeamXMode::Zen),
+        animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
 }

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -6,7 +6,7 @@ use ratatui::{
     text::Line,
 };
 use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use crate::state::AppState;
 use std::io::Stdout;
 
@@ -37,6 +37,7 @@ pub fn render_triage_panel(f: &mut PluginFrame<'_>, area: Rect, state: &mut AppS
         tick,
         enabled: true,
         style: BeamXStyle::from(BeamXMode::Triage),
+        animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
 

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -7,7 +7,7 @@ use crate::layout::{
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
 use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::collections::HashMap;
 
@@ -217,6 +217,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         tick,
         enabled: true,
         style: BeamXStyle::from(BeamXMode::Default),
+        animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,7 @@ use ratatui::{
     text::Line,
 };
 use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode};
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 
 
 pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
@@ -40,6 +40,7 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect) {
         tick,
         enabled: true,
         style: BeamXStyle::from(BeamXMode::Settings),
+        animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
 }

--- a/src/ui/beamx.rs
+++ b/src/ui/beamx.rs
@@ -1,4 +1,4 @@
-use ratatui::{backend::Backend, layout::Rect, style::{Color, Style}, widgets::Paragraph, Frame};
+use ratatui::{backend::Backend, layout::Rect, style::{Color, Style, Modifier}, widgets::Paragraph, Frame};
 
 /// Visual style and glyph configuration for [`BeamX`].
 pub struct BeamXStyle {
@@ -24,10 +24,26 @@ pub enum BeamXMode {
     Settings,
 }
 
+/// Animation themes for [`BeamX`].
+#[derive(Copy, Clone)]
+pub enum BeamXAnimationMode {
+    PulseEntryRadiate,
+    // Future: ZenFade,
+    // Future: SpotlightBlink,
+    // Future: DebugFlash,
+}
+
+impl Default for BeamXAnimationMode {
+    fn default() -> Self {
+        BeamXAnimationMode::PulseEntryRadiate
+    }
+}
+
 pub struct BeamX {
     pub tick: u64,
     pub enabled: bool,
     pub style: BeamXStyle,
+    pub animation: BeamXAnimationMode,
 }
 
 impl Default for BeamXStyle {
@@ -112,23 +128,55 @@ impl BeamX {
             return;
         }
 
-        let pulse = self.style.pulse;
-        let prism = pulse[(self.tick as usize) % pulse.len()];
+        match self.animation {
+            BeamXAnimationMode::PulseEntryRadiate => {
+                self.render_frame(f, area, self.tick);
+            }
+        }
+    }
+
+    fn render_frame<B: Backend>(&self, f: &mut Frame<B>, area: Rect, tick: u64) {
+        let frame = tick % 24;
         let x = area.right().saturating_sub(7);
         let y = area.top();
 
-        let style_border = Style::default().fg(self.style.border_color);
-        let style_status = Style::default().fg(self.style.status_color);
-        let style_prism = Style::default().fg(self.style.prism_color);
+        let border = Style::default().fg(self.style.border_color);
+        let status = Style::default().fg(self.style.status_color);
+        let prism = Style::default().fg(self.style.prism_color);
 
-        f.render_widget(Paragraph::new(self.style.top_left).style(style_border), Rect::new(x, y, 1, 1));
-        f.render_widget(Paragraph::new(self.style.top_right).style(style_border), Rect::new(x + 6, y, 1, 1));
-
-        f.render_widget(Paragraph::new(self.style.left).style(style_status), Rect::new(x + 1, y + 1, 1, 1));
-        f.render_widget(Paragraph::new(prism).style(style_prism), Rect::new(x + 3, y + 1, 1, 1));
-        f.render_widget(Paragraph::new(self.style.right).style(style_status), Rect::new(x + 5, y + 1, 1, 1));
-
-        f.render_widget(Paragraph::new(self.style.bottom_left).style(style_border), Rect::new(x, y + 2, 1, 1));
-        f.render_widget(Paragraph::new(self.style.bottom_right).style(style_border), Rect::new(x + 6, y + 2, 1, 1));
+        match frame {
+            0..=2 => {
+                // Entry arrow
+                f.render_widget(Paragraph::new("⇙").style(status), Rect::new(x + 6, y, 1, 1));
+            }
+            3..=4 => {
+                f.render_widget(Paragraph::new("✦").style(prism), Rect::new(x + 3, y + 1, 1, 1));
+            }
+            5..=7 => {
+                f.render_widget(Paragraph::new("X").style(prism.add_modifier(Modifier::BOLD)), Rect::new(x + 3, y + 1, 1, 1));
+            }
+            8..=10 => {
+                f.render_widget(Paragraph::new("X").style(prism.add_modifier(Modifier::BOLD)), Rect::new(x + 3, y + 1, 1, 1));
+                f.render_widget(Paragraph::new("⬉").style(border), Rect::new(x, y, 1, 1));
+                f.render_widget(Paragraph::new("⬊").style(border), Rect::new(x + 6, y + 2, 1, 1));
+            }
+            11..=14 => {
+                let b = border.add_modifier(Modifier::BOLD);
+                f.render_widget(Paragraph::new("X").style(prism.add_modifier(Modifier::BOLD)), Rect::new(x + 3, y + 1, 1, 1));
+                f.render_widget(Paragraph::new("⬉").style(b), Rect::new(x, y, 1, 1));
+                f.render_widget(Paragraph::new("⬊").style(b), Rect::new(x + 6, y + 2, 1, 1));
+            }
+            15..=19 => {
+                let dim_border = border.add_modifier(Modifier::DIM);
+                let dim_status = status.add_modifier(Modifier::DIM);
+                f.render_widget(Paragraph::new("⇙").style(dim_status), Rect::new(x + 6, y, 1, 1));
+                f.render_widget(Paragraph::new("⬉").style(dim_border), Rect::new(x, y, 1, 1));
+                f.render_widget(Paragraph::new("⬊").style(dim_border), Rect::new(x + 6, y + 2, 1, 1));
+            }
+            _ => {
+                // Idle / reset
+                f.render_widget(Paragraph::new("X").style(prism), Rect::new(x + 3, y + 1, 1, 1));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `BeamXAnimationMode` enum
- support `animation` field on `BeamX`
- implement `PulseEntryRadiate` frame logic
- update all BeamX callsites

## Testing
- `cargo build`
- `bash patches/patch-25.51l-beamx-pulse-entry-radiate/test_plan.sh`
