### PR TITLE
Add Spotlight command autocomplete

### DIFF
--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -1,5 +1,11 @@
-use ratatui::{backend::Backend, layout::Rect, style::{Style, Color}, widgets::{Block, Borders, Paragraph}, Frame};
-use crate::state::AppState;
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Style, Modifier},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use crate::{state::AppState, spotlight};
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;
@@ -40,4 +46,14 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         .style(Style::default().fg(Color::White));
 
     f.render_widget(paragraph, spotlight_area);
+
+    let matches = spotlight::command_suggestions(input);
+    for (i, suggestion) in matches.iter().take(5).enumerate() {
+        let y = y_offset + 2 + i as u16;
+        let style = Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM);
+        f.render_widget(
+            Paragraph::new(*suggestion).style(style),
+            Rect::new(x_offset, y, width, 1),
+        );
+    }
 }

--- a/src/spotlight.rs
+++ b/src/spotlight.rs
@@ -20,3 +20,15 @@ pub struct Spotlight {
     pub focus_index: usize,
     pub mode: SpotlightMode,
 }
+
+pub const COMMANDS: [&str; 5] = ["/triage", "/zen", "/settings", "/goto", "/plugin"];
+
+/// Return command suggestions that start with the given input prefix.
+pub fn command_suggestions(input: &str) -> Vec<&'static str> {
+    COMMANDS
+        .iter()
+        .filter(|c| c.starts_with(input))
+        .copied()
+        .take(5)
+        .collect()
+}

--- a/tests/autocomplete.rs
+++ b/tests/autocomplete.rs
@@ -1,0 +1,21 @@
+use prismx::spotlight::command_suggestions;
+
+#[test]
+fn autocomplete_matches_partial_command() {
+    let results = command_suggestions("/t");
+    assert!(results.contains(&"/triage"));
+}
+
+#[test]
+fn autocomplete_updates_dynamically() {
+    let initial = command_suggestions("/");
+    assert!(initial.contains(&"/triage"));
+    let updated = command_suggestions("/s");
+    assert_eq!(updated, vec!["/settings"]);
+}
+
+#[test]
+fn autocomplete_no_matches_returns_empty() {
+    let results = command_suggestions("/unknown");
+    assert!(results.is_empty());
+}


### PR DESCRIPTION
## Summary
- add a list of spotlight commands and new `command_suggestions` helper
- display suggestions in `render_spotlight`
- add basic tests for autocomplete logic

## Testing
- `cargo test`