### PR TITLE
Introduce root promotion lock

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -37,7 +37,7 @@ pub fn spawn_free_node(state: &mut AppState) {
 
     state.nodes.insert(new_id, node);
     state.root_nodes.push(new_id);
-    state.selected = Some(new_id);
+    state.set_selected(Some(new_id));
 }
 
 /// Determine which node is at the given coordinates considering current layout.
@@ -97,7 +97,7 @@ pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
     let wx = (state.scroll_x as f32 + (x as f32 / (bsx as f32 * zoom))).round() as i16;
     let wy = (state.scroll_y as f32 + (y as f32 / (bsy as f32 * zoom))).round() as i16;
     state.last_mouse = Some((wx, wy));
-    state.selected = Some(id);
+    state.set_selected(Some(id));
 }
 
 /// Update dragging node position based on new mouse coords.

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -283,4 +283,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);
+    if !drawn_at.is_empty() && !state.root_nodes.is_empty() {
+        state.last_promoted_root = None;
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -108,7 +108,8 @@ pub fn launch_ui() -> std::io::Result<()> {
 
     loop {
         if state.selected.is_none() && !state.nodes.is_empty() {
-            state.selected = Some(state.nodes.keys().copied().next().unwrap());
+            let first = state.nodes.keys().copied().next().unwrap();
+            state.set_selected(Some(first));
         }
 
         if event::poll(std::time::Duration::from_millis(100))? {


### PR DESCRIPTION
## Summary
- track last auto-promoted root in `AppState`
- ensure fallback root promotion happens only once per failure
- clear promotion lock after successful layout or manual selection

## Testing
- `cargo test`