### PR TITLE
Free node placement respects screen

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -26,13 +26,35 @@ pub fn spawn_free_node(state: &mut AppState) {
     let mut node = Node::new(new_id, "Free Node", None);
 
     if !state.auto_arrange {
-        let index = state.root_nodes.len();
-        let (tw, _) = terminal::size().unwrap_or((80, 20));
-        let margin = SIBLING_SPACING_X * 2;
-        let row_pad = CHILD_SPACING_Y * 2;
-        let cols = (tw as i16 / margin.max(1)).max(1) as usize;
-        node.x = ((index % cols) as i16) * margin + 1;
-        node.y = ((index / cols) as i16) * row_pad + GEMX_HEADER_HEIGHT + 1;
+        use std::collections::HashSet;
+
+        let (tw, th) = terminal::size().unwrap_or((80, 20));
+        let used: HashSet<(i16, i16)> =
+            state.nodes.values().map(|n| (n.x, n.y)).collect();
+
+        let base_x = 6;
+        let base_y = GEMX_HEADER_HEIGHT + 1;
+        let step_x = SIBLING_SPACING_X * 2;
+        let step_y = CHILD_SPACING_Y * 2;
+
+        let mut x = base_x;
+        let mut y = base_y;
+        let max_y = th as i16 - 2;
+        let max_x = tw as i16 - 4;
+
+        while used.contains(&(x, y)) {
+            y += step_y;
+            if y > max_y {
+                y = base_y;
+                x += step_x;
+                if x > max_x {
+                    x = base_x;
+                }
+            }
+        }
+
+        node.x = x;
+        node.y = y;
     }
 
     crate::log_debug!(
@@ -44,6 +66,9 @@ pub fn spawn_free_node(state: &mut AppState) {
         node.x,
         node.y
     );
+    if state.debug_input_mode {
+        eprintln!("📦 Free node {} at x={}, y={}", new_id, node.x, node.y);
+    }
 
     state.nodes.insert(new_id, node);
     state.root_nodes.push(new_id);

--- a/src/layout/fallback.rs
+++ b/src/layout/fallback.rs
@@ -39,15 +39,36 @@ pub fn promote_unreachable(
         state.fallback_this_frame = true;
         state.fallback_promoted_this_session.insert(id);
 
+        use std::collections::HashSet;
+        let filled: HashSet<(i16, i16)> =
+            state.nodes.values().map(|n| (n.x, n.y)).collect();
+
         if let Some(n) = state.nodes.get_mut(&id) {
             if n.x == 0 && n.y == 0 {
-                n.x = state.fallback_next_x;
-                n.y = state.fallback_next_y;
-                state.fallback_next_y += 3;
-                if state.fallback_next_y > area_height - 4 {
-                    state.fallback_next_y = GEMX_HEADER_HEIGHT + 2;
-                    state.fallback_next_x += 20;
+
+                let step_x = 20;
+                let step_y = 3;
+                let base_y = GEMX_HEADER_HEIGHT + 2;
+                let max_y = area_height - 4;
+                let mut x = state.fallback_next_x;
+                let mut y = state.fallback_next_y;
+
+                while filled.contains(&(x, y)) {
+                    if state.debug_input_mode {
+                        eprintln!("↪ collision at {},{}", x, y);
+                    }
+                    y += step_y;
+                    if y > max_y {
+                        y = base_y;
+                        x += step_x;
+                    }
                 }
+
+                n.x = x;
+                n.y = y;
+                state.fallback_next_x = x;
+                state.fallback_next_y = y + step_y;
+
                 if state.debug_input_mode {
                     eprintln!("\u{1F4D0} Placed Node {} at x={}, y={}", id, n.x, n.y);
                 }

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -186,19 +186,40 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             state.fallback_this_frame = true;
             state.fallback_promoted_this_session.insert(id);
 
+            use std::collections::HashSet;
+            let filled: HashSet<(i16, i16)> =
+                state.nodes.values().map(|n| (n.x, n.y)).collect();
+
             let Some(n) = state.nodes.get_mut(&id) else {
                 crate::log_debug!(state, "❌ Fallback failed: Node {} not found.", id);
                 return;
             };
 
             if n.x == 0 && n.y == 0 {
-                n.x = state.fallback_next_x;
-                n.y = state.fallback_next_y;
-                state.fallback_next_y += 3;
-                if state.fallback_next_y > area.height as i16 - 4 {
-                    state.fallback_next_y = GEMX_HEADER_HEIGHT + 2;
-                    state.fallback_next_x += 20;
+
+                let step_x = 20;
+                let step_y = 3;
+                let base_y = GEMX_HEADER_HEIGHT + 2;
+                let max_y = area.height as i16 - 4;
+                let mut x = state.fallback_next_x;
+                let mut y = state.fallback_next_y;
+
+                while filled.contains(&(x, y)) {
+                    if state.debug_input_mode {
+                        crate::log_debug!(state, "↪ collision at {},{}", x, y);
+                    }
+                    y += step_y;
+                    if y > max_y {
+                        y = base_y;
+                        x += step_x;
+                    }
                 }
+
+                n.x = x;
+                n.y = y;
+                state.fallback_next_x = x;
+                state.fallback_next_y = y + step_y;
+
                 crate::log_debug!(state, "📦 Placed Node {} at x={}, y={}", id, n.x, n.y);
             }
 


### PR DESCRIPTION
## Summary
- improve grid search for spawn_free_node
- avoid overlapping coords when enforcing manual layout grid
- track filled coordinates when falling back during render
- log coordinates for fallback recovery

## Testing
- `cargo test` *(fails: tests hang)*