### PR TITLE
Add layout snapshot undo/redo

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 pub type NodeID = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Node {
     pub id: NodeID,
     pub label: String,

--- a/tests/undo_redo.rs
+++ b/tests/undo_redo.rs
@@ -1,0 +1,28 @@
+use prismx::state::AppState;
+
+#[test]
+fn undo_removes_inserted_node() {
+    let mut state = AppState::default();
+    let initial = state.nodes.len();
+    state.push_undo();
+    state.add_sibling();
+    assert_eq!(state.nodes.len(), initial + 1);
+    state.spotlight_input = "/undo".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.nodes.len(), initial);
+}
+
+#[test]
+fn redo_restores_state() {
+    let mut state = AppState::default();
+    let initial = state.nodes.len();
+    state.push_undo();
+    state.add_child();
+    assert_eq!(state.nodes.len(), initial + 1);
+    state.spotlight_input = "/undo".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.nodes.len(), initial);
+    state.spotlight_input = "/redo".into();
+    state.execute_spotlight_command();
+    assert_eq!(state.nodes.len(), initial + 1);
+}


### PR DESCRIPTION
## Summary
- implement `LayoutSnapshot` and undo/redo stacks
- add `/undo` and `/redo` spotlight commands
- derive `PartialEq` for `Node`
- test undo and redo behaviour

## Testing
- `cargo test`