### PR TITLE
Fix drill/pop stack safety

### DIFF
--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -345,6 +345,24 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         }
     }
 
+    if let Some(id) = state.drawing_root {
+        if let Some(coords) = drawn_at.get(&id) {
+            let zoom = state.zoom_scale as f32;
+            let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
+            let hx = ((coords.x as f32 - state.scroll_x as f32) * bsx as f32 * zoom)
+                .round()
+                .max(0.0) as u16;
+            let hy = ((coords.y as f32 - state.scroll_y as f32) * bsy as f32 * zoom)
+                .round()
+                .max(0.0) as u16;
+            if hx < area.width && hy < area.height {
+                let mark = Paragraph::new("◆").style(Style::default().fg(Color::Magenta));
+                let rect = Rect::new(hx, hy, 1u16.min(area.width), 1u16.min(area.height));
+                f.render_widget(mark, rect);
+            }
+        }
+    }
+
     // Draw arrows
     for (source, targets) in &state.link_map {
         for target in targets {

--- a/tests/drill_pop.rs
+++ b/tests/drill_pop.rs
@@ -1,0 +1,62 @@
+use prismx::state::AppState;
+
+#[test]
+fn drill_to_valid_node_focuses_correct_root() {
+    let mut state = AppState::default();
+    let root = state.selected.unwrap();
+    state.add_child();
+    let child = state.selected.unwrap();
+    state.set_selected(Some(root));
+    state.drill_selected();
+    assert_eq!(state.drawing_root, Some(root));
+    state.set_selected(Some(child));
+    state.drill_selected();
+    assert_eq!(state.drawing_root, Some(child));
+    assert_eq!(state.view_stack.len(), 2);
+}
+
+#[test]
+fn pop_returns_to_previous_root() {
+    let mut state = AppState::default();
+    let root = state.selected.unwrap();
+    state.add_child();
+    let child = state.selected.unwrap();
+    state.set_selected(Some(root));
+    state.drill_selected();
+    state.set_selected(Some(child));
+    state.drill_selected();
+    state.pop_stack();
+    assert_eq!(state.drawing_root, Some(root));
+    state.pop_stack();
+    assert_eq!(state.drawing_root, None);
+}
+
+#[test]
+fn drill_fails_gracefully_on_deleted_node() {
+    let mut state = AppState::default();
+    state.add_child();
+    let child = state.selected.unwrap();
+    state.delete_node();
+    state.selected = Some(child);
+    state.drill_selected();
+    assert_eq!(state.drawing_root, None);
+}
+
+#[test]
+fn scroll_and_zoom_reset_on_pop() {
+    let mut state = AppState::default();
+    state.scroll_x = 5;
+    state.scroll_y = 5;
+    state.zoom_scale = 1.2;
+    state.drill_selected();
+    assert_eq!(state.scroll_x, 0);
+    assert_eq!(state.scroll_y, 0);
+    assert_eq!(state.zoom_scale, 1.0);
+    state.scroll_x = 3;
+    state.scroll_y = 4;
+    state.zoom_scale = 1.3;
+    state.pop_stack();
+    assert_eq!(state.scroll_x, 0);
+    assert_eq!(state.scroll_y, 0);
+    assert_eq!(state.zoom_scale, 1.0);
+}


### PR DESCRIPTION
## Summary
- add view stack for drill/pop
- reset zoom and scroll when navigating stack
- draw a marker for the drilled root
- test drill and pop behaviour

## Testing
- `cargo test --quiet`