### PR TITLE
Add dock focus navigation

### DIFF
--- a/src/render/favorites.rs
+++ b/src/render/favorites.rs
@@ -1,45 +1,22 @@
 use ratatui::{
     backend::Backend,
     layout::Rect,
-    style::Style,
+    style::{Color, Modifier, Style},
     widgets::{Block, Borders, Paragraph},
+    text::{Line, Span},
     Frame,
 };
-use crate::state::{AppState, FavoriteEntry, DockLayout};
+use crate::state::{AppState, DockLayout};
 use crate::beamx::style_for_mode;
 
 pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     if !state.favorite_dock_enabled {
         return;
     }
-    let default_favorites = [
-        ("⚙️", "/settings"),
-        ("📬", "/triage"),
-        ("💭", "/gemx"),
-        ("🧘", "/zen"),
-        ("🔍", "/spotlight"),
-    ];
-
-    let mut all: Vec<FavoriteEntry> = default_favorites
-        .iter()
-        .map(|&(icon, cmd)| FavoriteEntry { icon, command: cmd })
-        .chain(state.plugin_favorites.iter().cloned())
-        .take(5)
-        .collect();
-
-    if state.mode == "gemx" && all.len() >= 3 {
-        all[2].icon = "💬";
-    }
-    if state.mode == "triage" || state.show_triage {
-        if all.len() >= 2 {
-            all[1].icon = "📫";
-        }
-    }
-
-    let favorites = &mut all[..];
+    let mut favorites = state.favorite_entries();
 
     let theme = style_for_mode(&state.mode);
-    let style = Style::default().fg(theme.border_color);
+    let base_style = Style::default().fg(theme.border_color);
 
     let horizontal = state.favorite_dock_layout == DockLayout::Horizontal;
     let height = if horizontal { 3 } else { favorites.len() as u16 + 2 };
@@ -53,25 +30,42 @@ pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &m
         let x = area.x + 1;
         let y = area.height.saturating_sub(height + 3);
 
-        let border = Block::default().borders(Borders::ALL).style(style);
+        let border = Block::default().borders(Borders::ALL).style(base_style);
         f.render_widget(border, Rect::new(x - 1, y - 1, width, height));
 
