### PR TITLE
Patch 25.53q: spotlight animation redesign

### DIFF
--- a/patches/patch-25.53q-spotlight-animation/CODE_CHANGES.md
+++ b/patches/patch-25.53q-spotlight-animation/CODE_CHANGES.md
@@ -1,0 +1,6 @@
+## Code Changes
+
+- Removed arrow-based bounce animation in `render_spotlight`
+- Added scale-in calculation using `spotlight_animation_frame`
+- Spotlight width grows from 90% → 100% over three frames
+- Title now static; border color pulse remains

--- a/patches/patch-25.53q-spotlight-animation/DESCRIPTION.md
+++ b/patches/patch-25.53q-spotlight-animation/DESCRIPTION.md
@@ -1,0 +1,3 @@
+# Patch 25.53q – Spotlight Animation Redesign
+
+Smooth the Spotlight panel entrance with a short scale-in rather than the old bouncing arrow. The effect should start slightly smaller and settle at full size without overshoot or lateral motion.

--- a/patches/patch-25.53q-spotlight-animation/test_plan.sh
+++ b/patches/patch-25.53q-spotlight-animation/test_plan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Patch 25.53q Test Plan
+
+cargo test

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -12,7 +12,18 @@ use crate::spotlight::{command_preview, command_suggestions};
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;
-    let width = area.width.min(60);
+    let base_width = area.width.min(60);
+    let scale = if state.spotlight_just_opened {
+        match state.spotlight_animation_frame {
+            0 => 0.90,
+            1 => 0.97,
+            _ => 1.0,
+        }
+    } else {
+        1.0
+    };
+    let width = ((base_width as f32) * scale) as u16;
+    let width = width.max(3).min(base_width);
     let x_offset = area.x + (area.width.saturating_sub(width)) / 2;
     let y_offset = area.y + area.height / 3;
 
@@ -21,17 +32,6 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     // Ensure Spotlight stays above the status bar
     height = height.min(area.height.saturating_sub(1));
     let spotlight_area = Rect::new(x_offset, y_offset, width, height);
-
-    let arrow = if state.spotlight_just_opened {
-        match state.spotlight_animation_frame {
-            0 => "→ ",
-            1 => "→ → ",
-            2 => "→ → → ",
-            _ => "",
-        }
-    } else {
-        ""
-    };
 
     let border_color = if state.spotlight_just_opened {
         match state.spotlight_animation_frame {
@@ -44,7 +44,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     };
 
     let block = Block::default()
-        .title(format!("{}Spotlight", arrow))
+        .title("Spotlight")
         .borders(Borders::ALL)
         .style(Style::default().fg(border_color));
 


### PR DESCRIPTION
## Summary
- redesign Spotlight entrance animation
- grow Spotlight panel from 90% width to 100% with a calm ease-out
- document patch 25.53q

## Testing
- `cargo test`
