### PR TITLE
Fix selection tracking for node insertions

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -22,6 +22,15 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     // Reset unreachable fallback lock for this frame
     state.fallback_this_frame = false;
 
+    if let Some(sel) = state.selected {
+        if !state.nodes.contains_key(&sel) {
+            state.selected = None;
+        }
+    }
+    if state.selected.is_none() {
+        return;
+    }
+
     // Ensure we always have valid root nodes before any layout logic
     state.ensure_valid_roots();
     if state.auto_arrange {
@@ -35,15 +44,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             Paragraph::new("⚠ No valid root nodes."),
             Rect::new(area.x + 2, area.y + 2, 40, 1),
         );
-        return;
-    }
-
-    if let Some(sel) = state.selected {
-        if !state.nodes.contains_key(&sel) {
-            state.selected = None;
-        }
-    }
-    if state.selected.is_none() {
         return;
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -240,10 +240,14 @@ impl AppState {
     }
 
     pub fn add_child(&mut self) {
-        let parent_id = match self.selected {
-            Some(id) if self.nodes.contains_key(&id) => id,
-            _ => return,
+        let Some(parent_id) = self.selected else {
+            eprintln!("\u{26a0} Tab insert failed: no selected node.");
+            return;
         };
+        if !self.nodes.contains_key(&parent_id) {
+            eprintln!("\u{26a0} Tab insert failed: selected node is invalid.");
+            return;
+        }
 
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
@@ -262,7 +266,7 @@ impl AppState {
             self.root_nodes.push(parent_id);
         }
 
-        self.set_selected(Some(new_id));
+        self.selected = Some(new_id);
         if !self.auto_arrange {
             self.ensure_grid_positions();
         }
@@ -300,7 +304,7 @@ impl AppState {
             }
 
             self.nodes.insert(new_id, sibling);
-            self.set_selected(Some(new_id));
+            self.selected = Some(new_id);
             if !self.auto_arrange {
                 self.ensure_grid_positions();
             }


### PR DESCRIPTION
## Summary
- guard against invalid selection when adding a child
- keep new sibling/child selected after insertion
- validate selection early in gemx renderer to avoid fallback

## Testing
- `cargo test --quiet`