### PR TITLE
Fix recursive fallback layout

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -72,7 +72,6 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
                 oy,
                 tw as i16,
                 state.auto_arrange,
-                state.debug_input_mode,
             );
             for pos in l.values_mut() {
                 pos.x += ox;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -12,7 +12,7 @@ pub const MIN_NODE_GAP: i16 = 3;
 pub const CHILD_SPACING_Y: i16 = 1;
 pub const FREE_GRID_COLUMNS: usize = 4;
 pub const GEMX_HEADER_HEIGHT: i16 = 2;
-pub const MAX_LAYOUT_DEPTH: usize = 50;
+pub const MAX_DEPTH: usize = 32;
 pub const BASE_SPACING_X: i16 = 20;
 pub const BASE_SPACING_Y: i16 = 5;
 pub const SNAP_GRID_X: i16 = 4;
@@ -126,7 +126,6 @@ pub fn layout_nodes(
     start_y: i16,
     term_width: i16,
     auto_arrange: bool,
-    debug_input_mode: bool,
 ) -> (HashMap<NodeID, Coords>, HashMap<NodeID, LayoutRole>) {
     let start_y = start_y.max(GEMX_HEADER_HEIGHT);
     let start_x = if auto_arrange { 0 } else { term_width / 2 };
@@ -144,7 +143,6 @@ pub fn layout_nodes(
         auto_arrange,
         &mut visited,
         0,
-        debug_input_mode,
     );
 
 
@@ -175,20 +173,13 @@ fn layout_recursive_safe(
     auto_arrange: bool,
     visited: &mut HashSet<NodeID>,
     depth: usize,
-    debug_input_mode: bool,
 ) -> (i16, i16, i16) {
-    let inserted = visited.insert(node_id);
-    if !inserted || depth > MAX_LAYOUT_DEPTH {
-        if debug_input_mode {
-            eprintln!(
-                "⚠️ Recursion halted: Node {} (depth {})",
-                node_id,
-                depth
-            );
-        }
-        if inserted {
-            visited.remove(&node_id);
-        }
+    if !visited.insert(node_id) || depth > MAX_DEPTH {
+        crate::log_warn!(
+            "⚠ Recursion halted: Node {} (depth {})",
+            node_id,
+            depth
+        );
         return (y, x, x);
     }
 
@@ -242,7 +233,6 @@ fn layout_recursive_safe(
             auto_arrange,
             visited,
             depth + 1,
-            debug_input_mode,
         );
         max_y = max_y.max(cy);
         min_x_span = min_x_span.min(mi);

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -85,7 +85,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
                 oy,
                 area.width as i16,
                 state.auto_arrange,
-                state.debug_input_mode,
             );
             for pos in layout.values_mut() {
                 pos.x += ox;
@@ -112,7 +111,6 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
                 0,
                 area.width as i16,
                 state.auto_arrange,
-                state.debug_input_mode,
             );
             node_roles.extend(roles);
         }
@@ -149,6 +147,9 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     if state.auto_arrange {
         let node_ids: Vec<NodeID> = state.nodes.keys().copied().collect();
         for id in node_ids {
+            if state.fallback_this_frame {
+                continue;
+            }
             let node = match state.nodes.get(&id) {
                 Some(n) => n,
                 None => continue,
@@ -194,15 +195,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             drawn_at.insert(id, Coords { x: n.x, y: n.y });
             node_roles.insert(id, LayoutRole::Root);
 
-            if state.debug_input_mode {
-                eprintln!(
-                    "✅ Promoted Node {}: x={}, y={}, role={:?}",
-                    id,
-                    n.x,
-                    n.y,
-                    node_roles.get(&id)
-                );
-            }
+            crate::log_debug!(state, "\u{26a0} Promoted Node {} to root (label-safe)", id);
 
             break;
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1050,9 +1050,9 @@ impl AppState {
                     continue;
                 }
                 let op = &self.nodes[&other];
-                if (y - (op.y + crate::layout::CHILD_SPACING_Y)).abs() <= 1
+                if y > op.y
+                    && (y - op.y) <= crate::layout::CHILD_SPACING_Y + 1
                     && (x - op.x).abs() <= 1
-                    && y > op.y
                 {
                     parent_id = Some(other);
                     break;
@@ -1083,7 +1083,10 @@ impl AppState {
         // Apply structure and lock child positions
         for &id in &ids {
             if let Some(parent_id) = new_parents[&id] {
-                crate::log_debug!(self, "Assigning parent {:?} to node {}", parent_id, id);
+                if parent_id == id {
+                    continue;
+                }
+                crate::log_debug!(self, "Assigning parent {:?} \u{2192} {}", parent_id, id);
                 let (px, py) = {
                     let p = &self.nodes[&parent_id];
                     (p.x, p.y)

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -42,7 +42,7 @@ fn missing_parent_becomes_free() {
     state.nodes.insert(new_id, Node::new(new_id, "Dangling", Some(123)));
     state.nodes.get_mut(&root).unwrap().children.push(new_id);
 
-    let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true, state.debug_input_mode);
+    let (_c, roles) = layout_nodes(&state.nodes, root, 0, 80, true);
     assert_eq!(roles.get(&new_id), Some(&LayoutRole::Free));
 }
 


### PR DESCRIPTION
## Summary
- clamp layout recursion depth with MAX_DEPTH and visited set
- tighten role calculation so nodes can't claim multiple parents
- improve fallback promotion logging and limit to one per frame
- adjust test for new layout_nodes signature

## Testing
- `cargo test --quiet`