### PR TITLE
Fix sibling overlap and debug output

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -311,6 +311,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         f.render_widget(para, Rect::new(draw_x, draw_y, width as u16, 1));
         if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
             f.render_widget(Paragraph::new("■").style(style), Rect::new(draw_x, draw_y, 1, 1));
+            if x == 0 {
+                f.render_widget(Paragraph::new("■"), Rect::new(1, draw_y, 1, 1));
+            }
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -327,37 +327,35 @@ impl AppState {
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
         let mut sibling = Node::new(new_id, "New Sibling", parent_id);
 
-        if parent_id.is_none() {
-            // Creating a sibling of a root results in another root. Provide a
-            // reasonable default position when manual layout is active so the
-            // node is immediately visible.
-            if !self.auto_arrange {
+        if !self.auto_arrange {
+            if let Some(selected) = self.nodes.get(&selected_id) {
+                sibling.x = selected.x + SIBLING_SPACING_X;
+                sibling.y = selected.y;
+            } else {
                 sibling.x = (self.nodes.len() as i16 % 5) * SIBLING_SPACING_X;
                 sibling.y = GEMX_HEADER_HEIGHT + 2;
             }
+
+            if sibling.x == 0 {
+                sibling.x = ((self.nodes.len() as i16) % 5 + 1) * SIBLING_SPACING_X;
+            }
+        }
+
+        if parent_id.is_none() {
             self.root_nodes.push(new_id);
             self.root_nodes.sort_unstable();
             self.root_nodes.dedup();
-        } else {
-            if !self.auto_arrange {
-                if let Some(selected) = self.nodes.get(&selected_id) {
-                    sibling.x = selected.x + SIBLING_SPACING_X;
-                    sibling.y = selected.y;
-                }
-            }
-            if let Some(parent) = self.nodes.get_mut(&parent_id.unwrap()) {
-                parent.children.push(new_id);
-            }
+        } else if let Some(parent) = self.nodes.get_mut(&parent_id.unwrap()) {
+            parent.children.push(new_id);
         }
 
         if self.debug_input_mode {
             eprintln!(
-                "[Node {}] label=\"{}\", parent={:?}, x={}, y={}",
+                "[add_sibling] Inserted Node {} → x={}, y={}, parent={:?}",
                 new_id,
-                sibling.label,
-                sibling.parent,
                 sibling.x,
-                sibling.y
+                sibling.y,
+                parent_id
             );
         }
 


### PR DESCRIPTION
## Summary
- offset siblings relative to selection when manual layout is enabled
- clamp placement if a sibling would spawn at `x == 0`
- log insertion coordinates for debugging
- show a ghost box for collisions in debug mode

## Testing
- `cargo test`