### PR TITLE
Fix root node visibility and sibling insert stability

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -176,11 +176,9 @@ fn layout_recursive_safe(
     };
 
     let role = if depth == 0 {
-        if auto_arrange {
-            LayoutRole::Root
-        } else {
-            LayoutRole::Free
-        }
+        // Always treat the initial node as a root regardless of mode so that
+        // fallback-promoted nodes remain visible.
+        LayoutRole::Root
     } else {
         match node.parent {
             Some(pid) => {

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -97,6 +97,21 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
     }
 
+    // Ensure that every declared root node is represented in the drawn layout.
+    for &root_id in &state.root_nodes {
+        if !drawn_at.contains_key(&root_id) {
+            if state.auto_arrange {
+                let (layout, roles) =
+                    layout_nodes(&state.nodes, root_id, GEMX_HEADER_HEIGHT, area.width as i16, state.auto_arrange);
+                drawn_at.extend(layout);
+                node_roles.extend(roles);
+            } else if let Some(n) = state.nodes.get(&root_id) {
+                drawn_at.insert(root_id, Coords { x: n.x, y: n.y });
+                node_roles.insert(root_id, LayoutRole::Root);
+            }
+        }
+    }
+
     if drawn_at.is_empty() {
         f.render_widget(Paragraph::new("⚠ No valid root nodes."), area);
         return;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -288,23 +288,27 @@ impl AppState {
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
         let mut sibling = Node::new(new_id, "New Sibling", parent_id);
 
-        if !self.auto_arrange {
-            if let Some(selected) = self.nodes.get(&selected_id) {
-                sibling.x = selected.x + SIBLING_SPACING_X;
-                sibling.y = selected.y;
+        if parent_id.is_none() {
+            // Creating a sibling of a root results in another root. Provide a
+            // reasonable default position when manual layout is active so the
+            // node is immediately visible.
+            if !self.auto_arrange {
+                sibling.x = (self.nodes.len() as i16 % 5) * SIBLING_SPACING_X;
+                sibling.y = GEMX_HEADER_HEIGHT + 2;
             }
-        }
-
-        if let Some(pid) = parent_id {
-            if let Some(parent) = self.nodes.get_mut(&pid) {
-                parent.children.push(new_id);
-            }
-        }
-
-        if parent_id.is_none() && !self.root_nodes.contains(&new_id) {
             self.root_nodes.push(new_id);
             self.root_nodes.sort_unstable();
             self.root_nodes.dedup();
+        } else {
+            if !self.auto_arrange {
+                if let Some(selected) = self.nodes.get(&selected_id) {
+                    sibling.x = selected.x + SIBLING_SPACING_X;
+                    sibling.y = selected.y;
+                }
+            }
+            if let Some(parent) = self.nodes.get_mut(&parent_id.unwrap()) {
+                parent.children.push(new_id);
+            }
         }
 
         self.nodes.insert(new_id, sibling);


### PR DESCRIPTION
## Summary
- draw fallback-promoted root nodes immediately
- treat the top layout node as a root in any mode
- handle root sibling insertion correctly

## Testing
- `cargo test --quiet`