### PR TITLE
Patch 25.51u-n – Modularize Layout Logic

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -135,7 +135,7 @@ pub fn drag_update(state: &mut AppState, x: u16, y: u16) {
 pub fn end_drag(state: &mut AppState) {
     state.dragging = None;
     state.last_mouse = None;
-    state.recalculate_roles();
+    crate::layout::roles::recalculate_roles(state);
 }
 
 /// Drag a node and its children recursively.

--- a/src/layout/fallback.rs
+++ b/src/layout/fallback.rs
@@ -1,0 +1,64 @@
+use std::collections::{HashMap, HashSet};
+use crate::state::AppState;
+use crate::node::NodeID;
+use crate::layout::{Coords, LayoutRole, GEMX_HEADER_HEIGHT};
+
+/// Promote unreachable nodes to root positions when auto-arrange is enabled.
+/// This helps recover nodes that would otherwise be lost off-screen.
+#[allow(clippy::too_many_arguments)]
+pub fn promote_unreachable(
+    state: &mut AppState,
+    reachable_ids: &HashSet<NodeID>,
+    drawn_at: &mut HashMap<NodeID, Coords>,
+    node_roles: &mut HashMap<NodeID, LayoutRole>,
+    area_height: i16,
+) {
+    let node_ids: Vec<NodeID> = state.nodes.keys().copied().collect();
+    for id in node_ids {
+        if state.fallback_this_frame {
+            continue;
+        }
+        let node = match state.nodes.get(&id) {
+            Some(n) => n,
+            None => continue,
+        };
+        if state.root_nodes.contains(&id)
+            || drawn_at.contains_key(&id)
+            || reachable_ids.contains(&id)
+            || state.fallback_promoted_this_session.contains(&id)
+        {
+            continue;
+        }
+        if node.children.is_empty() {
+            continue;
+        }
+
+        state.root_nodes.push(id);
+        state.root_nodes.sort_unstable();
+        state.root_nodes.dedup();
+        state.fallback_this_frame = true;
+        state.fallback_promoted_this_session.insert(id);
+
+        if let Some(n) = state.nodes.get_mut(&id) {
+            if n.x == 0 && n.y == 0 {
+                n.x = state.fallback_next_x;
+                n.y = state.fallback_next_y;
+                state.fallback_next_y += 3;
+                if state.fallback_next_y > area_height - 4 {
+                    state.fallback_next_y = GEMX_HEADER_HEIGHT + 2;
+                    state.fallback_next_x += 20;
+                }
+                if state.debug_input_mode {
+                    eprintln!("\u{1F4D0} Placed Node {} at x={}, y={}", id, n.x, n.y);
+                }
+            }
+            drawn_at.insert(id, Coords { x: n.x, y: n.y });
+            node_roles.insert(id, LayoutRole::Root);
+        } else {
+            eprintln!("❌ Fallback failed: Node {} not found.", id);
+        }
+
+        crate::log_debug!(state, "\u{26a0} Promoted Node {} to root (label-safe)", id);
+        break;
+    }
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,6 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use crate::node::{NodeID, NodeMap};
 
+pub mod roles;
+pub mod fallback;
+
+pub use roles::recalculate_roles;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Coords {
     pub x: i16,

--- a/src/layout/roles.rs
+++ b/src/layout/roles.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+use crate::node::NodeID;
+use crate::state::AppState;
+use crate::layout::{LayoutRole, CHILD_SPACING_Y};
+
+/// Recalculate parent/child relationships based on node positions.
+/// Nodes directly beneath another (±1 cell) become children of that node.
+/// Nodes on the same row become siblings if that row already has a parent.
+/// Otherwise the node is considered free/root.
+pub fn recalculate_roles(state: &mut AppState) {
+    state.clear_fallback_promotions();
+    state.layout_roles.clear();
+
+    let ids: Vec<NodeID> = state.nodes.keys().copied().collect();
+
+    // Clear current structure
+    for node in state.nodes.values_mut() {
+        node.children.clear();
+        node.parent = None;
+    }
+    state.root_nodes.clear();
+
+    // Pass 1: detect direct parent above
+    let mut new_parents: HashMap<NodeID, Option<NodeID>> = HashMap::new();
+    for &id in &ids {
+        let (x, y) = {
+            let n = &state.nodes[&id];
+            (n.x, n.y)
+        };
+        let mut parent_id = None;
+        for &other in &ids {
+            if other == id {
+                continue;
+            }
+            let op = &state.nodes[&other];
+            if y > op.y && (y - op.y) <= CHILD_SPACING_Y + 1 && (x - op.x).abs() <= 1 {
+                parent_id = Some(other);
+                break;
+            }
+        }
+        new_parents.insert(id, parent_id);
+    }
+
+    // Pass 2: siblings on same row inherit existing parent
+    for &id in &ids {
+        if new_parents[&id].is_some() {
+            continue;
+        }
+        let y = state.nodes[&id].y;
+        for &other in &ids {
+            if other == id {
+                continue;
+            }
+            if (state.nodes[&other].y - y).abs() <= 1 {
+                if let Some(pid) = new_parents[&other] {
+                    new_parents.insert(id, Some(pid));
+                    break;
+                }
+            }
+        }
+    }
+
+    // Apply structure and lock child positions
+    for &id in &ids {
+        if let Some(parent_id) = new_parents[&id] {
+            if parent_id == id {
+                continue;
+            }
+            crate::log_debug!(state, "Assigning parent {:?} \u{2192} {}", parent_id, id);
+            let (px, py) = {
+                let p = &state.nodes[&parent_id];
+                (p.x, p.y)
+            };
+            if let Some(node) = state.nodes.get_mut(&id) {
+                node.parent = Some(parent_id);
+                node.x = px;
+                node.y = py + CHILD_SPACING_Y;
+            }
+            if let Some(parent) = state.nodes.get_mut(&parent_id) {
+                parent.children.push(id);
+            }
+        } else {
+            if let Some(node) = state.nodes.get_mut(&id) {
+                node.parent = None;
+            }
+            state.root_nodes.push(id);
+        }
+    }
+
+    // Deduplicate lists
+    state.root_nodes.sort_unstable();
+    state.root_nodes.dedup();
+    for node in state.nodes.values_mut() {
+        node.children.sort_unstable();
+        node.children.dedup();
+    }
+
+    for &id in &state.root_nodes {
+        state.layout_roles.insert(id, LayoutRole::Root);
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -466,7 +466,7 @@ impl AppState {
         if !self.auto_arrange {
             self.ensure_grid_positions();
         }
-        self.recalculate_roles();
+        crate::layout::roles::recalculate_roles(self);
         self.ensure_valid_roots();
     }
 
@@ -509,7 +509,7 @@ impl AppState {
         if !self.auto_arrange {
             self.ensure_grid_positions();
         }
-        self.recalculate_roles();
+        crate::layout::roles::recalculate_roles(self);
         self.ensure_valid_roots();
     }
 
@@ -653,7 +653,7 @@ impl AppState {
         self.nodes.insert(new_id, node);
         self.root_nodes.push(new_id);
         self.set_selected(Some(new_id));
-        self.recalculate_roles();
+        crate::layout::roles::recalculate_roles(self);
     }
 
     pub fn drill_down(&mut self) {
@@ -849,7 +849,7 @@ impl AppState {
             self.nodes = prev.nodes;
             self.root_nodes = prev.root_nodes;
             self.selected = prev.selected;
-            self.recalculate_roles();
+            crate::layout::roles::recalculate_roles(self);
             self.ensure_valid_roots();
         }
     }
@@ -866,7 +866,7 @@ impl AppState {
             self.nodes = next.nodes;
             self.root_nodes = next.root_nodes;
             self.selected = next.selected;
-            self.recalculate_roles();
+            crate::layout::roles::recalculate_roles(self);
             self.ensure_valid_roots();
         }
     }
@@ -1064,107 +1064,6 @@ impl AppState {
         }
     }
 
-    /// Recalculate parent/child relationships based on node positions.
-    /// Nodes directly beneath another (±1 cell) become children of that node.
-    /// Nodes on the same row become siblings if that row already has a parent.
-    /// Otherwise the node is considered free/root.
-    pub fn recalculate_roles(&mut self) {
-        use std::collections::HashMap;
-
-        self.clear_fallback_promotions();
-        self.layout_roles.clear();
-
-        let ids: Vec<NodeID> = self.nodes.keys().copied().collect();
-
-        // Clear current structure
-        for node in self.nodes.values_mut() {
-            node.children.clear();
-            node.parent = None;
-        }
-        self.root_nodes.clear();
-
-        // Pass 1: detect direct parent above
-        let mut new_parents: HashMap<NodeID, Option<NodeID>> = HashMap::new();
-        for &id in &ids {
-            let (x, y) = {
-                let n = &self.nodes[&id];
-                (n.x, n.y)
-            };
-            let mut parent_id = None;
-            for &other in &ids {
-                if other == id {
-                    continue;
-                }
-                let op = &self.nodes[&other];
-                if y > op.y
-                    && (y - op.y) <= crate::layout::CHILD_SPACING_Y + 1
-                    && (x - op.x).abs() <= 1
-                {
-                    parent_id = Some(other);
-                    break;
-                }
-            }
-            new_parents.insert(id, parent_id);
-        }
-
-        // Pass 2: siblings on same row inherit existing parent
-        for &id in &ids {
-            if new_parents[&id].is_some() {
-                continue;
-            }
-            let y = self.nodes[&id].y;
-            for &other in &ids {
-                if other == id {
-                    continue;
-                }
-                if (self.nodes[&other].y - y).abs() <= 1 {
-                    if let Some(pid) = new_parents[&other] {
-                        new_parents.insert(id, Some(pid));
-                        break;
-                    }
-                }
-            }
-        }
-
-        // Apply structure and lock child positions
-        for &id in &ids {
-            if let Some(parent_id) = new_parents[&id] {
-                if parent_id == id {
-                    continue;
-                }
-                crate::log_debug!(self, "Assigning parent {:?} \u{2192} {}", parent_id, id);
-                let (px, py) = {
-                    let p = &self.nodes[&parent_id];
-                    (p.x, p.y)
-                };
-                if let Some(node) = self.nodes.get_mut(&id) {
-                    node.parent = Some(parent_id);
-                    node.x = px;
-                    node.y = py + crate::layout::CHILD_SPACING_Y;
-                }
-                if let Some(parent) = self.nodes.get_mut(&parent_id) {
-                    parent.children.push(id);
-                }
-            } else {
-                if let Some(node) = self.nodes.get_mut(&id) {
-                    node.parent = None;
-                }
-                self.root_nodes.push(id);
-            }
-        }
-
-        // Deduplicate lists
-        self.root_nodes.sort_unstable();
-        self.root_nodes.dedup();
-        for node in self.nodes.values_mut() {
-            node.children.sort_unstable();
-            node.children.dedup();
-        }
-
-        for &id in &self.root_nodes {
-            self.layout_roles.insert(id, LayoutRole::Root);
-        }
-    }
 }
 
 // Outside impl block:


### PR DESCRIPTION
## Summary
- restructure `layout` module as a directory
- add `layout::roles` and `layout::fallback` helpers
- move `recalculate_roles` out of `AppState`
- update screen and interaction code to call new helpers

## Testing
- `cargo test --quiet` *(fails: render_gemx_snapshot::gemx_renders_correctly)*