### PR TITLE
Add WASM viewer subcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ ratatui = "0.23"
 # Utilities
 chrono = "0.4"
 dirs = "4.0"
+
+[workspace]
+members = [".", "wasm"]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prismx-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wasm-bindgen = "0.2"
+wee_alloc = "0.4"
+console_error_panic_hook = "0.1"

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>PrismX WASM View</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.19.0/css/xterm.css" />
+<script src="https://cdn.jsdelivr.net/npm/xterm@4.19.0/lib/xterm.js"></script>
+</head>
+<body>
+<div id="terminal" style="width:100%; height:100vh;"></div>
+<script type="module">
+import init from './pkg/prismx_wasm.js';
+const term = new Terminal();
+term.open(document.getElementById('terminal'));
+window.prismx_write = text => term.writeln(text);
+init();
+</script>
+</body>
+</html>

--- a/wasm/snapshots/mindmap.json
+++ b/wasm/snapshots/mindmap.json
@@ -1,0 +1,8 @@
+{
+  "id": "root",
+  "title": "PrismX",
+  "children": [
+    { "id": "n1", "title": "Welcome", "children": [] },
+    { "id": "n2", "title": "Docs", "children": [] }
+  ]
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,41 @@
+use wasm_bindgen::prelude::*;
+use wee_alloc::WeeAlloc;
+
+#[global_allocator]
+static ALLOC: WeeAlloc = WeeAlloc::INIT;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = prismx_write)]
+    fn prismx_write(s: &str);
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct MindmapNode {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub children: Vec<MindmapNode>,
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+    let data = include_str!("../snapshots/mindmap.json");
+    let root: MindmapNode = serde_json::from_str(data).expect("invalid mindmap");
+    let mut out = String::new();
+    render(&root, 0, &mut out);
+    prismx_write(&out);
+}
+
+fn render(node: &MindmapNode, depth: usize, out: &mut String) {
+    for _ in 0..depth {
+        out.push_str("  ");
+    }
+    out.push_str("- ");
+    out.push_str(&node.title);
+    out.push('\n');
+    for child in &node.children {
+        render(child, depth + 1, out);
+    }
+}


### PR DESCRIPTION
## Summary
- create new `prismx-wasm` crate for browser preview
- include simple mindmap sample and renderer using `wasm-bindgen` + `wee_alloc`
- provide `index.html` using xterm.js for display
- add workspace config including the wasm crate

## Testing
- `cargo test --no-run`
- `cargo check --workspace` *(fails: could not download crates)*