### PR TITLE
Implement BeamX 6-point animation

### DIFF
--- a/tests/golden/gemx.snapshot
+++ b/tests/golden/gemx.snapshot
@@ -1,8 +1,8 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━⬉     ⇙
-┃[A] Auto-Arrange                             ✦   
-┃ Node A                      Node B             ⬊
-┃                                                ┃
-┃                                                ┃
+┃[A] Auto-Arrange                           ⬉    ⇙
+┃ Node A                      Node B          ·   
+┃                                               ⬊┃
+┃                                                ⬊
 ┃                                                ┃
 ┃                                                ┃
 ┃                                                ┃


### PR DESCRIPTION
## Summary
- expand BeamX pulse renderer to six-beam layout
- animate entry/exit beams and color-cycling center prism
- sync border pulse with beam bright phase
- update golden snapshot

## Testing
- `cargo test`