### PR TITLE
Prevent layout recursion overflow with guardrails

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -66,7 +66,14 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
             let w = subtree_span(&state.nodes, root_id);
             let h = subtree_depth(&state.nodes, root_id) * CHILD_SPACING_Y + 1;
             let (ox, oy) = pack.insert((w, h));
-            let (mut l, _roles) = layout_nodes(&state.nodes, root_id, oy, tw as i16, state.auto_arrange);
+            let (mut l, _roles) = layout_nodes(
+                &state.nodes,
+                root_id,
+                oy,
+                tw as i16,
+                state.auto_arrange,
+                state.debug_input_mode,
+            );
             for pos in l.values_mut() {
                 pos.x += ox;
             }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -124,6 +124,7 @@ pub fn layout_nodes(
     start_y: i16,
     term_width: i16,
     auto_arrange: bool,
+    debug_input_mode: bool,
 ) -> (HashMap<NodeID, Coords>, HashMap<NodeID, LayoutRole>) {
     let start_y = start_y.max(GEMX_HEADER_HEIGHT);
     let start_x = if auto_arrange { 0 } else { term_width / 2 };
@@ -141,6 +142,7 @@ pub fn layout_nodes(
         auto_arrange,
         &mut visited,
         0,
+        debug_input_mode,
     );
 
     if let Some(min_x) = coords.values().map(|c| c.x).min() {
@@ -165,8 +167,15 @@ fn layout_recursive_safe(
     auto_arrange: bool,
     visited: &mut HashSet<NodeID>,
     depth: usize,
+    debug_input_mode: bool,
 ) -> (i16, i16, i16) {
     if !visited.insert(node_id) || depth > MAX_LAYOUT_DEPTH {
+        if debug_input_mode {
+            eprintln!(
+                "⚠️ Recursion halted: Node {} already visited or max depth exceeded.",
+                node_id
+            );
+        }
         return (y, x, x);
     }
 
@@ -220,6 +229,7 @@ fn layout_recursive_safe(
             auto_arrange,
             visited,
             depth + 1,
+            debug_input_mode,
         );
         max_y = max_y.max(cy);
         min_x_span = min_x_span.min(mi);

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -69,8 +69,14 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             let h = subtree_depth(&state.nodes, root_id) * CHILD_SPACING_Y + 1;
             let (ox, oy) = pack.insert((w, h));
 
-            let (mut layout, roles) =
-                layout_nodes(&state.nodes, root_id, oy, area.width as i16, state.auto_arrange);
+            let (mut layout, roles) = layout_nodes(
+                &state.nodes,
+                root_id,
+                oy,
+                area.width as i16,
+                state.auto_arrange,
+                state.debug_input_mode,
+            );
             for pos in layout.values_mut() {
                 pos.x += ox;
             }
@@ -90,8 +96,14 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         }
         for &root_id in &roots {
             collect(&state.nodes, root_id, &mut drawn_at);
-            let (_, roles) =
-                layout_nodes(&state.nodes, root_id, 0, area.width as i16, state.auto_arrange);
+            let (_, roles) = layout_nodes(
+                &state.nodes,
+                root_id,
+                0,
+                area.width as i16,
+                state.auto_arrange,
+                state.debug_input_mode,
+            );
             node_roles.extend(roles);
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -308,10 +308,30 @@ impl AppState {
 
         let new_id = self.nodes.keys().max().copied().unwrap_or(100) + 1;
 
-        let mut child = Node::new(new_id, "New Child", Some(parent_id));
+        if parent_id == new_id {
+            eprintln!("❌ Invalid insert: node cannot parent itself.");
+            return;
+        }
+
         if let Some(parent) = self.nodes.get(&parent_id) {
-            child.x = parent.x;
-            child.y = parent.y + 1;
+            if parent.children.contains(&parent_id) {
+                eprintln!("❌ Cycle detected: parent already linked to self.");
+                return;
+            }
+        }
+
+        let mut child = Node::new(new_id, "New Child", Some(parent_id));
+        if self.auto_arrange {
+            if let Some(parent) = self.nodes.get(&parent_id) {
+                child.x = parent.x;
+                child.y = parent.y + 1;
+            }
+        } else {
+            let base_x = 6 + ((self.nodes.len() as i16) % 10) * SIBLING_SPACING_X;
+            let base_y =
+                GEMX_HEADER_HEIGHT + 2 + ((self.nodes.len() as i16) / 10) * CHILD_SPACING_Y;
+            child.x = base_x;
+            child.y = base_y;
         }
 
         self.nodes.insert(new_id, child);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -42,7 +42,7 @@ fn missing_parent_becomes_free() {
     state.nodes.insert(new_id, Node::new(new_id, "Dangling", Some(123)));
     state.nodes.get_mut(&root).unwrap().children.push(new_id);
 
-    let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true);
+    let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true, state.debug_input_mode);
     assert_eq!(roles.get(&new_id), Some(&LayoutRole::Free));
 }
 


### PR DESCRIPTION
## Summary
- add cycle detection to `add_child`
- assign fallback coordinates for manual child inserts
- clamp recursion in `layout_recursive_safe`
- pass debug flag through layout calls

## Testing
- `cargo test --quiet`