### PR TITLE
Fix module labels in switcher and status

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -3,9 +3,10 @@ use ratatui::{backend::Backend, layout::Rect, style::{Color, Style, Modifier}, w
 pub fn module_icon(mode: &str) -> &'static str {
     match mode {
         "gemx" => "💭",
-        "zen" => "✍️",
+        "zen" => "🧘",
         "triage" => "🧭",
         "spotlight" => "🔍",
+        "settings" => "⚙️",
         _ => "❓",
     }
 }

--- a/src/render/module_switcher.rs
+++ b/src/render/module_switcher.rs
@@ -10,9 +10,9 @@ use ratatui::{
 pub fn render_module_switcher<B: Backend>(f: &mut Frame<B>, area: Rect, index: usize) {
     let modules = [
         ("💭", "Mindmap"),
-        ("✍️", "Zen Mode"),
+        ("🧘", "Zen"),
         ("🧭", "Triage"),
-        ("🔍", "Spotlight"),
+        ("⚙️", "Settings"),
     ];
 
     let lines: Vec<Line> = modules

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -602,8 +602,8 @@ impl AppState {
         match self.module_switcher_index % 4 {
             0 => "gemx",
             1 => "zen",
-            2 => "settings",
-            3 => "triage",
+            2 => "triage",
+            3 => "settings",
             _ => "gemx",
         }
     }

--- a/tests/module_icon.rs
+++ b/tests/module_icon.rs
@@ -1,0 +1,10 @@
+use prismx::render::module_icon::module_icon;
+
+#[test]
+fn module_icon_matches_mode() {
+    assert_eq!(module_icon("gemx"), "💭");
+    assert_eq!(module_icon("zen"), "🧘");
+    assert_eq!(module_icon("triage"), "🧭");
+    assert_eq!(module_icon("spotlight"), "🔍");
+    assert_eq!(module_icon("settings"), "⚙️");
+}

--- a/tests/module_switcher.rs
+++ b/tests/module_switcher.rs
@@ -1,0 +1,14 @@
+use prismx::state::AppState;
+
+#[test]
+fn module_switcher_displays_correct_labels() {
+    let mut state = AppState::default();
+    state.module_switcher_index = 0;
+    assert_eq!(state.get_module_by_index(), "gemx");
+    state.module_switcher_index = 1;
+    assert_eq!(state.get_module_by_index(), "zen");
+    state.module_switcher_index = 2;
+    assert_eq!(state.get_module_by_index(), "triage");
+    state.module_switcher_index = 3;
+    assert_eq!(state.get_module_by_index(), "settings");
+}


### PR DESCRIPTION
## Summary
- correct icon mapping for module icon overlay
- list Settings in module switcher
- update module lookup order
- add tests for module icon and switcher mappings

## Testing
- `cargo test --quiet`