### PR TITLE
Enable dock glyph commands

### DIFF
--- a/src/render/favorites.rs
+++ b/src/render/favorites.rs
@@ -5,38 +5,15 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
-use crate::state::{AppState, FavoriteEntry, DockLayout};
+use crate::state::{AppState, DockLayout};
 use crate::beamx::style_for_mode;
 
 pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     if !state.favorite_dock_enabled {
         return;
     }
-    let default_favorites = [
-        ("⚙️", "/settings"),
-        ("📬", "/triage"),
-        ("💭", "/gemx"),
-        ("🧘", "/zen"),
-        ("🔍", "/spotlight"),
-    ];
-
-    let mut all: Vec<FavoriteEntry> = default_favorites
-        .iter()
-        .map(|&(icon, cmd)| FavoriteEntry { icon, command: cmd })
-        .chain(state.plugin_favorites.iter().cloned())
-        .take(5)
-        .collect();
-
-    if state.mode == "gemx" && all.len() >= 3 {
-        all[2].icon = "💬";
-    }
-    if state.mode == "triage" || state.show_triage {
-        if all.len() >= 2 {
-            all[1].icon = "📫";
-        }
-    }
-
-    let favorites = &mut all[..];
+    let favorites = state.favorite_entries();
+    state.dock_entry_bounds.clear();
 
     let theme = style_for_mode(&state.mode);
     let style = Style::default().fg(theme.border_color);
@@ -56,8 +33,12 @@ pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &m
         let border = Block::default().borders(Borders::ALL).style(style);
         f.render_widget(border, Rect::new(x - 1, y - 1, width, height));
 
-        let line: String = favorites.iter().map(|e| e.icon).collect::<Vec<_>>().join("  ");
-        f.render_widget(Paragraph::new(line).style(style), Rect::new(x, y, width - 2, 1));
+        for (i, entry) in favorites.iter().enumerate() {
+            let gx = x + i as u16 * 3;
+            let rect = Rect::new(gx, y, 2, 1);
+            f.render_widget(Paragraph::new(entry.icon).style(style), rect);
+            state.dock_entry_bounds.push((rect, entry.command.to_string()));
+        }
     } else {
         if favorites.is_empty() {
             return;
@@ -67,7 +48,14 @@ pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &m
         for (i, entry) in favorites.iter().enumerate() {
             let gy = base_y + i as u16;
             let line = format!("{} |", entry.icon);
-            f.render_widget(Paragraph::new(line).style(style), Rect::new(0, gy, 5, 1));
+            let rect = Rect::new(0, gy, 5, 1);
+            let style_entry = if state.favorite_focus_index == Some(i) {
+                style.add_modifier(ratatui::style::Modifier::REVERSED)
+            } else {
+                style
+            };
+            f.render_widget(Paragraph::new(line).style(style_entry), rect);
+            state.dock_entry_bounds.push((rect, entry.command.to_string()));
         }
         let bottom_y = base_y + favorites.len() as u16;
         let underscore_len = area.width.saturating_sub(3) as usize;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,6 +18,10 @@ use crate::render::{
     render_module_icon,
     render_favorites_dock,
 };
+
+fn rect_contains(rect: ratatui::layout::Rect, x: u16, y: u16) -> bool {
+    x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
+}
 use crate::screen::render_gemx;
 use crate::settings::render_settings;
 
@@ -318,6 +322,17 @@ pub fn launch_ui() -> std::io::Result<()> {
                     continue;
                 }
 
+                if modifiers.contains(KeyModifiers::CONTROL) {
+                    if let KeyCode::Char(digit) = code {
+                        if ('1'..='5').contains(&digit) {
+                            let idx = digit as usize - '1' as usize;
+                            state.trigger_favorite(idx);
+                            draw(&mut terminal, &mut state, &last_key)?;
+                            continue;
+                        }
+                    }
+                }
+
                 // ⌨️ Navigation + Typing
                 match code {
                     KeyCode::Esc => {
@@ -411,7 +426,15 @@ pub fn launch_ui() -> std::io::Result<()> {
                     match me.kind {
                         MouseEventKind::Down(MouseButton::Left) => {
                             state.last_mouse_click = Some((me.column, me.row));
-                            if state.mode == "gemx" {
+                            let mut handled = false;
+                            for (idx, (rect, _cmd)) in state.dock_entry_bounds.iter().enumerate() {
+                                if rect_contains(*rect, me.column, me.row) {
+                                    state.trigger_favorite(idx);
+                                    handled = true;
+                                    break;
+                                }
+                            }
+                            if !handled && state.mode == "gemx" {
                                 if let Some(id) = crate::gemx::interaction::node_at_position(&state, me.column, me.row) {
                                     crate::gemx::interaction::start_drag(&mut state, id, me.column, me.row);
                                 }

--- a/tests/plugin_favorites.rs
+++ b/tests/plugin_favorites.rs
@@ -1,0 +1,11 @@
+use prismx::state::{AppState, register_plugin_favorite};
+
+#[test]
+fn plugin_favorite_triggers_spotlight() {
+    let mut state = AppState::default();
+    state.favorite_dock_limit = 5;
+    register_plugin_favorite(&mut state, "🔨", "/run-tests");
+    state.trigger_favorite(0); // plugin comes first
+    assert_eq!(state.spotlight_input, "/run-tests");
+    assert!(state.show_spotlight);
+}


### PR DESCRIPTION
## Summary
- allow plugin favorites to trigger spotlight commands
- track dock entry bounds for mouse clicks
- add keyboard shortcuts for favorites dock
- expose `trigger_favorite` and `favorite_entries`
- test plugin favorites

## Testing
- `cargo test --quiet`