### PR TITLE
Add async spotlight indexing task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ ratatui = "0.23"
 # Utilities
 chrono = "0.4"
 dirs = "4.0"
+crossbeam-channel = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,4 @@ pub mod settings;
 #[path = "state/mod.rs"]
 pub mod state;
 pub mod shortcuts;
+pub mod spotlight_task;

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -74,4 +74,24 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
             Rect::new(x_offset, y, width, 1),
         );
     }
+
+    let start_y = y_offset + 2 + matches.len() as u16;
+    for (idx, result) in state.spotlight_results.iter().take(5).enumerate() {
+        let y = start_y + idx as u16;
+        let label = match result {
+            crate::spotlight::SpotlightResult::Node(id) => {
+                state.nodes.get(id).map(|n| n.label.as_str()).unwrap_or("")
+            }
+            crate::spotlight::SpotlightResult::Command(cmd) => cmd.as_str(),
+            crate::spotlight::SpotlightResult::Tag(tag) => tag.as_str(),
+            crate::spotlight::SpotlightResult::Jump(id) => {
+                state.nodes.get(id).map(|n| n.label.as_str()).unwrap_or("")
+            }
+        };
+        let style = Style::default().fg(Color::Yellow);
+        f.render_widget(
+            Paragraph::new(label).style(style),
+            Rect::new(x_offset, y, width, 1),
+        );
+    }
 }

--- a/src/spotlight_task.rs
+++ b/src/spotlight_task.rs
@@ -1,0 +1,37 @@
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use std::thread;
+
+use crate::node::NodeMap;
+use crate::spotlight::SpotlightResult;
+
+pub struct SpotlightTask {
+    pub result_rx: Receiver<Vec<SpotlightResult>>,
+    cancel_tx: Sender<()>,
+    handle: thread::JoinHandle<()>,
+}
+
+impl SpotlightTask {
+    pub fn spawn(nodes: NodeMap, query: String) -> Self {
+        let (result_tx, result_rx) = unbounded();
+        let (cancel_tx, cancel_rx) = unbounded();
+        let handle = thread::spawn(move || {
+            let q = query.to_lowercase();
+            let mut results = Vec::new();
+            for (id, node) in nodes.iter() {
+                if cancel_rx.try_recv().is_ok() {
+                    return;
+                }
+                if node.label.to_lowercase().contains(&q) {
+                    results.push(SpotlightResult::Node(*id));
+                }
+            }
+            let _ = result_tx.send(results);
+        });
+        Self { result_rx, cancel_tx, handle }
+    }
+
+    pub fn cancel(self) {
+        let _ = self.cancel_tx.send(());
+        let _ = self.handle.join();
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -146,6 +146,8 @@ pub fn launch_ui() -> std::io::Result<()> {
             state.set_selected(Some(first));
         }
 
+        state.poll_spotlight_results();
+
         state.auto_save_zen();
 
         if let Some(sim_input) = state.simulate_input_queue.pop_front() {
@@ -197,10 +199,12 @@ pub fn launch_ui() -> std::io::Result<()> {
                         KeyCode::Char(c) => {
                             state.spotlight_input.push(c);
                             state.spotlight_history_index = None;
+                            state.start_spotlight_index();
                         }
                         KeyCode::Backspace => {
                             state.spotlight_input.pop();
                             state.spotlight_history_index = None;
+                            state.start_spotlight_index();
                         }
                         KeyCode::Up => {
                             if state.spotlight_history.is_empty() {
@@ -212,9 +216,11 @@ pub fn launch_ui() -> std::io::Result<()> {
                                 if let Some(idx) = state.spotlight_history_index {
                                     state.spotlight_input = state.spotlight_history[idx].clone();
                                 }
+                                state.start_spotlight_index();
                             } else {
                                 state.spotlight_history_index = Some(0);
                                 state.spotlight_input = state.spotlight_history[0].clone();
+                                state.start_spotlight_index();
                             }
                         }
                         KeyCode::Down => {
@@ -224,9 +230,11 @@ pub fn launch_ui() -> std::io::Result<()> {
                                     if let Some(idx) = state.spotlight_history_index {
                                         state.spotlight_input = state.spotlight_history[idx].clone();
                                     }
+                                    state.start_spotlight_index();
                                 } else {
                                     state.spotlight_history_index = None;
                                     state.spotlight_input.clear();
+                                    state.start_spotlight_index();
                                 }
                             }
                         }
@@ -244,6 +252,9 @@ pub fn launch_ui() -> std::io::Result<()> {
                 {
                     state.show_spotlight = !state.show_spotlight;
                     state.spotlight_history_index = None;
+                    if state.show_spotlight {
+                        state.start_spotlight_index();
+                    }
                     draw(&mut terminal, &mut state, &last_key)?;
                     continue;
                 }


### PR DESCRIPTION
## Summary
- introduce `crossbeam-channel` dependency
- add `SpotlightTask` for background indexing
- track async task and results in `AppState`
- start indexing on spotlight input changes
- display node matches in Spotlight panel

## Testing
- `cargo test` *(fails: failed to download dependencies)*