### PR TITLE
Patch 25.51q child layout safety

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -73,6 +73,14 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
     }
 
+    if drawn_at.is_empty() {
+        f.render_widget(
+            Paragraph::new("⚠ Layout Error"),
+            Rect::new(area.x + 2, area.y + 2, 30, 1),
+        );
+        eprintln!("⚠ layout_nodes() returned no visible nodes.");
+    }
+
     // When auto-arrange is active, adjust zoom and scroll to fit all nodes
     if state.auto_arrange && !drawn_at.is_empty() {
         let min_x = drawn_at.values().map(|c| c.x).min().unwrap_or(0);
@@ -177,6 +185,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
                     style = style.add_modifier(Modifier::DIM | Modifier::UNDERLINED);
                 }
                 _ => {}
+            }
+        }
+
+        if state.debug_input_mode {
+            let has_parent = node.parent.is_some();
+            if !has_parent && !matches!(role, LayoutRole::Root | LayoutRole::Free) {
+                style = style.bg(Color::Red);
             }
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -208,12 +208,13 @@ impl AppState {
                 child.y = parent.y + 1;
             }
 
+            self.nodes.insert(new_id, child);
             if let Some(parent) = self.nodes.get_mut(&parent_id) {
                 parent.children.push(new_id);
             }
 
-            self.nodes.insert(new_id, child);
             self.selected = Some(new_id);
+            self.recalculate_roles();
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure new child nodes always have coordinates
- warn if layout renders no nodes
- highlight detached nodes in debug mode

## Testing
- `cargo test --quiet`