### PR TITLE
Remove debug traces and strip fallback labels

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -83,7 +83,7 @@ impl Default for AppState {
         nodes.insert(node_a, Node::new(node_a, "Node A", None));
         nodes.insert(node_b, Node::new(node_b, "Node B", None));
 
-        Self {
+        let mut state = Self {
             mode: "gemx".into(),
             zen_buffer: vec![String::from(" ")],
             nodes,
@@ -133,7 +133,15 @@ impl Default for AppState {
             favorite_dock_enabled: true,
             last_mouse_click: None,
 
+        };
+
+        for node in state.nodes.values_mut() {
+            if node.label.starts_with("[F]") {
+                node.label = node.label.replacen("[F] ", "", 1);
+            }
         }
+
+        state
     }
 }
 
@@ -287,17 +295,6 @@ impl AppState {
             child.x = parent.x;
             child.y = parent.y + 1;
         }
-        if self.debug_input_mode {
-            eprintln!(
-                "[INSERT] Node {} \u{2192} label=\"{}\", parent={:?}, x={}, y={}, mode={:?}",
-                new_id,
-                child.label,
-                child.parent,
-                child.x,
-                child.y,
-                self.mode
-            );
-        }
 
         self.nodes.insert(new_id, child);
         if let Some(parent) = self.nodes.get_mut(&parent_id) {
@@ -350,17 +347,6 @@ impl AppState {
             parent.children.push(new_id);
         }
 
-        if self.debug_input_mode {
-            eprintln!(
-                "[INSERT] Node {} → label=\"{}\", parent={:?}, x={}, y={}, mode={:?}",
-                new_id,
-                sibling.label,
-                parent_id,
-                sibling.x,
-                sibling.y,
-                self.mode
-            );
-        }
 
         self.nodes.insert(new_id, sibling);
         self.selected = Some(new_id);


### PR DESCRIPTION
## Summary
- eliminate `[INSERT]` logging from `AppState` add ops
- remove `[RENDER TREE]` dump and replace with concise frame stats
- stop attaching `[F]` markers when promoting nodes
- clean up any existing fallback markers when building default `AppState`

## Testing
- `cargo test --quiet`