### PR TITLE
Add grid snapping to layout

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -15,6 +15,8 @@ pub const GEMX_HEADER_HEIGHT: i16 = 2;
 pub const MAX_LAYOUT_DEPTH: usize = 50;
 pub const BASE_SPACING_X: i16 = 20;
 pub const BASE_SPACING_Y: i16 = 5;
+pub const SNAP_GRID_X: i16 = 4;
+pub const SNAP_GRID_Y: i16 = 2;
 
 pub fn spacing_for_zoom(zoom: f32) -> (i16, i16) {
     if zoom < 0.7 {
@@ -145,12 +147,18 @@ pub fn layout_nodes(
         debug_input_mode,
     );
 
+
     if let Some(min_x) = coords.values().map(|c| c.x).min() {
         if min_x < 0 {
             for pos in coords.values_mut() {
                 pos.x -= min_x;
             }
         }
+    }
+
+    for pos in coords.values_mut() {
+        pos.x -= pos.x % SNAP_GRID_X;
+        pos.y -= pos.y % SNAP_GRID_Y;
     }
 
     (coords, roles)

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -3,7 +3,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::layout::{
     layout_nodes, Coords, LayoutRole, PackRegion, GEMX_HEADER_HEIGHT,
     CHILD_SPACING_Y, subtree_span, subtree_depth, spacing_for_zoom,
-    BASE_SPACING_X, BASE_SPACING_Y, SIBLING_SPACING_X,
+    BASE_SPACING_X, BASE_SPACING_Y, SIBLING_SPACING_X, SNAP_GRID_X, SNAP_GRID_Y,
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
@@ -18,6 +18,16 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })
         .borders(Borders::NONE);
     f.render_widget(block, area);
+
+    if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
+        let dot = Paragraph::new("·").style(Style::default().fg(Color::DarkGray));
+        for gx in (0..area.width).step_by(SNAP_GRID_X as usize) {
+            for gy in (0..area.height).step_by(SNAP_GRID_Y as usize) {
+                let rect = Rect::new(area.x + gx, area.y + gy, 1, 1);
+                f.render_widget(dot.clone(), rect);
+            }
+        }
+    }
 
     // Reset unreachable fallback lock for this frame
     state.fallback_this_frame = false;


### PR DESCRIPTION
## Summary
- add SNAP_GRID_X/Y constants
- snap layout coordinates to the new grid
- optionally draw a debug grid overlay when debug mode is active

## Testing
- `cargo test`