### PR TITLE
Fix clipping around status bar

### DIFF
--- a/src/render/favorites.rs
+++ b/src/render/favorites.rs
@@ -30,7 +30,8 @@ pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &m
 
     if horizontal {
         let x = area.x + 1;
-        let y = area.height.saturating_sub(height + 3);
+        // shift dock up slightly so icons never overlap the status bar
+        let y = area.height.saturating_sub(height + 4);
 
         let border = Block::default().borders(Borders::ALL).style(base_style);
         f.render_widget(border, Rect::new(x - 1, y - 1, width, height));
@@ -45,7 +46,8 @@ pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &m
         if favorites.is_empty() {
             return;
         }
-        let base_y = area.height.saturating_sub(favorites.len() as u16 + 2);
+        // leave extra padding above the footer
+        let base_y = area.height.saturating_sub(favorites.len() as u16 + 3);
         f.render_widget(Paragraph::new("\\__").style(base_style), Rect::new(0, base_y - 1, 3, 1));
         for (i, entry) in favorites.iter().enumerate() {
             let gy = base_y + i as u16;

--- a/src/render/module_switcher.rs
+++ b/src/render/module_switcher.rs
@@ -43,7 +43,9 @@ pub fn render_module_switcher<B: Backend>(f: &mut Frame<B>, area: Rect, index: u
         .saturating_add(4);
 
     let width = content_width.min(area.width);
-    let height = lines.len() as u16 + 2;
+    let mut height = lines.len() as u16 + 2;
+    // Keep overlay above the status bar
+    height = height.min(area.height.saturating_sub(1));
 
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;

--- a/src/render/shortcuts_overlay.rs
+++ b/src/render/shortcuts_overlay.rs
@@ -16,5 +16,6 @@ pub fn render_shortcuts_overlay<B: Backend>(f: &mut Frame<B>, area: Rect) {
     let content = Paragraph::new(keys.join("\n"))
         .block(Block::default().title("Shortcuts").borders(Borders::ALL));
 
-    f.render_widget(content, Rect::new(area.x + 1, area.y + 1, area.width - 2, area.height - 2));
+    let inner_height = area.height.saturating_sub(3);
+    f.render_widget(content, Rect::new(area.x + 1, area.y + 1, area.width - 2, inner_height));
 }

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -17,7 +17,9 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let y_offset = area.y + area.height / 3;
 
     let preview = command_preview(input);
-    let height = if preview.is_some() { 4 } else { 3 };
+    let mut height = if preview.is_some() { 4 } else { 3 };
+    // Ensure Spotlight stays above the status bar
+    height = height.min(area.height.saturating_sub(1));
     let spotlight_area = Rect::new(x_offset, y_offset, width, height);
 
     let arrow = if state.spotlight_just_opened {
@@ -68,6 +70,9 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let matches = command_suggestions(input);
     for (i, suggestion) in matches.iter().take(5).enumerate() {
         let y = y_offset + 2 + i as u16;
+        if y >= area.y + area.height.saturating_sub(1) {
+            break;
+        }
         let style = Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM);
         f.render_widget(
             Paragraph::new(*suggestion).style(style),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -127,7 +127,9 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppStat
         .saturating_add(4);
 
     let width = content_width.min(area.width);
-    let height = lines.len() as u16 + 2;
+    let mut height = lines.len() as u16 + 2;
+    // Clamp box height so it never overlaps the status bar
+    height = height.min(area.height.saturating_sub(1));
 
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;


### PR DESCRIPTION
## Summary
- clamp Settings height against remaining screen area
- keep module switcher above the footer
- prevent Spotlight suggestions and panel from touching the last row
- adjust shortcuts overlay height
- move favorites dock icons up

## Testing
- `cargo test` *(fails: render_gemx_snapshot::gemx_renders_correctly)*