-        let line: String = favorites.iter().map(|e| e.icon).collect::<Vec<_>>().join("  ");
-        f.render_widget(Paragraph::new(line).style(style), Rect::new(x, y, width - 2, 1));
+        let spans: Vec<Span> = favorites
+            .iter()
+            .enumerate()
+            .flat_map(|(i, e)| {
+                let style = if Some(i) == state.dock_focus_index {
+                    Style::default().fg(Color::LightCyan).add_modifier(Modifier::REVERSED)
+                } else {
+                    base_style
+                };
+                vec![Span::styled(e.icon.to_string(), style), Span::raw("  ")]
+            })
+            .collect();
+        let line = Line::from(spans);
+        f.render_widget(Paragraph::new(line), Rect::new(x, y, width - 2, 1));
     } else {
         if favorites.is_empty() {
             return;
         }
         let base_y = area.height.saturating_sub(favorites.len() as u16 + 2);
-        f.render_widget(Paragraph::new("\\__").style(style), Rect::new(0, base_y - 1, 3, 1));
+        f.render_widget(Paragraph::new("\\__").style(base_style), Rect::new(0, base_y - 1, 3, 1));
         for (i, entry) in favorites.iter().enumerate() {
             let gy = base_y + i as u16;
+            let style = if Some(i) == state.dock_focus_index {
+                Style::default().fg(Color::LightCyan).add_modifier(Modifier::REVERSED)
+            } else {
+                base_style
+            };
             let line = format!("{} |", entry.icon);
             f.render_widget(Paragraph::new(line).style(style), Rect::new(0, gy, 5, 1));
         }
         let bottom_y = base_y + favorites.len() as u16;
         let underscore_len = area.width.saturating_sub(3) as usize;
         let bottom_line = format!("  |{}", "_".repeat(underscore_len));
-        f.render_widget(Paragraph::new(bottom_line).style(style), Rect::new(0, bottom_y, area.width, 1));
+        f.render_widget(Paragraph::new(bottom_line).style(base_style), Rect::new(0, bottom_y, area.width, 1));
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,6 +29,9 @@ fn toggle_dock_layout(s: &mut AppState) {
         DockLayout::Vertical => DockLayout::Horizontal,
         DockLayout::Horizontal => DockLayout::Vertical,
     };
+    s.dock_focus_index = None;
+    s.status_message.clear();
+    s.status_message_last_updated = None;
 }
 
 pub const SETTING_TOGGLES: &[SettingToggle] = &[

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -83,6 +83,7 @@ pub struct AppState {
     pub favorite_dock_limit: usize,
     pub favorite_dock_layout: DockLayout,
     pub favorite_dock_enabled: bool,
+    pub dock_focus_index: Option<usize>,
     pub last_mouse_click: Option<(u16, u16)>,
     pub settings_focus_index: usize,
 
@@ -148,6 +149,7 @@ impl Default for AppState {
             favorite_dock_limit: 3,
             favorite_dock_layout: DockLayout::Vertical,
             favorite_dock_enabled: true,
+            dock_focus_index: None,
             last_mouse_click: None,
             settings_focus_index: 0,
 
@@ -175,6 +177,68 @@ impl AppState {
     pub fn set_selected(&mut self, id: Option<NodeID>) {
         self.selected = id;
         self.last_promoted_root = None;
+    }
+
+    pub fn favorite_entries(&self) -> Vec<FavoriteEntry> {
+        let default_favorites = [
+            ("⚙️", "/settings"),
+            ("📬", "/triage"),
+            ("💭", "/gemx"),
+            ("🧘", "/zen"),
+            ("🔍", "/spotlight"),
+        ];
+
+        let mut all: Vec<FavoriteEntry> = default_favorites
+            .iter()
+            .map(|&(icon, cmd)| FavoriteEntry { icon, command: cmd })
+            .chain(self.plugin_favorites.iter().cloned())
+            .take(5)
+            .collect();
+
+        if self.mode == "gemx" && all.len() >= 3 {
+            all[2].icon = "💬";
+        }
+        if (self.mode == "triage" || self.show_triage) && all.len() >= 2 {
+            all[1].icon = "📫";
+        }
+
+        all
+    }
+
+    pub fn dock_focus_prev(&mut self) {
+        let len = self.favorite_entries().len();
+        if len == 0 {
+            self.dock_focus_index = None;
+            return;
+        }
+        self.dock_focus_index = Some(match self.dock_focus_index.unwrap_or(0) {
+            0 => len - 1,
+            i => i - 1,
+        });
+        if let Some(idx) = self.dock_focus_index {
+            if let Some(entry) = self.favorite_entries().get(idx) {
+                self.status_message = entry.command.to_string();
+                self.status_message_last_updated = Some(std::time::Instant::now());
+            }
+        }
+    }
+
+    pub fn dock_focus_next(&mut self) {
+        let len = self.favorite_entries().len();
+        if len == 0 {
+            self.dock_focus_index = None;
+            return;
+        }
+        self.dock_focus_index = Some(match self.dock_focus_index.unwrap_or(len - 1) {
+            i if i + 1 >= len => 0,
+            i => i + 1,
+        });
+        if let Some(idx) = self.dock_focus_index {
+            if let Some(entry) = self.favorite_entries().get(idx) {
+                self.status_message = entry.command.to_string();
+                self.status_message_last_updated = Some(std::time::Instant::now());
+            }
+        }
     }
 
     pub fn visible_node_order(&self) -> Vec<NodeID> {
@@ -454,6 +518,9 @@ impl AppState {
             } else if layout.eq_ignore_ascii_case("vertical") {
                 self.favorite_dock_layout = DockLayout::Vertical;
             }
+            self.dock_focus_index = None;
+            self.status_message.clear();
+            self.status_message_last_updated = None;
         } else if input.starts_with("/dock_limit=") {
             let value = &input["/dock_limit=".len()..];
             if let Ok(num) = value.parse::<usize>() {
@@ -463,6 +530,11 @@ impl AppState {
             let value = &input["/dock_enabled=".len()..];
             if let Ok(flag) = value.parse::<bool>() {
                 self.favorite_dock_enabled = flag;
+            }
+            if !self.favorite_dock_enabled {
+                self.dock_focus_index = None;
+                self.status_message.clear();
+                self.status_message_last_updated = None;
             }
         } else if input.starts_with("/simulate") {
             for token in input.split_whitespace().skip(1) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -357,6 +357,15 @@ pub fn launch_ui() -> std::io::Result<()> {
                         (crate::settings::SETTING_TOGGLES[idx].toggle)(&mut state);
                     }
 
+                    KeyCode::Up if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {
+                        state.dock_focus_prev();
+                        if state.mode == "gemx" { state.move_focus_up(); }
+                    }
+                    KeyCode::Down if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {
+                        state.dock_focus_next();
+                        if state.mode == "gemx" { state.move_focus_down(); }
+                    }
+
                     KeyCode::Up if state.mode == "gemx" => state.move_focus_up(),
                     KeyCode::Down if state.mode == "gemx" => state.move_focus_down(),
                     KeyCode::Left if state.mode == "gemx" => state.move_focus_left(),

--- a/tests/dock_navigation.rs
+++ b/tests/dock_navigation.rs
@@ -1,0 +1,17 @@
+use prismx::state::AppState;
+
+#[test]
+fn dock_focus_updates_index_and_status() {
+    let mut state = AppState::default();
+    state.dock_focus_next();
+    assert_eq!(state.dock_focus_index, Some(0));
+    assert_eq!(state.status_message, "/settings");
+    state.dock_focus_next();
+    assert_eq!(state.dock_focus_index, Some(1));
+    assert_eq!(state.status_message, "/triage");
+    // wrap around
+    for _ in 0..10 {
+        state.dock_focus_next();
+    }
+    assert!(state.dock_focus_index.is_some());
+}


### PR DESCRIPTION
## Summary
- allow favorites dock navigation with up/down keys
- highlight focused dock entry with cyan reversed style
- expose `favorite_entries` and focus helpers in `AppState`
- reset dock focus on layout/enable changes
- show focused entry command in status
- add unit test for dock focus helpers

## Testing
- `cargo test`