### PR TITLE
Fix selection tracking and layout guard

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -38,6 +38,15 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         return;
     }
 
+    if let Some(sel) = state.selected {
+        if !state.nodes.contains_key(&sel) {
+            state.selected = None;
+        }
+    }
+    if state.selected.is_none() {
+        return;
+    }
+
 
     // // ✅ Always print the structure for diagnostics
     // println!("=== NODES AND CHILDREN ===");

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -240,43 +240,42 @@ impl AppState {
     }
 
     pub fn add_child(&mut self) {
-        if let Some(parent_id) = self.selected {
-            if !self.nodes.contains_key(&parent_id) {
-                return;
-            }
+        let parent_id = match self.selected {
+            Some(id) if self.nodes.contains_key(&id) => id,
+            _ => return,
+        };
 
-            let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
+        let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
-            let mut child = Node::new(new_id, "New Child", Some(parent_id));
-            if let Some(parent) = self.nodes.get(&parent_id) {
-                child.x = parent.x;
-                child.y = parent.y + 1;
-            }
-
-            self.nodes.insert(new_id, child);
-            if let Some(parent) = self.nodes.get_mut(&parent_id) {
-                parent.children.push(new_id);
-            }
-
-            if !self.root_nodes.contains(&parent_id) {
-                self.root_nodes.push(parent_id);
-            }
-
-            self.set_selected(Some(new_id));
-            if !self.auto_arrange {
-                self.ensure_grid_positions();
-            }
-            self.recalculate_roles();
-            self.ensure_valid_roots();
+        let mut child = Node::new(new_id, "New Child", Some(parent_id));
+        if let Some(parent) = self.nodes.get(&parent_id) {
+            child.x = parent.x;
+            child.y = parent.y + 1;
         }
+
+        self.nodes.insert(new_id, child);
+        if let Some(parent) = self.nodes.get_mut(&parent_id) {
+            parent.children.push(new_id);
+        }
+
+        if !self.root_nodes.contains(&parent_id) {
+            self.root_nodes.push(parent_id);
+        }
+
+        self.set_selected(Some(new_id));
+        if !self.auto_arrange {
+            self.ensure_grid_positions();
+        }
+        self.recalculate_roles();
+        self.ensure_valid_roots();
     }
 
     pub fn add_sibling(&mut self) {
-        if let Some(selected_id) = self.selected {
-            if !self.nodes.contains_key(&selected_id) {
-                return;
-            }
-            let parent_id = self.nodes.get(&selected_id).and_then(|n| n.parent);
+        let selected_id = match self.selected {
+            Some(id) if self.nodes.contains_key(&id) => id,
+            _ => return,
+        };
+        let parent_id = self.nodes.get(&selected_id).and_then(|n| n.parent);
 
             let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
             let mut sibling = Node::new(new_id, "New Sibling", parent_id);
@@ -307,7 +306,6 @@ impl AppState {
             }
             self.recalculate_roles();
         }
-    }
 
 
     pub fn delete_node(&mut self) {

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -45,3 +45,25 @@ fn missing_parent_becomes_free() {
     let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true);
     assert_eq!(roles.get(&new_id), Some(&LayoutRole::Free));
 }
+
+#[test]
+fn tab_requires_valid_selection() {
+    let mut state = AppState::default();
+    state.selected = Some(999);
+    let count = state.nodes.len();
+    state.add_child();
+    assert_eq!(state.nodes.len(), count);
+}
+
+#[test]
+fn tab_after_enter_keeps_child_reachable() {
+    let mut state = AppState::default();
+    if let Some(b) = state.nodes.get_mut(&2) { b.x = 10; }
+    state.add_sibling();
+    let sibling = state.selected.unwrap();
+    state.add_child();
+    let child = state.selected.unwrap();
+    let parent = state.nodes.get(&child).unwrap().parent;
+    assert!(parent.is_some());
+    assert!(state.nodes.get(&parent.unwrap()).unwrap().children.contains(&child));
+}


### PR DESCRIPTION
## Summary
- validate selected node before inserting siblings/children
- follow newly added nodes in selection
- early-return from `render_gemx` when no selection is valid
- test invalid selection and add-child sequence

## Testing
- `cargo test --quiet`