### PR TITLE
Implement Spotlight command execution

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -375,6 +375,10 @@ impl AppState {
             }
         } else {
             match input {
+                "/triage" => self.mode = "triage".into(),
+                "/zen" => self.mode = "zen".into(),
+                "/settings" => self.mode = "settings".into(),
+                "/gemx" => self.mode = "gemx".into(),
                 "/toggle triage" => self.show_triage = !self.show_triage,
                 "/toggle keymap" => self.show_keymap = !self.show_keymap,
                 "/toggle spotlight" => self.show_spotlight = !self.show_spotlight,
@@ -389,6 +393,7 @@ impl AppState {
         }
         self.spotlight_input.clear();
         self.show_spotlight = false;
+        self.spotlight_just_opened = false;
     }
 
     pub fn add_free_node(&mut self) {

--- a/tests/spotlight_exec.rs
+++ b/tests/spotlight_exec.rs
@@ -1,0 +1,34 @@
+use prismx::state::AppState;
+
+#[test]
+fn spotlight_exec_triage_switches_mode() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/triage".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.mode, "triage");
+}
+
+#[test]
+fn spotlight_exec_settings_switches_mode() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/settings".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.mode, "settings");
+}
+
+#[test]
+fn spotlight_exec_closes_panel() {
+    let mut state = AppState::default();
+    state.show_spotlight = true;
+    state.spotlight_input = "/zen".into();
+    state.execute_spotlight_command();
+    assert!(!state.show_spotlight);
+}
+
+#[test]
+fn spotlight_input_clears_after_execution() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/gemx".into();
+    state.execute_spotlight_command();
+    assert!(state.spotlight_input.is_empty());
+}


### PR DESCRIPTION
## Summary
- add command handling for `/triage`, `/zen`, `/settings`, and `/gemx`
- close spotlight and clear input after command execution
- add tests covering spotlight command execution

## Testing
- `cargo test --quiet`
- `cargo test spotlight_input_clears_after_execution -- --nocapture`