### PR TITLE
Add simulated input queue

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 use std::io::stdout;
 
-use crate::state::AppState;
+use crate::state::{AppState, SimInput};
 use crate::render::{
     render_status_bar,
     render_zen_journal,
@@ -126,6 +126,25 @@ pub fn launch_ui() -> std::io::Result<()> {
         if state.selected.is_none() && !state.nodes.is_empty() {
             let first = state.nodes.keys().copied().next().unwrap();
             state.set_selected(Some(first));
+        }
+
+        if let Some(sim_input) = state.simulate_input_queue.pop_front() {
+            match sim_input {
+                SimInput::Enter => state.add_sibling(),
+                SimInput::Tab => state.add_child(),
+                SimInput::Delete => state.delete_node(),
+                SimInput::Drill => state.drill_selected(),
+                SimInput::Pop => state.pop_stack(),
+                SimInput::Undo => state.undo(),
+                SimInput::Redo => state.redo(),
+            }
+
+            if state.debug_input_mode {
+                eprintln!("\u{1F9EA} Simulated input: {:?}", sim_input);
+                if state.simulate_input_queue.is_empty() {
+                    eprintln!("\u{1F9EA} Simulation complete.");
+                }
+            }
         }
 
         if event::poll(std::time::Duration::from_millis(100))? {

--- a/tests/simulate.rs
+++ b/tests/simulate.rs
@@ -1,0 +1,32 @@
+use prismx::state::{AppState, SimInput};
+
+#[test]
+fn simulate_command_parses_sequence() {
+    let mut state = AppState::default();
+    state.spotlight_input = "/simulate enter tab delete".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.simulate_input_queue.len(), 3);
+    assert!(matches!(state.simulate_input_queue[0], SimInput::Enter));
+    assert!(matches!(state.simulate_input_queue[1], SimInput::Tab));
+    assert!(matches!(state.simulate_input_queue[2], SimInput::Delete));
+}
+
+#[test]
+fn simulated_sequence_performs_actions() {
+    let mut state = AppState::default();
+    let initial = state.nodes.len();
+    state.spotlight_input = "/simulate enter tab enter".into();
+    state.execute_spotlight_command();
+    while let Some(sim) = state.simulate_input_queue.pop_front() {
+        match sim {
+            SimInput::Enter => state.add_sibling(),
+            SimInput::Tab => state.add_child(),
+            SimInput::Delete => state.delete_node(),
+            SimInput::Drill => state.drill_selected(),
+            SimInput::Pop => state.pop_stack(),
+            SimInput::Undo => state.undo(),
+            SimInput::Redo => state.redo(),
+        }
+    }
+    assert_eq!(state.nodes.len(), initial + 3);
+}


### PR DESCRIPTION
## Summary
- support queued simulated inputs via `/simulate` command
- parse `/simulate` tokens
- run queued inputs each frame
- expose helper methods for drilling and popping
- test new simulation feature

## Testing
- `cargo test --quiet`