### PR TITLE
Enable plugin favorites in dock

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -7,13 +7,12 @@ use crate::plugin::PluginHost;
 mod hotkeys;
 pub use hotkeys::*;
 
-use ratatui::layout::Rect;
+
 
 #[derive(Clone, Default)]
 pub struct FavoriteEntry {
-    pub label: &'static str,
-    pub mode: &'static str,
-    pub bounds: Rect,
+    pub icon: &'static str,
+    pub command: &'static str,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -65,7 +64,6 @@ pub struct AppState {
     pub status_message: String,
     pub status_message_last_updated: Option<std::time::Instant>,
     pub plugin_host: PluginHost,
-    pub favorite_entries: Vec<FavoriteEntry>,
     pub plugin_favorites: Vec<FavoriteEntry>,
     pub favorite_dock_limit: usize,
     pub favorite_dock_layout: DockLayout,
@@ -126,7 +124,6 @@ impl Default for AppState {
             status_message: String::new(),
             status_message_last_updated: None,
             plugin_host: PluginHost::new(),
-            favorite_entries: Vec::new(),
             plugin_favorites: Vec::new(),
             favorite_dock_limit: 3,
             favorite_dock_layout: DockLayout::Vertical,
@@ -698,7 +695,7 @@ impl AppState {
         }
     }
 
-    pub fn get_module_by_index(&self) -> &str {
+pub fn get_module_by_index(&self) -> &str {
         match self.module_switcher_index % 4 {
             0 => "gemx",
             1 => "zen",
@@ -706,5 +703,11 @@ impl AppState {
             3 => "settings",
             _ => "gemx",
         }
+    }
+}
+
+pub fn register_plugin_favorite(state: &mut AppState, icon: &'static str, command: &'static str) {
+    if state.plugin_favorites.len() < 5 {
+        state.plugin_favorites.push(FavoriteEntry { icon, command });
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -377,17 +377,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     match me.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
                             state.last_mouse_click = Some((me.column, me.row));
-                            let mut handled = false;
-                            for entry in &state.favorite_entries {
-                                if me.column >= entry.bounds.x && me.column < entry.bounds.x + entry.bounds.width &&
-                                   me.row >= entry.bounds.y && me.row < entry.bounds.y + entry.bounds.height {
-                                    state.mode = entry.mode.to_string();
-                                    state.show_spotlight = false;
-                                    handled = true;
-                                    break;
-                                }
-                            }
-                            if !handled && state.mode == "gemx" {
+                            if state.mode == "gemx" {
                                 if let Some(id) = crate::gemx::interaction::node_at_position(&state, me.column, me.row) {
                                     crate::gemx::interaction::start_drag(&mut state, id, me.column, me.row);
                                 }


### PR DESCRIPTION
## Summary
- support plugin-provided dock icons
- add registration helper
- display plugin favorites alongside defaults
- simplify mouse handling logic

## Testing
- `cargo test --quiet`