### PR TITLE
Implement configurable favorites dock

### DIFF
--- a/src/render/favorites.rs
+++ b/src/render/favorites.rs
@@ -1,35 +1,64 @@
-use ratatui::{backend::Backend, layout::Rect, style::{Style, Color}, widgets::Paragraph, Frame};
-use crate::state::{AppState, FavoriteEntry};
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::Style,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use crate::state::{AppState, FavoriteEntry, DockLayout};
+use crate::beamx::style_for_mode;
 
 pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
-    let mut entries = vec![
+    let mut all = vec![
         FavoriteEntry { label: "⚙️", mode: "settings", bounds: Rect::default() },
         FavoriteEntry { label: "📬", mode: "triage", bounds: Rect::default() },
         FavoriteEntry { label: "💭", mode: "gemx", bounds: Rect::default() },
+        FavoriteEntry { label: "🧘", mode: "zen", bounds: Rect::default() },
+        FavoriteEntry { label: "🔍", mode: "spotlight", bounds: Rect::default() },
     ];
 
-    if state.mode == "gemx" {
-        entries[2].label = "💬";
+    if state.mode == "gemx" && all.len() >= 3 {
+        all[2].label = "💬";
     }
     if state.mode == "triage" || state.show_triage {
-        entries[1].label = "📫";
+        if all.len() >= 2 {
+            all[1].label = "📫";
+        }
     }
+
+    let limit = state.favorite_dock_limit.min(all.len());
+    let favorites = &mut all[..limit];
+
+    let theme = style_for_mode(&state.mode);
+    let style = Style::default().fg(theme.border_color);
+
+    let horizontal = state.favorite_dock_layout == DockLayout::Horizontal;
+    let height = if horizontal { 3 } else { favorites.len() as u16 + 2 };
+    let width = if horizontal {
+        favorites.len() as u16 * 3 + 2
+    } else {
+        6
+    };
 
     let x = area.x + 1;
-    let base_y = area.height.saturating_sub(6);
-    let style = Style::default().fg(Color::Cyan);
+    let y = area.height.saturating_sub(height + 3);
 
-    f.render_widget(Paragraph::new("|__").style(style), Rect::new(x, base_y, 12, 1));
-    for (i, entry) in entries.iter_mut().enumerate() {
-        let y = base_y + 1 + i as u16;
-        let line = match i {
-            0 => format!(" {}\\", entry.label),
-            1 => format!(" {} \\", entry.label),
-            _ => format!(" {}   \\____", entry.label),
-        };
-        f.render_widget(Paragraph::new(line).style(style), Rect::new(x, y, 12, 1));
-        entry.bounds = Rect::new(x, y, 4, 1);
+    let border = Block::default().borders(Borders::ALL).style(style);
+    f.render_widget(border, Rect::new(x - 1, y - 1, width, height));
+
+    if horizontal {
+        let line: String = favorites.iter().map(|e| e.label).collect::<Vec<_>>().join("  ");
+        f.render_widget(Paragraph::new(line).style(style), Rect::new(x, y, width - 2, 1));
+        for (i, entry) in favorites.iter_mut().enumerate() {
+            entry.bounds = Rect::new(x + (i as u16 * 3), y, 2, 1);
+        }
+    } else {
+        for (i, entry) in favorites.iter_mut().enumerate() {
+            let gy = y + i as u16;
+            f.render_widget(Paragraph::new(entry.label).style(style), Rect::new(x, gy, 4, 1));
+            entry.bounds = Rect::new(x, gy, 2, 1);
+        }
     }
 
-    state.favorite_entries = entries;
+    state.favorite_entries = favorites.to_vec();
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -16,6 +16,12 @@ pub struct FavoriteEntry {
     pub bounds: Rect,
 }
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum DockLayout {
+    Vertical,
+    Horizontal,
+}
+
 pub struct AppState {
     pub mode: String,
     pub zen_buffer: Vec<String>,
@@ -60,6 +66,8 @@ pub struct AppState {
     pub plugin_host: PluginHost,
     pub favorite_entries: Vec<FavoriteEntry>,
     pub plugin_favorites: Vec<FavoriteEntry>,
+    pub favorite_dock_limit: usize,
+    pub favorite_dock_layout: DockLayout,
     pub last_mouse_click: Option<(u16, u16)>,
 
 }
@@ -117,6 +125,8 @@ impl Default for AppState {
             plugin_host: PluginHost::new(),
             favorite_entries: Vec::new(),
             plugin_favorites: Vec::new(),
+            favorite_dock_limit: 3,
+            favorite_dock_layout: DockLayout::Vertical,
             last_mouse_click: None,
 
         }
@@ -386,6 +396,18 @@ impl AppState {
                 if let Ok(days) = num.parse::<u64>() {
                     self.plugin_host.add_countdown(label, days);
                 }
+            }
+        } else if input.starts_with("/dock_layout=") {
+            let layout = &input["/dock_layout=".len()..];
+            if layout.eq_ignore_ascii_case("horizontal") {
+                self.favorite_dock_layout = DockLayout::Horizontal;
+            } else if layout.eq_ignore_ascii_case("vertical") {
+                self.favorite_dock_layout = DockLayout::Vertical;
+            }
+        } else if input.starts_with("/dock_limit=") {
+            let value = &input["/dock_limit=".len()..];
+            if let Ok(num) = value.parse::<usize>() {
+                self.favorite_dock_limit = num.min(5);
             }
         } else {
             match input {

--- a/tests/favorites_config.rs
+++ b/tests/favorites_config.rs
@@ -1,0 +1,17 @@
+use prismx::state::{AppState, DockLayout};
+
+#[test]
+fn spotlight_dock_limit_command() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/dock_limit=5".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.favorite_dock_limit, 5);
+}
+
+#[test]
+fn spotlight_dock_layout_command() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/dock_layout=horizontal".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.favorite_dock_layout, DockLayout::Horizontal);
+}


### PR DESCRIPTION
## Summary
- support dock layout and limit configuration
- render dock horizontally or vertically with themed border
- expose `/dock_layout=` and `/dock_limit=` commands
- add tests for spotlight commands

## Testing
- `cargo test --quiet`