### PR TITLE
Implement view-aware cluster layout

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -101,11 +101,18 @@ impl PackRegion {
         let row_padding = CHILD_SPACING_Y * 2;
         let (w, h) = size;
         if self.x + w + margin > self.max_width {
+            tracing::debug!(
+                "wrap pack column x={} size={:?} max_width={}",
+                self.x,
+                size,
+                self.max_width
+            );
             self.x = 0;
             self.y += self.max_height + row_padding;
             self.max_height = 0;
         }
         let anchor = (self.x, self.y);
+        tracing::debug!("pack insert size {:?} at {:?}", size, anchor);
         self.x += w + margin;
         if h > self.max_height {
             self.max_height = h;

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -3,7 +3,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use crate::layout::{
     layout_nodes, Coords, LayoutRole, PackRegion, GEMX_HEADER_HEIGHT,
     CHILD_SPACING_Y, subtree_span, subtree_depth, spacing_for_zoom,
-    BASE_SPACING_X, BASE_SPACING_Y, SIBLING_SPACING_X, SNAP_GRID_X, SNAP_GRID_Y,
+    BASE_SPACING_X, BASE_SPACING_Y, SNAP_GRID_X, SNAP_GRID_Y,
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
@@ -73,7 +73,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     let mut drawn_at = HashMap::new();
     let mut node_roles = HashMap::new();
     if state.auto_arrange {
-        let mut pack = PackRegion::new(i16::MAX, GEMX_HEADER_HEIGHT);
+        let mut pack = PackRegion::new(area.width as i16, GEMX_HEADER_HEIGHT);
         for &root_id in &roots {
             let w = subtree_span(&state.nodes, root_id);
             let h = subtree_depth(&state.nodes, root_id) * CHILD_SPACING_Y + 1;


### PR DESCRIPTION
## Summary
- extend PackRegion to log column wraps and placement
- pack root nodes using the frame width

## Testing
- `cargo test --quiet`
- `bash patches/patch-25.51u-o-view-aware-layout/test_plan.sh`