### PR TITLE
Fix orphan Tab crash and root recovery logs

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -25,6 +25,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
     // Ensure we always have at least one valid root after role recalculation
     state.ensure_valid_roots();
+    if state.root_nodes.is_empty() {
+        f.render_widget(
+            Paragraph::new("⚠ No valid root nodes."),
+            Rect::new(area.x + 2, area.y + 2, 40, 1),
+        );
+        return;
+    }
 
 
     // // ✅ Always print the structure for diagnostics
@@ -79,11 +86,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     use std::collections::HashSet;
     let reachable_ids: HashSet<NodeID> = drawn_at.keys().copied().collect();
     for (id, _node) in &state.nodes {
-        if !reachable_ids.contains(id) {
+        if !reachable_ids.contains(id) && !state.root_nodes.contains(id) {
             eprintln!("⚠ Node {} is unreachable from root", id);
-            if !state.root_nodes.contains(id) {
-                state.root_nodes.push(*id);
-            }
+            state.root_nodes.push(*id);
         }
     }
     state.root_nodes.sort_unstable();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -125,7 +125,8 @@ impl AppState {
     /// are empty or invalid.
     pub fn ensure_valid_roots(&mut self) {
         self.root_nodes.retain(|id| self.nodes.contains_key(id));
-        if self.root_nodes.is_empty() && !self.nodes.is_empty() {
+        let was_empty = self.root_nodes.is_empty();
+        if was_empty && !self.nodes.is_empty() {
             if let Some((&first_id, _)) = self.nodes.iter().next() {
                 self.root_nodes.push(first_id);
                 eprintln!("\u{26a0} root_nodes was empty — promoted Node {} to root", first_id);
@@ -231,6 +232,7 @@ impl AppState {
 
             self.selected = Some(new_id);
             self.recalculate_roles();
+            self.ensure_valid_roots();
         }
     }
 

--- a/tests/tab_no_crash.rs
+++ b/tests/tab_no_crash.rs
@@ -1,0 +1,11 @@
+use prismx::{state::AppState, node::Node};
+
+#[test]
+fn test_tab_no_crash_on_orphan() {
+    let mut state = AppState::default();
+    state.nodes.clear();
+    state.nodes.insert(2, Node::new(2, "Test", None));
+    state.root_nodes.clear();
+    state.ensure_valid_roots();
+    assert!(state.root_nodes.contains(&2));
+}


### PR DESCRIPTION
## Summary
- prevent gemx layout from rendering without valid root nodes
- promote a root node once and suppress repeated logs
- keep roots valid when adding a child
- test that root promotion works on orphaned nodes

## Testing
- `cargo test -- --nocapture`