### PR TITLE
Add interactive settings panel with keyboard toggles

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -71,6 +71,7 @@ pub struct AppState {
     pub favorite_dock_layout: DockLayout,
     pub favorite_dock_enabled: bool,
     pub last_mouse_click: Option<(u16, u16)>,
+    pub settings_focus_index: usize,
 
 }
 
@@ -132,6 +133,7 @@ impl Default for AppState {
             favorite_dock_layout: DockLayout::Vertical,
             favorite_dock_enabled: true,
             last_mouse_click: None,
+            settings_focus_index: 0,
 
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -323,6 +323,21 @@ pub fn launch_ui() -> std::io::Result<()> {
                         state.toggle_snap_grid();
                     }
 
+                    KeyCode::Up if state.mode == "settings" => {
+                        if state.settings_focus_index > 0 {
+                            state.settings_focus_index -= 1;
+                        } else {
+                            state.settings_focus_index = crate::settings::SETTING_TOGGLES.len() - 1;
+                        }
+                    }
+                    KeyCode::Down if state.mode == "settings" => {
+                        state.settings_focus_index = (state.settings_focus_index + 1) % crate::settings::SETTING_TOGGLES.len();
+                    }
+                    KeyCode::Enter | KeyCode::Char(' ') if state.mode == "settings" => {
+                        let idx = state.settings_focus_index % crate::settings::SETTING_TOGGLES.len();
+                        (crate::settings::SETTING_TOGGLES[idx].toggle)(&mut state);
+                    }
+
                     KeyCode::Up if state.mode == "gemx" => state.move_focus_up(),
                     KeyCode::Down if state.mode == "gemx" => state.move_focus_down(),
                     KeyCode::Left if state.mode == "gemx" => state.move_focus_left(),


### PR DESCRIPTION
## Summary
- implement `SettingToggle` and built-in toggles
- expose settings focus index in `AppState`
- render new settings panel with checkbox UI
- allow arrow navigation and space/enter toggling in settings mode

## Testing
- `cargo test --quiet`