### PR TITLE
Patch 25.55h – BeamX Color Customization & Module Toggles

### DIFF
--- a/src/beam_color.rs
+++ b/src/beam_color.rs
@@ -1,0 +1,54 @@
+use ratatui::style::Color;
+use serde::{Serialize, Deserialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub enum BeamColor {
+    Prism,
+    Infrared,
+    Aqua,
+    Emerald,
+    Ice,
+}
+
+impl Default for BeamColor {
+    fn default() -> Self { BeamColor::Prism }
+}
+
+impl std::str::FromStr for BeamColor {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "prism" => Ok(BeamColor::Prism),
+            "infrared" => Ok(BeamColor::Infrared),
+            "aqua" => Ok(BeamColor::Aqua),
+            "emerald" => Ok(BeamColor::Emerald),
+            "ice" => Ok(BeamColor::Ice),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for BeamColor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            BeamColor::Prism => "Prism",
+            BeamColor::Infrared => "Infrared",
+            BeamColor::Aqua => "Aqua",
+            BeamColor::Emerald => "Emerald",
+            BeamColor::Ice => "Ice",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl BeamColor {
+    pub fn palette(self) -> (Color, Color, Color) {
+        match self {
+            BeamColor::Prism => (Color::Magenta, Color::Cyan, Color::White),
+            BeamColor::Infrared => (Color::Red, Color::LightRed, Color::White),
+            BeamColor::Aqua => (Color::Cyan, Color::LightCyan, Color::White),
+            BeamColor::Emerald => (Color::Green, Color::LightGreen, Color::White),
+            BeamColor::Ice => (Color::White, Color::LightBlue, Color::White),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod input;
 pub mod dashboard;
 pub mod render;
 pub mod beamx;
+pub mod beam_color;
 pub mod ui;
 pub mod gemx;
 pub mod routineforge;

--- a/src/render/favorites.rs
+++ b/src/render/favorites.rs
@@ -3,21 +3,19 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, Paragraph},
-    text::{Line, Span},
     Frame,
 };
 use crate::state::{AppState, DockLayout};
-use crate::beamx::style_for_mode;
 
 pub fn render_favorites_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     if !state.favorite_dock_enabled {
         return;
     }
 
-    let mut favorites = state.favorite_entries();
+    let favorites = state.favorite_entries();
     state.dock_entry_bounds.clear();
 
-    let theme = style_for_mode(&state.mode);
+    let theme = state.beam_style_for_mode(&state.mode);
     let base_style = Style::default().fg(theme.border_color);
 
     let horizontal = state.favorite_dock_layout == DockLayout::Horizontal;

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -1,10 +1,11 @@
 use ratatui::{backend::Backend, layout::Rect, style::Style, widgets::{Block, Borders, Paragraph}, Frame};
-use crate::beamx::{render_full_border, style_for_mode};
+use crate::beamx::render_full_border;
+use crate::state::AppState;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
-    let style = style_for_mode("triage");
+pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    let style = state.beam_style_for_mode("triage");
     let block = Block::default().title("Triage Panel").borders(Borders::NONE)
         .style(Style::default().fg(ratatui::style::Color::Red));
 
@@ -22,11 +23,15 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect) {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() / 300) as u64;
+    let mut bx_style = BeamXStyle::from(BeamXMode::Triage);
+    bx_style.border_color = style.border_color;
+    bx_style.status_color = style.status_color;
+    bx_style.prism_color = style.prism_color;
     let beamx = BeamX {
         tick,
         enabled: true,
         mode: BeamXMode::Triage,
-        style: BeamXStyle::from(BeamXMode::Triage),
+        style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,13 +1,12 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph}};
 use crate::state::{AppState, ZenSyntax, ZenTheme, ZenJournalView};
-use crate::beamx::{render_full_border, style_for_mode};
-use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
+use crate::beamx::render_full_border;
+
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
-    use ratatui::text::{Line, Span};
-    let mut style = style_for_mode(&state.mode);
+    let mut style = state.beam_style_for_mode(&state.mode);
     if let ZenTheme::DarkGray = state.zen_theme {
         style.border_color = Color::DarkGray;
     }
@@ -47,7 +46,6 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
 }
 
 fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
-    use ratatui::text::Span;
     let padding = area.width / 4;
     let usable_width = area.width - padding * 2;
     let caret = if tick % 2 == 0 { "|" } else { " " };
@@ -56,7 +54,7 @@ fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, ti
     let input_rect = Rect::new(area.x + padding, area.bottom().saturating_sub(2), usable_width, 1);
     let widget = Paragraph::new(input).block(Block::default().borders(Borders::NONE));
     f.render_widget(widget, input_rect);
