### PR TITLE
Patch 25.51u-q Drag Safety & Link Guard

### DIFF
--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -23,6 +23,7 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("open_module_switcher".into(), "ctrl-space" .into());
     map.insert("start_drag".into(), "ctrl-r".into());
     map.insert("start_link".into(), "ctrl-l".into());
+    map.insert("toggle_link_mode".into(), "ctrl-b".into());
     map.insert("redo".into(), "ctrl-shift-z".into());
     map.insert("toggle_snap_grid".into(), "ctrl-g".into());
     map.insert("zen_toggle_theme".into(), "ctrl-a".into());

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -104,6 +104,7 @@ pub struct AppState {
     pub snap_to_grid: bool,
     pub drawing_root: Option<NodeID>,
     pub dragging: Option<NodeID>,
+    pub link_mode: bool,
     pub last_mouse: Option<(i16, i16)>,
     pub fallback_this_frame: bool,
     pub fallback_promoted_this_session: HashSet<NodeID>,
@@ -186,6 +187,7 @@ impl Default for AppState {
             snap_to_grid: false,
             drawing_root: None,
             dragging: None,
+            link_mode: false,
             last_mouse: None,
             fallback_this_frame: false,
             fallback_promoted_this_session: HashSet::new(),
@@ -983,9 +985,16 @@ impl AppState {
 
     pub fn start_drag(&mut self) {
         self.selected_drag_source = self.selected;
+        self.link_mode = true;
     }
 
     pub fn complete_drag(&mut self, target_id: NodeID) {
+        if !self.link_mode {
+            tracing::debug!("drag complete attempted without link_mode");
+            self.selected_drag_source = None;
+            return;
+        }
+        self.link_mode = false;
         if let Some(source_id) = self.selected_drag_source.take() {
             if source_id == target_id {
                 return; // prevent self-parenting

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -318,6 +318,9 @@ pub fn launch_ui() -> std::io::Result<()> {
                     } else {
                         state.start_link();
                     }
+                } else if match_hotkey("toggle_link_mode", code, modifiers, &state) {
+                    state.link_mode = !state.link_mode;
+                    crate::log_debug!(state, "link_mode toggled: {}", state.link_mode);
                 } else if match_hotkey("save", code, modifiers, &state) {
                     state.export_zen_to_file();
                 } else if match_hotkey("mode_zen", code, modifiers, &state) {


### PR DESCRIPTION
## Summary
- add `link_mode` flag to prevent accidental link mutations
- log and skip mouse drags on child nodes unless link mode is enabled
- toggle link mode via new `Ctrl+B` hotkey
- guard keyboard drag completion behind link mode

## Testing
- `cargo test --locked`