### PR TITLE
Add mode glyph overlay

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,6 +4,7 @@ pub mod shortcuts_overlay;
 pub mod spotlight;
 pub mod triage;
 pub mod module_switcher;
+pub mod module_icon;
 
 pub use zen::render_zen_journal;
 pub use status::render_status_bar;
@@ -11,3 +12,4 @@ pub use shortcuts_overlay::render_shortcuts_overlay;
 pub use spotlight::render_spotlight;
 pub use triage::render_triage;
 pub use module_switcher::render_module_switcher;
+pub use module_icon::render_module_icon;

--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -1,0 +1,19 @@
+use ratatui::{backend::Backend, layout::Rect, style::{Color, Style, Modifier}, widgets::Paragraph, Frame};
+
+pub fn module_icon(mode: &str) -> &'static str {
+    match mode {
+        "gemx" => "💭",
+        "zen" => "✍️",
+        "triage" => "🧭",
+        "spotlight" => "🔍",
+        _ => "❓",
+    }
+}
+
+pub fn render_module_icon<B: Backend>(f: &mut Frame<B>, area: Rect, mode: &str) {
+    let glyph = module_icon(mode);
+    let style = Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD);
+    let x = area.x + 1;
+    let y = area.y;
+    f.render_widget(Paragraph::new(glyph).style(style), Rect::new(x, y, 2, 1));
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,6 +15,7 @@ use crate::render::{
     render_spotlight,
     render_triage,
     render_module_switcher,
+    render_module_icon,
 };
 use crate::screen::render_gemx;
 use crate::settings::render_settings;
@@ -89,6 +90,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
         } else {
             state.status_message.as_str()
         };
+        render_module_icon(f, full, &state.mode);
         render_status_bar(f, vertical[1], display);
     })?;
     Ok(())


### PR DESCRIPTION
## Summary
- add module icon overlay renderer
- export render_module_icon
- show the active module glyph in the UI

## Testing
- `cargo test --quiet`