### PR TITLE
Add Spotlight command history

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{ SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT };
 use crossterm::terminal;
@@ -19,6 +19,8 @@ pub struct AppState {
     pub prev_show_spotlight: bool,
     pub spotlight_just_opened: bool,
     pub spotlight_animation_frame: u8,
+    pub spotlight_history: VecDeque<String>,
+    pub spotlight_history_index: Option<usize>,
     pub show_triage: bool,
     pub show_keymap: bool,
     pub module_switcher_open: bool,
@@ -70,6 +72,8 @@ impl Default for AppState {
             prev_show_spotlight: false,
             spotlight_just_opened: false,
             spotlight_animation_frame: 0,
+            spotlight_history: VecDeque::new(),
+            spotlight_history_index: None,
             show_triage: false,
             show_keymap: false,
             module_switcher_open: false,
@@ -340,6 +344,13 @@ impl AppState {
 
     pub fn execute_spotlight_command(&mut self) {
         let input = self.spotlight_input.trim();
+        if !input.is_empty() {
+            self.spotlight_history.push_front(input.to_string());
+            while self.spotlight_history.len() > 10 {
+                self.spotlight_history.pop_back();
+            }
+        }
+        self.spotlight_history_index = None;
         if input == "/start pomodoro" {
             self.plugin_host.start_pomodoro();
         } else if input.starts_with("/countdown ") {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -149,9 +149,46 @@ pub fn launch_ui() -> std::io::Result<()> {
                 // 🌟 Spotlight
                 if state.show_spotlight {
                     match code {
-                        KeyCode::Esc => state.show_spotlight = false,
-                        KeyCode::Char(c) => state.spotlight_input.push(c),
-                        KeyCode::Backspace => { state.spotlight_input.pop(); }
+                        KeyCode::Esc => {
+                            state.show_spotlight = false;
+                            state.spotlight_history_index = None;
+                        }
+                        KeyCode::Char(c) => {
+                            state.spotlight_input.push(c);
+                            state.spotlight_history_index = None;
+                        }
+                        KeyCode::Backspace => {
+                            state.spotlight_input.pop();
+                            state.spotlight_history_index = None;
+                        }
+                        KeyCode::Up => {
+                            if state.spotlight_history.is_empty() {
+                                // nothing
+                            } else if let Some(i) = state.spotlight_history_index {
+                                if i + 1 < state.spotlight_history.len() {
+                                    state.spotlight_history_index = Some(i + 1);
+                                }
+                                if let Some(idx) = state.spotlight_history_index {
+                                    state.spotlight_input = state.spotlight_history[idx].clone();
+                                }
+                            } else {
+                                state.spotlight_history_index = Some(0);
+                                state.spotlight_input = state.spotlight_history[0].clone();
+                            }
+                        }
+                        KeyCode::Down => {
+                            if let Some(i) = state.spotlight_history_index {
+                                if i > 0 {
+                                    state.spotlight_history_index = Some(i - 1);
+                                    if let Some(idx) = state.spotlight_history_index {
+                                        state.spotlight_input = state.spotlight_history[idx].clone();
+                                    }
+                                } else {
+                                    state.spotlight_history_index = None;
+                                    state.spotlight_input.clear();
+                                }
+                            }
+                        }
                         KeyCode::Enter => state.execute_spotlight_command(),
                         _ => {}
                     }
@@ -165,6 +202,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     && modifiers.contains(KeyModifiers::SHIFT)
                 {
                     state.show_spotlight = !state.show_spotlight;
+                    state.spotlight_history_index = None;
                     draw(&mut terminal, &mut state, &last_key)?;
                     continue;
                 }


### PR DESCRIPTION
## Summary
- track recent Spotlight commands in a VecDeque
- capture command history on Enter
- allow arrow up/down to traverse previous commands

## Testing
- `cargo test --quiet`