### PR TITLE
Patch 25.51u-s: disable drag while auto arrange

### DIFF
--- a/patches/patch-25.51u-s-auto-arrange-drag-lockout/CODE_CHANGES.md
+++ b/patches/patch-25.51u-s-auto-arrange-drag-lockout/CODE_CHANGES.md
@@ -1,0 +1,8 @@
+## Code Changes
+
+### 1. `src/gemx/interaction.rs`
+- Import `std::time::Instant`
+- In `start_drag()` return early when `auto_arrange` is `true`
+  - Show status message "Drag disabled while auto-arrange is enabled"
+  - Log a debug message when in debug mode
+- In `drag_update()` skip all movement logic when `auto_arrange` is `true`

--- a/patches/patch-25.51u-s-auto-arrange-drag-lockout/DESCRIPTION.md
+++ b/patches/patch-25.51u-s-auto-arrange-drag-lockout/DESCRIPTION.md
@@ -1,0 +1,6 @@
+# Patch 25.51u-s – Auto-Arrange Drag Lockout
+
+## Goals
+- Prevent users from dragging nodes while auto-arrange mode is active
+- Avoid layout corruption or flicker from unintended moves
+- Provide a small notice when dragging is disabled

--- a/patches/patch-25.51u-s-auto-arrange-drag-lockout/test_plan.sh
+++ b/patches/patch-25.51u-s-auto-arrange-drag-lockout/test_plan.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+Patch 25.51u-s Test Plan
+
+# Ensure drag handler skips when auto-arrange is active
+grep -q "Drag disabled while auto-arrange is enabled" src/gemx/interaction.rs && echo "✅ status message added"
+grep -q "auto_arrange" -n src/gemx/interaction.rs | head

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -7,6 +7,7 @@ use crate::layout::{
 };
 use crossterm::terminal;
 use std::collections::HashMap;
+use std::time::Instant;
 
 /// Toggle snap-to-grid mode
 pub fn toggle_snap(state: &mut AppState) {
@@ -108,6 +109,12 @@ pub fn node_at_position(state: &AppState, x: u16, y: u16) -> Option<NodeID> {
 
 /// Begin dragging the specified node from mouse coords.
 pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
+    if state.auto_arrange {
+        state.status_message = "Drag disabled while auto-arrange is enabled".into();
+        state.status_message_last_updated = Some(Instant::now());
+        crate::log_debug!(state, "drag attempt blocked: auto-arrange active");
+        return;
+    }
     state.dragging = Some(id);
     let zoom = state.zoom_scale as f32;
     let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
@@ -119,6 +126,9 @@ pub fn start_drag(state: &mut AppState, id: NodeID, x: u16, y: u16) {
 
 /// Update dragging node position based on new mouse coords.
 pub fn drag_update(state: &mut AppState, x: u16, y: u16) {
+    if state.auto_arrange {
+        return;
+    }
     let zoom = state.zoom_scale as f32;
     let (bsx, bsy) = spacing_for_zoom(state.zoom_scale);
     let wx = (state.scroll_x as f32 + (x as f32 / (bsx as f32 * zoom))).round() as i16;


### PR DESCRIPTION
## Summary
- block dragging when auto-arrange mode is on
- show status message and debug log when drag is blocked
- document Auto-Arrange Drag Lockout patch

## Testing
- `cargo test`