### PR TITLE
Improve root recovery dedup

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -6,7 +6,8 @@ use crate::layout::{
     BASE_SPACING_X, BASE_SPACING_Y,
 };
 use crate::node::{NodeID, NodeMap};
-use crate::state::AppState;
+use crate::state::{AppState, PROMOTION_LOGGED};
+use std::sync::atomic::Ordering;
 use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,6 +19,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })
         .borders(Borders::NONE);
     f.render_widget(block, area);
+
+    // reset log flag for this frame
+    PROMOTION_LOGGED.store(false, Ordering::Relaxed);
 
     if state.auto_arrange {
         state.recalculate_roles();


### PR DESCRIPTION
## Summary
- keep deduplicated list of root nodes when recovering from orphaned state
- suppress repeated promotion warnings by tracking frame state

## Testing
- `cargo test --quiet`