### PR TITLE
Patch 25.53p command module clarity fix

### DIFF
--- a/patches/patch-25.53p-command-module-clarity-fix/CODE_CHANGES.md
+++ b/patches/patch-25.53p-command-module-clarity-fix/CODE_CHANGES.md
@@ -1,0 +1,11 @@
+## Code Changes
+
+### 1. Spotlight Background Clearing
+- Added `Clear` widget in `render_spotlight` to clear the drawing area so
+  background panels cannot bleed through.
+
+### 2. Solid Styling
+- Spotlight block, input line, preview text and suggestions now render with
+  `bg(Color::Black)` for full opacity.
+- Removed dim styling from suggestions and warnings.
+- Input line uses `Modifier::BOLD` for easier reading.

--- a/patches/patch-25.53p-command-module-clarity-fix/DESCRIPTION.md
+++ b/patches/patch-25.53p-command-module-clarity-fix/DESCRIPTION.md
@@ -1,0 +1,7 @@
+# Patch 25.53p – Command Module Clarity Fix
+
+Improve visibility and contrast of the Spotlight command module:
+
+- Prevent background content from showing through the input field
+- Ensure the command box and preview use a solid background
+- Use bolder text with higher contrast for legibility

--- a/patches/patch-25.53p-command-module-clarity-fix/test_plan.sh
+++ b/patches/patch-25.53p-command-module-clarity-fix/test_plan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Patch 25.53p Test Plan
+
+cargo test --locked

--- a/src/render/spotlight.rs
+++ b/src/render/spotlight.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, Clear},
     Frame,
 };
 
@@ -46,17 +46,31 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let block = Block::default()
         .title(format!("{}Spotlight", arrow))
         .borders(Borders::ALL)
-        .style(Style::default().fg(border_color));
+        .style(Style::default().fg(border_color).bg(Color::Black));
 
-    let mut lines = vec![Line::styled(format!("> {}", input), Style::default().fg(Color::White))];
+    let mut lines = vec![
+        Line::styled(
+            format!("> {}", input),
+            Style::default()
+                .fg(Color::White)
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
     if let Some((msg, known)) = preview {
         if known {
             lines.push(Line::from(vec![
-                Span::styled("→ ", Style::default().fg(Color::Cyan)),
-                Span::styled(msg, Style::default().fg(Color::White)),
+                Span::styled(
+                    "→ ",
+                    Style::default().fg(Color::Cyan).bg(Color::Black),
+                ),
+                Span::styled(
+                    msg,
+                    Style::default().fg(Color::White).bg(Color::Black),
+                ),
             ]));
         } else {
-            let style = Style::default().fg(Color::Red).add_modifier(Modifier::DIM);
+            let style = Style::default().fg(Color::Red).bg(Color::Black);
             lines.push(Line::from(vec![
                 Span::styled("⚠ ", style),
                 Span::styled(msg, style),
@@ -65,6 +79,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     }
 
     let paragraph = Paragraph::new(lines).block(block);
+    f.render_widget(Clear, spotlight_area);
     f.render_widget(paragraph, spotlight_area);
 
     let matches = command_suggestions(input);
@@ -73,7 +88,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         if y >= area.y + area.height.saturating_sub(1) {
             break;
         }
-        let style = Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM);
+        let style = Style::default().fg(Color::Cyan).bg(Color::Black);
         f.render_widget(
             Paragraph::new(*suggestion).style(style),
             Rect::new(x_offset, y, width, 1),


### PR DESCRIPTION
## Summary
- clear and style Spotlight command box to prevent background bleed
- make Spotlight text high contrast and remove dim styling
- document patch 25.53p with test plan

## Testing
- `cargo test --locked`