### PR TITLE
Refactor core modules for optional no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ ratatui = "0.23"
 # Utilities
 chrono = "0.4"
 dirs = "4.0"
+hashbrown = { version = "0.14", default-features = false, features = ["alloc"] }
+
+[features]
+default = ["std"]
+std = []

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -1,0 +1,21 @@
+//! Abstractions over collection types that work in both `std` and `no_std`
+//! builds. When the `std` feature is enabled we simply re-export the types
+//! from `std::collections`.  In `no_std` mode we rely on `hashbrown` for
+//! `HashMap`/`HashSet` and `alloc::collections` for `VecDeque`.
+
+#![allow(dead_code)]
+
+#[cfg(feature = "std")]
+pub use std::collections::{HashMap, HashSet, VecDeque};
+#[cfg(feature = "std")]
+pub use std::rc::Rc;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+pub use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+pub use hashbrown::{HashMap, HashSet};
+#[cfg(not(feature = "std"))]
+pub use alloc::rc::Rc;
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 
 pub fn start_sync_if_enabled() {
     match fs::read_to_string("federation/sync_status.json") {

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -6,7 +6,7 @@ use crate::layout::{
     subtree_depth, spacing_for_zoom,
 };
 use crossterm::terminal;
-use std::collections::HashMap;
+use crate::collections::HashMap;
 
 /// Toggle snap-to-grid mode
 pub fn toggle_snap(state: &mut AppState) {

--- a/src/gemx/state.rs
+++ b/src/gemx/state.rs
@@ -1,5 +1,5 @@
 use super::nodes::MindmapNode;
-use std::fs;
+use crate::io::fs;
 use std::path::Path;
 
 pub fn load() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,39 @@
+//! Minimal wrapper around filesystem and environment access so the core
+//! application can build in `no_std` contexts.  When the `std` feature is
+//! enabled we simply re-export the standard library modules.  Without `std`
+//! these APIs become stubs that return errors.
+
+#[cfg(feature = "std")]
+pub mod fs {
+    pub use std::fs::*;
+}
+
+#[cfg(not(feature = "std"))]
+pub mod fs {
+    use alloc::string::String;
+
+    pub fn read_to_string<P: ?Sized>(_path: &P) -> Result<String, ()> {
+        Err(())
+    }
+
+    pub fn write<P: ?Sized>(_path: &P, _data: impl AsRef<[u8]>) -> Result<(), ()> {
+        Err(())
+    }
+
+    pub fn create_dir_all<P: ?Sized>(_path: &P) -> Result<(), ()> {
+        Err(())
+    }
+}
+
+#[cfg(feature = "std")]
+pub mod env {
+    pub use std::env::*;
+}
+
+#[cfg(not(feature = "std"))]
+pub mod env {
+    pub fn var(_key: &str) -> Result<String, ()> {
+        Err(())
+    }
+}
+

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use crate::collections::{HashMap, HashSet};
 use crate::node::{NodeID, NodeMap};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[macro_use]
 pub mod logging;
+pub mod collections;
+pub mod io;
 pub mod node;
 pub mod layout;
 pub mod screen;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::collections::HashMap;
 
 pub type NodeID = u64;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,6 @@
 use crate::plugins::{PluginFrame, PluginRender, PomodoroPlugin, CountdownPlugin};
 use ratatui::layout::Rect;
-use std::collections::VecDeque;
+use crate::collections::VecDeque;
 use std::time::{Duration, SystemTime};
 
 pub struct PluginHost {

--- a/src/retire.rs
+++ b/src/retire.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 
 pub fn check_retirement() -> Result<(), Box<dyn std::error::Error>> {
     let retire = fs::read_to_string("policy/retire.toml")?;

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -10,7 +10,7 @@ use crate::state::AppState;
 use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::collections::HashMap;
+use crate::collections::HashMap;
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let style = style_for_mode(&state.mode);
@@ -19,7 +19,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         .borders(Borders::NONE);
     f.render_widget(block, area);
 
-    if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
+    if state.debug_input_mode && crate::io::env::var("PRISMX_TEST").is_err() {
         let dot = Paragraph::new("·").style(Style::default().fg(Color::DarkGray));
         for gx in (0..area.width).step_by(SNAP_GRID_X as usize) {
             for gy in (0..area.height).step_by(SNAP_GRID_Y as usize) {
@@ -142,7 +142,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         return;
     }
 
-    use std::collections::HashSet;
+    use crate::collections::HashSet;
     let reachable_ids: HashSet<NodeID> = drawn_at.keys().copied().collect();
     if state.auto_arrange {
         let node_ids: Vec<NodeID> = state.nodes.keys().copied().collect();
@@ -345,7 +345,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             1u16.min(area.height),
         );
         f.render_widget(para, safe_rect);
-        if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
+        if state.debug_input_mode && crate::io::env::var("PRISMX_TEST").is_err() {
             let mark_rect = Rect::new(
                 draw_x.min(area.width.saturating_sub(1)),
                 draw_y.min(area.height.saturating_sub(1)),
@@ -412,7 +412,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     }
 
     render_full_border(f, area, &style, true, !state.debug_border);
-    let tick = if std::env::var("PRISMX_TEST").is_ok() {
+    let tick = if crate::io::env::var("PRISMX_TEST").is_ok() {
         0
     } else {
         (SystemTime::now()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use serde::{Deserialize, Serialize};
-use std::fs;
+use crate::io::fs;
 
 use crate::state::{AppState, DockLayout};
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 use std::path::Path;
 
 pub fn load_snapshot() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::collections::HashMap;
 
 pub fn load_default_hotkeys() -> HashMap<String, String> {
     let mut map = HashMap::new();

--- a/src/state/mindmap.rs
+++ b/src/state/mindmap.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use crate::collections::Rc;
 use std::cell::RefCell;
 
 #[derive(Debug)]

--- a/src/state/zen.rs
+++ b/src/state/zen.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 use std::io::Write;
 use dirs;
 use crate::state::AppState;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,6 @@
 use ratatui::style::{Color, Style};
-use std::collections::HashMap;
-use std::fs;
+use crate::collections::HashMap;
+use crate::io::fs;
 
 static mut CURRENT_THEME: &str = "dark";
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use crate::io::fs;
 
 pub fn verify_trust_chains() -> Result<(), Box<dyn std::error::Error>> {
     let seal = fs::read_to_string("trust/seal/gemx.seal.toml")?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -50,7 +50,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
                 .constraints([Constraint::Min(50), Constraint::Length(30)].as_ref())
                 .split(full)
         } else {
-            std::rc::Rc::from(vec![full])
+            crate::collections::Rc::from(vec![full])
         };
 
         let vertical = Layout::default()


### PR DESCRIPTION
## Summary
- prepare crate for optional no_std builds
- abstract collections behind `collections` module
- gate filesystem and environment access behind new `io` module
- swap `std` collections usage to crate equivalents

## Testing
- `cargo check` *(fails: Could not connect to server)*
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*