### PR TITLE
Add Zen mode metadata footer

### DIFF
--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -96,6 +96,15 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
         }
     }
 
+    let unsaved_marker = if state.zen_dirty { " \u{270E}" } else { "" };
+    let footer_text = format!("\u{1F4C4} {}   \u{270D} {} words{}", state.zen_current_filename, state.zen_word_count, unsaved_marker);
+    let x_offset = area.width.saturating_sub(footer_text.len() as u16 + 2);
+    let footer_rect = Rect::new(area.x + x_offset, area.y + area.height - 1, footer_text.len() as u16, 1);
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(Color::DarkGray)),
+        footer_rect,
+    );
+
     render_full_border(f, area, &style, true, false);
     let beamx = BeamX {
         tick,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -89,6 +89,9 @@ pub struct AppState {
     pub zen_toolbar_open: bool,
     pub zen_recent_files: Vec<String>,
     pub zen_toolbar_index: usize,
+    pub zen_current_filename: String,
+    pub zen_word_count: usize,
+    pub zen_dirty: bool,
 
 }
 
@@ -158,6 +161,9 @@ impl Default for AppState {
             zen_toolbar_open: false,
             zen_recent_files: vec!["README.md".into()],
             zen_toolbar_index: 0,
+            zen_current_filename: "Untitled".into(),
+            zen_word_count: 0,
+            zen_dirty: false,
 
         };
 
@@ -174,6 +180,8 @@ impl Default for AppState {
                 node.label = node.label.replacen("[F] ", "", 1);
             }
         }
+
+        state.update_zen_word_count();
 
         state
     }
@@ -581,7 +589,11 @@ impl AppState {
                     self.zen_toolbar_open = !self.zen_toolbar_open;
                     self.zen_toolbar_index = 0;
                 }
-                "/clear" => self.zen_buffer = vec![String::new()],
+                "/clear" => {
+                    self.zen_buffer = vec![String::new()];
+                    self.update_zen_word_count();
+                    self.zen_dirty = true;
+                }
                 _ => {}
             }
         }
@@ -636,6 +648,9 @@ impl AppState {
         if let Ok(content) = std::fs::read_to_string(path) {
             self.zen_buffer = content.lines().map(|l| l.to_string()).collect();
             self.zen_buffer.push(String::new());
+            self.zen_current_filename = path.to_string();
+            self.update_zen_word_count();
+            self.zen_dirty = false;
             self.add_recent_file(path);
         }
     }
@@ -648,7 +663,14 @@ impl AppState {
         if let Ok(mut file) = std::fs::File::create(path) {
             let _ = file.write_all(self.zen_buffer.join("\n").as_bytes());
             self.add_recent_file(path);
+            self.zen_current_filename = path.to_string();
+            self.zen_dirty = false;
         }
+    }
+
+    pub fn update_zen_word_count(&mut self) {
+        let text = self.zen_buffer.join(" ");
+        self.zen_word_count = text.split_whitespace().count();
     }
 
     pub fn add_recent_file(&mut self, path: &str) {
@@ -682,6 +704,9 @@ impl AppState {
                 match self.zen_toolbar_index {
                     0 => {
                         self.zen_buffer = vec![String::new()];
+                        self.zen_current_filename = "Untitled".into();
+                        self.update_zen_word_count();
+                        self.zen_dirty = false;
                     }
                     1 => {
                         if let Some(path) = self.zen_recent_files.first().cloned() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -412,16 +412,22 @@ pub fn launch_ui() -> std::io::Result<()> {
                         if let Some(last) = state.zen_buffer.last_mut() {
                             last.push(c);
                         }
+                        state.update_zen_word_count();
+                        state.zen_dirty = true;
                     }
 
                     KeyCode::Backspace if state.mode == "zen" => {
                         if let Some(last) = state.zen_buffer.last_mut() {
                             last.pop();
                         }
+                        state.update_zen_word_count();
+                        state.zen_dirty = true;
                     }
 
                     KeyCode::Enter if state.mode == "zen" => {
                         state.zen_buffer.push(String::new());
+                        state.update_zen_word_count();
+                        state.zen_dirty = true;
                     }
 
                     _ => {}

--- a/tests/zen_footer.rs
+++ b/tests/zen_footer.rs
@@ -1,0 +1,25 @@
+use prismx::state::AppState;
+
+#[test]
+fn word_count_updates_on_edit() {
+    let mut state = AppState::default();
+    if let Some(last) = state.zen_buffer.last_mut() {
+        last.clear();
+        last.push_str("hello world");
+    }
+    state.update_zen_word_count();
+    state.zen_dirty = true;
+    assert_eq!(state.zen_word_count, 2);
+    assert!(state.zen_dirty);
+}
+
+#[test]
+fn open_sets_filename_and_resets_dirty() {
+    let path = "/tmp/zen_footer_test.txt";
+    std::fs::write(path, "one two three").unwrap();
+    let mut state = AppState::default();
+    state.open_zen_file(path);
+    assert_eq!(state.zen_current_filename, path);
+    assert_eq!(state.zen_word_count, 3);
+    assert!(!state.zen_dirty);
+}


### PR DESCRIPTION
## Summary
- track filename, word count and dirty flag for Zen documents
- update word count and dirty flag on edits
- show metadata footer in Zen mode
- set fields when opening/saving files
- add basic tests for footer state

## Testing
- `cargo test --quiet`