### PR TITLE
Introduce Renderable trait

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,6 +6,7 @@ pub mod triage;
 pub mod module_switcher;
 pub mod module_icon;
 pub mod favorites;
+pub mod renderable;
 
 pub use zen::render_zen_journal;
 pub use status::render_status_bar;
@@ -15,3 +16,4 @@ pub use triage::render_triage;
 pub use module_switcher::render_module_switcher;
 pub use module_icon::render_module_icon;
 pub use favorites::render_favorites_dock;
+pub use renderable::Renderable;

--- a/src/render/renderable.rs
+++ b/src/render/renderable.rs
@@ -1,0 +1,5 @@
+use ratatui::prelude::*;
+
+pub trait Renderable {
+    fn draw<B: Backend>(&self, frame: &mut Frame<B>, area: Rect);
+}

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -9,8 +9,33 @@ use ratatui::{
 
 use crate::state::AppState;
 use crate::spotlight::{command_preview, command_suggestions};
+use crate::render::Renderable;
+use std::cell::RefCell;
+use std::marker::PhantomData;
+
+pub struct Spotlight<'a> {
+    state: RefCell<&'a mut AppState>,
+    _marker: PhantomData<&'a mut AppState>,
+}
+
+impl<'a> Spotlight<'a> {
+    pub fn new(state: &'a mut AppState) -> Self {
+        Self { state: RefCell::new(state), _marker: PhantomData }
+    }
+}
+
+impl<'a> Renderable for Spotlight<'a> {
+    fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
+        let mut state = self.state.borrow_mut();
+        render_spotlight_impl(f, area, &mut *state);
+    }
+}
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
+    Spotlight::new(state).draw(f, area);
+}
+
+fn render_spotlight_impl<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;
     let width = area.width.min(60);
     let x_offset = area.x + (area.width.saturating_sub(width)) / 2;

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -2,10 +2,32 @@ use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph}};
 use crate::state::{AppState, ZenSyntax, ZenTheme, ZenJournalView};
 use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
+use crate::render::Renderable;
+use std::cell::RefCell;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub struct Zen<'a> {
+    state: &'a AppState,
+}
+
+impl<'a> Zen<'a> {
+    pub fn new(state: &'a AppState) -> Self {
+        Self { state }
+    }
+}
+
+impl<'a> Renderable for Zen<'a> {
+    fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
+        render_zen_journal_impl(f, area, self.state);
+    }
+}
+
 pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    Zen::new(state).draw(f, area);
+}
+
+fn render_zen_journal_impl<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     use ratatui::text::{Line, Span};
     let mut style = style_for_mode(&state.mode);
     if let ZenTheme::DarkGray = state.zen_theme {

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -11,8 +11,31 @@ use crate::beamx::{render_full_border, style_for_mode};
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::collections::HashMap;
+use crate::render::Renderable;
+use std::cell::RefCell;
+
+pub struct GemX<'a> {
+    state: RefCell<&'a mut AppState>,
+}
+
+impl<'a> GemX<'a> {
+    pub fn new(state: &'a mut AppState) -> Self {
+        Self { state: RefCell::new(state) }
+    }
+}
+
+impl<'a> Renderable for GemX<'a> {
+    fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
+        let mut state = self.state.borrow_mut();
+        gemx_impl(f, area, &mut *state);
+    }
+}
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
+    GemX::new(state).draw(f, area);
+}
+
+fn gemx_impl<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let style = style_for_mode(&state.mode);
     let block = Block::default()
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })


### PR DESCRIPTION
## Summary
- add a `Renderable` trait for polymorphic drawing
- implement `Renderable` for GemX, Zen and Spotlight
- expose trait from `render` module

## Testing
- `cargo test --test golden -- render_gemx_snapshot::gemx_renders_correctly --quiet` *(fails: assertion `left == right` failed)*