### PR TITLE
Fix crash on child insert by validating roots early

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -19,11 +19,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         .borders(Borders::NONE);
     f.render_widget(block, area);
 
+    // Ensure we always have valid root nodes before any layout logic
+    state.ensure_valid_roots();
     if state.auto_arrange {
         state.recalculate_roles();
     }
 
-    // Ensure we always have at least one valid root after role recalculation
+    // Validate again in case role recalculation removed all roots
     state.ensure_valid_roots();
     if state.root_nodes.is_empty() {
         f.render_widget(

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -131,7 +131,12 @@ impl AppState {
             if let Some((&first_id, _)) = self.nodes.iter().next() {
                 if !self.root_nodes.contains(&first_id) {
                     self.root_nodes.push(first_id);
-                    eprintln!("\u{26a0} root_nodes was empty — promoted Node {} to root", first_id);
+                    if self.debug_input_mode {
+                        eprintln!(
+                            "\u{26a0} root_nodes was empty — promoted Node {} to root",
+                            first_id
+                        );
+                    }
                 }
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,7 +181,10 @@ pub fn launch_ui() -> std::io::Result<()> {
                 } else if match_hotkey("toggle_keymap", code, modifiers, &state) {
                     state.show_keymap = !state.show_keymap;
                 } else if match_hotkey("create_child", code, modifiers, &state) && state.mode == "gemx" {
-                    state.push_undo(); state.add_child();
+                    state.ensure_valid_roots();
+                    debug_assert!(!state.root_nodes.is_empty());
+                    state.push_undo();
+                    state.add_child();
                 } else if match_hotkey("create_sibling", code, modifiers, &state) && state.mode == "gemx" {
                     state.push_undo(); state.add_sibling();
                 } else if match_hotkey("add_free_node", code, modifiers, &state) {


### PR DESCRIPTION
## Summary
- ensure valid roots before tab child insert
- gate root promotion logging behind debug input mode
- validate root nodes before and after role recalculation during render

## Testing
- `cargo test`