### PR TITLE
Enhance Zen mode with themes and syntax

### DIFF
--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -25,6 +25,7 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("start_link".into(), "ctrl-l".into());
     map.insert("redo".into(), "ctrl-shift-z".into());
     map.insert("toggle_snap_grid".into(), "ctrl-g".into());
+    map.insert("zen_toggle_theme".into(), "ctrl-a".into());
 
 
     map

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -322,6 +322,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.export_zen_to_file();
                 } else if match_hotkey("mode_zen", code, modifiers, &state) {
                     state.mode = "zen".into();
+                } else if match_hotkey("zen_toggle_theme", code, modifiers, &state) && state.mode == "zen" {
+                    state.cycle_zen_theme();
                 } else if code == KeyCode::Char('t')
                     && modifiers == KeyModifiers::CONTROL
                     && state.mode == "zen"


### PR DESCRIPTION
## Summary
- introduce `ZenSyntax` and `ZenTheme` enums
- track theme and syntax in `AppState`
- implement `/open` command, theme cycling and syntax inference
- add simple syntax highlighting render logic
- display phantom controls in Zen mode UI

## Testing
- `cargo test --quiet`