### PR TITLE
Improve node insertion diagnostics

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -35,6 +35,17 @@ pub fn spawn_free_node(state: &mut AppState) {
         node.y = ((index / cols) as i16) * row_pad + GEMX_HEADER_HEIGHT + 1;
     }
 
+    if state.debug_input_mode {
+        eprintln!(
+            "[Node {}] label=\"{}\", parent={:?}, x={}, y={}",
+            new_id,
+            node.label,
+            node.parent,
+            node.x,
+            node.y
+        );
+    }
+
     state.nodes.insert(new_id, node);
     state.root_nodes.push(new_id);
     state.set_selected(Some(new_id));

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -111,6 +111,22 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         }
     }
 
+    if state.debug_input_mode {
+        eprintln!("Render Tree:");
+        for (&id, coords) in &drawn_at {
+            let role = node_roles.get(&id).unwrap_or(&LayoutRole::Free);
+            let label = &state.nodes[&id].label;
+            eprintln!(
+                "Node {} \u{2192} (x: {}, y: {}) | {:?} | {}",
+                id,
+                coords.x,
+                coords.y,
+                role,
+                label
+            );
+        }
+    }
+
     if drawn_at.is_empty() {
         let msg = if state.auto_arrange {
             "⚠ Node exists but layout failed."
@@ -293,6 +309,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
         let para = Paragraph::new(label).style(style);
         f.render_widget(para, Rect::new(draw_x, draw_y, width as u16, 1));
+        if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
+            f.render_widget(Paragraph::new("■").style(style), Rect::new(draw_x, draw_y, 1, 1));
+        }
     }
 
     // Draw arrows

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -287,6 +287,16 @@ impl AppState {
             child.x = parent.x;
             child.y = parent.y + 1;
         }
+        if self.debug_input_mode {
+            eprintln!(
+                "[Node {}] label=\"{}\", parent={:?}, x={}, y={}",
+                new_id,
+                child.label,
+                child.parent,
+                child.x,
+                child.y
+            );
+        }
 
         self.nodes.insert(new_id, child);
         if let Some(parent) = self.nodes.get_mut(&parent_id) {
@@ -338,6 +348,17 @@ impl AppState {
             if let Some(parent) = self.nodes.get_mut(&parent_id.unwrap()) {
                 parent.children.push(new_id);
             }
+        }
+
+        if self.debug_input_mode {
+            eprintln!(
+                "[Node {}] label=\"{}\", parent={:?}, x={}, y={}",
+                new_id,
+                sibling.label,
+                sibling.parent,
+                sibling.x,
+                sibling.y
+            );
         }
 
         self.nodes.insert(new_id, sibling);
@@ -443,7 +464,11 @@ impl AppState {
 
     pub fn add_free_node(&mut self) {
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
-        let node = Node::new(new_id, "Free Node", None);
+        let mut node = Node::new(new_id, "Free Node", None);
+        if !self.auto_arrange {
+            node.x = (self.nodes.len() as i16 % 5) * SIBLING_SPACING_X;
+            node.y = GEMX_HEADER_HEIGHT + 2;
+        }
         self.nodes.insert(new_id, node);
         self.root_nodes.push(new_id);
         self.set_selected(Some(new_id));


### PR DESCRIPTION
## Summary
- add debug logging for node insertion
- space new root nodes in manual layout
- snapshot node positions while rendering
- render a glyph overlay in debug mode

## Testing
- `cargo test --quiet`