### PR TITLE
Patch 25.53o - Spotlight background fix

### DIFF
--- a/patches/patch-25.53o-spotlight-background-block/CODE_CHANGES.md
+++ b/patches/patch-25.53o-spotlight-background-block/CODE_CHANGES.md
@@ -1,0 +1,6 @@
+## Code Changes
+
+- Draw a Clear widget and solid Block behind the Spotlight panel
+- Render input line, preview, and suggestions with `bg(Color::Black)`
+- Remove dim styling so text is fully opaque
+- Reorder render calls so Spotlight draws last

--- a/patches/patch-25.53o-spotlight-background-block/DESCRIPTION.md
+++ b/patches/patch-25.53o-spotlight-background-block/DESCRIPTION.md
@@ -1,0 +1,3 @@
+# Patch 25.53o – Spotlight Render Fix: Full Background Block
+
+Fix the Spotlight UI to prevent text and nodes from appearing behind it.

--- a/patches/patch-25.53o-spotlight-background-block/test_plan.sh
+++ b/patches/patch-25.53o-spotlight-background-block/test_plan.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Patch 25.53o Test Plan: Spotlight Render Fix
+
+echo "Manual: activate Spotlight over text. Ensure no background bleedthrough." 

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, Clear},
     Frame,
 };
 
@@ -17,9 +17,12 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let y_offset = area.y + area.height / 3;
 
     let preview = command_preview(input);
+    let matches = command_suggestions(input);
     let mut height = if preview.is_some() { 4 } else { 3 };
     // Ensure Spotlight stays above the status bar
     height = height.min(area.height.saturating_sub(1));
+    let suggestion_count = matches.len().min(5) as u16;
+    let total_height = height + suggestion_count;
     let spotlight_area = Rect::new(x_offset, y_offset, width, height);
 
     let arrow = if state.spotlight_just_opened {
@@ -46,17 +49,25 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let block = Block::default()
         .title(format!("{}Spotlight", arrow))
         .borders(Borders::ALL)
-        .style(Style::default().fg(border_color));
+        .style(Style::default().fg(border_color).bg(Color::Black));
 
-    let mut lines = vec![Line::styled(format!("> {}", input), Style::default().fg(Color::White))];
+    let mut lines = vec![
+        Line::styled(
+            format!("> {}", input),
+            Style::default().fg(Color::White).bg(Color::Black),
+        ),
+    ];
     if let Some((msg, known)) = preview {
         if known {
             lines.push(Line::from(vec![
-                Span::styled("→ ", Style::default().fg(Color::Cyan)),
-                Span::styled(msg, Style::default().fg(Color::White)),
+                Span::styled(
+                    "→ ",
+                    Style::default().fg(Color::Cyan).bg(Color::Black),
+                ),
+                Span::styled(msg, Style::default().fg(Color::White).bg(Color::Black)),
             ]));
         } else {
-            let style = Style::default().fg(Color::Red).add_modifier(Modifier::DIM);
+            let style = Style::default().fg(Color::Red).bg(Color::Black);
             lines.push(Line::from(vec![
                 Span::styled("⚠ ", style),
                 Span::styled(msg, style),
@@ -65,15 +76,21 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     }
 
     let paragraph = Paragraph::new(lines).block(block);
+    let bg_rect = Rect::new(x_offset, y_offset, width, total_height);
+
+    f.render_widget(Clear, bg_rect);
+    f.render_widget(
+        Block::default().style(Style::default().bg(Color::Black)),
+        bg_rect,
+    );
     f.render_widget(paragraph, spotlight_area);
 
-    let matches = command_suggestions(input);
     for (i, suggestion) in matches.iter().take(5).enumerate() {
         let y = y_offset + 2 + i as u16;
         if y >= area.y + area.height.saturating_sub(1) {
             break;
         }
-        let style = Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM);
+        let style = Style::default().fg(Color::Cyan).bg(Color::Black);
         f.render_widget(
             Paragraph::new(*suggestion).style(style),
             Rect::new(x_offset, y, width, 1),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -69,16 +69,16 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
             }
         }
 
-        if state.show_spotlight {
-            render_spotlight(f, vertical[0], state);
-        }
-
         if state.show_keymap && layout_chunks.len() > 1 {
             render_shortcuts_overlay(f, layout_chunks[1]);
         }
 
         if state.module_switcher_open {
             render_module_switcher(f, vertical[0], state.module_switcher_index);
+        }
+
+        if state.show_spotlight {
+            render_spotlight(f, vertical[0], state);
         }
 
         if let Some(last) = state.status_message_last_updated {


### PR DESCRIPTION
## Summary
- render opaque background for Spotlight
- ensure Spotlight text uses full contrast
- reorder overlay draw order so Spotlight appears on top
- add patch docs for 25.53o

## Testing
- `cargo test`