### PR TITLE
Implement fallback node grid placement

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -154,8 +154,19 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             };
 
             if n.x == 0 && n.y == 0 {
-                n.x = 6 + ((id as i16) % 10) * SIBLING_SPACING_X;
-                n.y = GEMX_HEADER_HEIGHT + 3;
+                n.x = state.fallback_next_x;
+                n.y = state.fallback_next_y;
+                state.fallback_next_y += 3;
+                if state.fallback_next_y > area.height as i16 - 4 {
+                    state.fallback_next_y = GEMX_HEADER_HEIGHT + 2;
+                    state.fallback_next_x += 20;
+                }
+                if state.debug_input_mode {
+                    eprintln!(
+                        "\u{1F4D0} Placed Node {} at x={}, y={}",
+                        id, n.x, n.y
+                    );
+                }
             }
 
             drawn_at.insert(id, Coords { x: n.x, y: n.y });

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -57,6 +57,8 @@ pub struct AppState {
     pub last_mouse: Option<(i16, i16)>,
     pub fallback_this_frame: bool,
     pub fallback_promoted_this_session: HashSet<NodeID>,
+    pub fallback_next_x: i16,
+    pub fallback_next_y: i16,
     pub layout_roles: HashMap<NodeID, LayoutRole>,
     pub layout_warning_logged: bool,
     pub debug_input_mode: bool,
@@ -118,6 +120,8 @@ impl Default for AppState {
             last_mouse: None,
             fallback_this_frame: false,
             fallback_promoted_this_session: HashSet::new(),
+            fallback_next_x: 6,
+            fallback_next_y: GEMX_HEADER_HEIGHT + 2,
             layout_roles: HashMap::new(),
             layout_warning_logged: false,
             debug_input_mode: true,
@@ -543,6 +547,8 @@ impl AppState {
 
     pub fn clear_fallback_promotions(&mut self) {
         self.fallback_promoted_this_session.clear();
+        self.fallback_next_x = 6;
+        self.fallback_next_y = GEMX_HEADER_HEIGHT + 2;
     }
 
     pub fn start_drag(&mut self) {


### PR DESCRIPTION
## Summary
- track next fallback grid coordinates in `AppState`
- reset fallback grid when clearing fallback promotions
- assign fallback-promoted nodes a spot on the grid
- trace placement when debug mode is on

## Testing
- `cargo test`