-    render_full_border(f, area, &style_for_mode(&state.mode), true, false);
+    render_full_border(f, area, &state.beam_style_for_mode(&state.mode), true, false);
 }
 
 fn render_review<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -71,7 +69,7 @@ fn render_review<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         y = y.saturating_add(3);
         if y > area.bottom() { break; }
     }
-    render_full_border(f, area, &style_for_mode(&state.mode), true, false);
+    render_full_border(f, area, &state.beam_style_for_mode(&state.mode), true, false);
 }
 
 fn parse_markdown_line(input: &str) -> Line {

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     text::Line,
 };
-use crate::beamx::{render_full_border, style_for_mode};
+use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use crate::state::AppState;
 use std::io::Stdout;
@@ -15,7 +15,7 @@ type PluginFrame<'a> = Frame<'a, CrosstermBackend<Stdout>>;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn render_triage_panel(f: &mut PluginFrame<'_>, area: Rect, state: &mut AppState) {
-    let style = style_for_mode("triage");
+    let style = state.beam_style_for_mode("triage");
     let tasks = vec![
         Line::from("[ ] Design new node engine"),
         Line::from("[x] Fix dashboard overflow"),
@@ -33,11 +33,15 @@ pub fn render_triage_panel(f: &mut PluginFrame<'_>, area: Rect, state: &mut AppS
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() / 300) as u64;
+    let mut bx_style = BeamXStyle::from(BeamXMode::Triage);
+    bx_style.border_color = style.border_color;
+    bx_style.status_color = style.status_color;
+    bx_style.prism_color = style.prism_color;
     let beamx = BeamX {
         tick,
         enabled: true,
         mode: BeamXMode::Triage,
-        style: BeamXStyle::from(BeamXMode::Triage),
+        style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -7,13 +7,13 @@ use crate::layout::{
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
-use crate::beamx::{render_full_border, style_for_mode};
+use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::collections::HashMap;
 
 pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
-    let style = style_for_mode(&state.mode);
+    let style = state.beam_style_for_mode(&state.mode);
     let block = Block::default()
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })
         .borders(Borders::NONE);
@@ -428,11 +428,15 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             .unwrap_or_default()
             .as_millis() / 300) as u64
     };
+    let mut bx_style = BeamXStyle::from(BeamXMode::Default);
+    bx_style.border_color = style.border_color;
+    bx_style.status_color = style.status_color;
+    bx_style.prism_color = style.prism_color;
     let beamx = BeamX {
         tick,
         enabled: true,
         mode: BeamXMode::Default,
-        style: BeamXStyle::from(BeamXMode::Default),
+        style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,
     };
     beamx.render(f, area);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -62,7 +62,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
             "zen" => render_zen_journal(f, vertical[0], state),
             "gemx" => render_gemx(f, vertical[0], state),
             "settings" => render_settings(f, vertical[0], state),
-            "triage" => render_triage(f, vertical[0]),
+            "triage" => render_triage(f, vertical[0], state),
             _ => {
                 let fallback = Paragraph::new("Unknown mode");
                 f.render_widget(fallback, vertical[0]);
@@ -400,14 +400,14 @@ pub fn launch_ui() -> std::io::Result<()> {
                         if state.settings_focus_index > 0 {
                             state.settings_focus_index -= 1;
                         } else {
-                            state.settings_focus_index = crate::settings::SETTING_TOGGLES.len() - 1;
+                            state.settings_focus_index = crate::settings::settings_len() - 1;
                         }
                     }
                     KeyCode::Down if state.mode == "settings" => {
-                        state.settings_focus_index = (state.settings_focus_index + 1) % crate::settings::SETTING_TOGGLES.len();
+                        state.settings_focus_index = (state.settings_focus_index + 1) % crate::settings::settings_len();
                     }
                     KeyCode::Enter | KeyCode::Char(' ') if state.mode == "settings" => {
-                        let idx = state.settings_focus_index % crate::settings::SETTING_TOGGLES.len();
+                        let idx = state.settings_focus_index % crate::settings::settings_len();
                         (crate::settings::SETTING_TOGGLES[idx].toggle)(&mut state);
                     }
 


### PR DESCRIPTION
## Summary
- add BeamColor enum with new color palettes
- persist per-module BeamX color in `UserSettings` and `AppState`
- expose color toggles in settings UI and support cycling
- apply selected colors through `AppState::beam_style_for_mode`
- clean up warnings from renderers

## Testing
- `cargo check`
- `cargo test --quiet`
