### PR TITLE
Fix Enter+Tab fallback and selection updates

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -98,17 +98,8 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     }
 
     if drawn_at.is_empty() {
-        f.render_widget(
-            Paragraph::new("⚠ layout_nodes() returned no visible nodes."),
-            Rect::new(area.x + 2, area.y + 2, 40, 1),
-        );
-        if !state.layout_warning_logged {
-            eprintln!("⚠ layout_nodes() failed to render any nodes.");
-            state.layout_warning_logged = true;
-        }
+        f.render_widget(Paragraph::new("⚠ No valid root nodes."), area);
         return;
-    } else {
-        state.layout_warning_logged = false;
     }
 
     use std::collections::HashSet;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -246,16 +246,10 @@ impl AppState {
     }
 
     pub fn add_child(&mut self) {
-        let parent_id = if let Some(id) = self.selected {
-            if !self.nodes.contains_key(&id) {
-                eprintln!("\u{26a0} Tab failed: invalid selection.");
-                return;
-            }
-            id
-        } else {
-            eprintln!("\u{26a0} Tab failed: no selected node.");
+        let Some(parent_id) = self.selected else { return };
+        if !self.nodes.contains_key(&parent_id) {
             return;
-        };
+        }
 
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
@@ -319,6 +313,7 @@ impl AppState {
             self.ensure_grid_positions();
         }
         self.recalculate_roles();
+        self.ensure_valid_roots();
     }
 
 


### PR DESCRIPTION
## Summary
- update child/sibling insertion logic to ensure valid selection and roots
- show warning when layout has no roots instead of retrying fallback

## Testing
- `cargo test --quiet`