### PR TITLE
Add live spotlight command preview

### DIFF
--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -1,5 +1,13 @@
-use ratatui::{backend::Backend, layout::Rect, style::{Style, Color}, widgets::{Block, Borders, Paragraph}, Frame};
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
 use crate::state::AppState;
+use crate::spotlight::command_preview;
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;
@@ -7,7 +15,9 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let x_offset = area.x + (area.width.saturating_sub(width)) / 2;
     let y_offset = area.y + area.height / 3;
 
-    let spotlight_area = Rect::new(x_offset, y_offset, width, 3);
+    let preview = command_preview(input);
+    let height = if preview.is_some() { 4 } else { 3 };
+    let spotlight_area = Rect::new(x_offset, y_offset, width, height);
 
     let arrow = if state.spotlight_just_opened {
         match state.spotlight_animation_frame {
@@ -35,9 +45,23 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         .borders(Borders::ALL)
         .style(Style::default().fg(border_color));
 
-    let paragraph = Paragraph::new(format!("> {}", input))
-        .block(block)
-        .style(Style::default().fg(Color::White));
+    let mut lines = vec![Line::styled(format!("> {}", input), Style::default().fg(Color::White))];
+    if let Some((msg, known)) = preview {
+        if known {
+            lines.push(Line::from(vec![
+                Span::styled("→ ", Style::default().fg(Color::Cyan)),
+                Span::styled(msg, Style::default().fg(Color::White)),
+            ]));
+        } else {
+            let style = Style::default().fg(Color::Red).add_modifier(Modifier::DIM);
+            lines.push(Line::from(vec![
+                Span::styled("⚠ ", style),
+                Span::styled(msg, style),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(block);
 
     f.render_widget(paragraph, spotlight_area);
 }

--- a/src/spotlight.rs
+++ b/src/spotlight.rs
@@ -20,3 +20,41 @@ pub struct Spotlight {
     pub focus_index: usize,
     pub mode: SpotlightMode,
 }
+
+/// Return a preview message for the given command input.
+///
+/// If the input matches a known command, `Some((message, true))` is returned.
+/// Unknown commands starting with `/` return `Some((message, false))`.
+/// All other input yields `None`.
+pub fn command_preview(input: &str) -> Option<(&'static str, bool)> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('/') || trimmed.len() <= 1 {
+        return None;
+    }
+
+    let (msg, known) = match trimmed {
+        "/triage" => ("Switches to Triage panel", true),
+        "/zen" => ("Opens Zen mode", true),
+        "/gemx" => ("Opens GemX mode", true),
+        "/settings" => ("Opens Settings panel", true),
+        _ => ("Unknown command", false),
+    };
+
+    Some((msg, known))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_preview;
+
+    #[test]
+    fn known_command_has_preview() {
+        assert_eq!(command_preview("/triage"), Some(("Switches to Triage panel", true)));
+        assert_eq!(command_preview("/zen"), Some(("Opens Zen mode", true)));
+    }
+
+    #[test]
+    fn unknown_command_reports_warning() {
+        assert_eq!(command_preview("/badcmd"), Some(("Unknown command", false)));
+    }
+}


### PR DESCRIPTION
## Summary
- give spotlight a real-time command preview
- render preview text with color cues
- expose `command_preview` helper for testing

## Testing
- `cargo test`