### PR TITLE
Stabilize manual layout insertion

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -187,10 +187,10 @@ fn layout_recursive_safe(
                 if nodes.get(&pid).is_some() {
                     LayoutRole::Child
                 } else {
-                    LayoutRole::Orphan
+                    LayoutRole::Free
                 }
             }
-            None => LayoutRole::Orphan,
+            None => LayoutRole::Free,
         }
     };
     roles.insert(node_id, role);

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -96,11 +96,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
                 && !state.root_nodes.contains(id)
                 && !state.fallback_this_frame
                 && !node.children.is_empty()
+                && !state.fallback_promoted_this_session.contains(id)
             {
                 state.root_nodes.push(*id);
                 state.root_nodes.sort_unstable();
                 state.root_nodes.dedup();
                 state.fallback_this_frame = true;
+                state.fallback_promoted_this_session.insert(*id);
 
                 if state.debug_input_mode {
                     eprintln!("⚠ Node {} is unreachable — promoting to root", id);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{ SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT };
 use crossterm::terminal;
@@ -37,6 +37,7 @@ pub struct AppState {
     pub dragging: Option<NodeID>,
     pub last_mouse: Option<(i16, i16)>,
     pub fallback_this_frame: bool,
+    pub fallback_promoted_this_session: HashSet<NodeID>,
     pub debug_input_mode: bool,
     pub debug_border: bool,
     pub status_message: String,
@@ -84,6 +85,7 @@ impl Default for AppState {
             dragging: None,
             last_mouse: None,
             fallback_this_frame: false,
+            fallback_promoted_this_session: HashSet::new(),
             debug_input_mode: true,
             debug_border: std::env::var("PRISMX_DEBUG_BORDER").is_ok(),
             status_message: String::new(),
@@ -233,6 +235,10 @@ impl AppState {
 
     pub fn add_child(&mut self) {
         if let Some(parent_id) = self.selected {
+            if !self.nodes.contains_key(&parent_id) {
+                return;
+            }
+
             let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
             let mut child = Node::new(new_id, "New Child", Some(parent_id));
@@ -251,6 +257,9 @@ impl AppState {
             }
 
             self.set_selected(Some(new_id));
+            if !self.auto_arrange {
+                self.ensure_grid_positions();
+            }
             self.recalculate_roles();
             self.ensure_valid_roots();
         }
@@ -258,6 +267,9 @@ impl AppState {
 
     pub fn add_sibling(&mut self) {
         if let Some(selected_id) = self.selected {
+            if !self.nodes.contains_key(&selected_id) {
+                return;
+            }
             let parent_id = self.nodes.get(&selected_id).and_then(|n| n.parent);
 
             let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
@@ -284,6 +296,9 @@ impl AppState {
 
             self.nodes.insert(new_id, sibling);
             self.set_selected(Some(new_id));
+            if !self.auto_arrange {
+                self.ensure_grid_positions();
+            }
             self.recalculate_roles();
         }
     }
@@ -440,6 +455,10 @@ impl AppState {
         }
     }
 
+    pub fn clear_fallback_promotions(&mut self) {
+        self.fallback_promoted_this_session.clear();
+    }
+
     pub fn start_drag(&mut self) {
         self.selected_drag_source = self.selected;
     }
@@ -486,6 +505,8 @@ impl AppState {
     /// Otherwise the node is considered free/root.
     pub fn recalculate_roles(&mut self) {
         use std::collections::HashMap;
+
+        self.clear_fallback_promotions();
 
         let ids: Vec<NodeID> = self.nodes.keys().copied().collect();
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -228,9 +228,11 @@ pub fn launch_ui() -> std::io::Result<()> {
                 } else if match_hotkey("drill_down", code, modifiers, &state) {
                     state.drawing_root = state.selected;
                     state.fallback_this_frame = false;
+                    state.clear_fallback_promotions();
                 } else if match_hotkey("pop_up", code, modifiers, &state) {
                     state.drawing_root = None;
                     state.fallback_this_frame = false;
+                    state.clear_fallback_promotions();
                 } else if match_hotkey("toggle_settings", code, modifiers, &state) {
                     state.mode = "settings".into();
                 } else if code == KeyCode::Char('.') && modifiers == KeyModifiers::CONTROL {

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -1,0 +1,47 @@
+use prismx::{state::AppState, node::Node};
+
+#[test]
+fn enter_adds_sibling_with_same_parent() {
+    let mut state = AppState::default();
+    if let Some(b) = state.nodes.get_mut(&2) {
+        b.x = 10;
+    }
+    let original = state.selected.unwrap();
+    let orig_parent = state.nodes.get(&original).unwrap().parent;
+    state.add_sibling();
+    let new_id = state.selected.unwrap();
+    assert_ne!(original, new_id);
+    assert_eq!(state.nodes.get(&new_id).unwrap().parent, orig_parent);
+    if let Some(pid) = orig_parent {
+        assert!(state.nodes.get(&pid).unwrap().children.contains(&new_id));
+    } else {
+        assert!(state.root_nodes.contains(&new_id));
+    }
+}
+
+#[test]
+fn tab_adds_child_under_selection() {
+    let mut state = AppState::default();
+    // separate root nodes so role detection is stable
+    if let Some(b) = state.nodes.get_mut(&2) {
+        b.x = 10;
+    }
+    let parent = state.selected.unwrap();
+    state.add_child();
+    let new_id = state.selected.unwrap();
+    assert_eq!(state.nodes.get(&new_id).unwrap().parent, Some(parent));
+    assert!(state.nodes.get(&parent).unwrap().children.contains(&new_id));
+}
+
+#[test]
+fn missing_parent_becomes_free() {
+    use prismx::layout::{layout_nodes, LayoutRole};
+    let mut state = AppState::default();
+    let root = state.root_nodes[0];
+    let new_id = 999;
+    state.nodes.insert(new_id, Node::new(new_id, "Dangling", Some(123)));
+    state.nodes.get_mut(&root).unwrap().children.push(new_id);
+
+    let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true);
+    assert_eq!(roles.get(&new_id), Some(&LayoutRole::Free));
+}


### PR DESCRIPTION
## Summary
- track fallback promotion across frames and clear on resets
- handle invalid parents as free in layout
- validate add_child/add_sibling targets
- avoid unreachable promotions in render
- test insertion behavior and orphan layout

## Testing
- `cargo test --all --quiet`