### PR TITLE
Patch 25.55j – Customizable Prism Glyph Panel

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -5,3 +5,5 @@ gemx_beam_color = "Prism"
 zen_beam_color = "Aqua"
 triage_beam_color = "Aqua"
 settings_beam_color = "Aqua"
+beamx_panel_theme = "Prism"
+beamx_panel_visible = true

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -24,12 +24,13 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState)
         .unwrap_or_default()
         .as_millis() / 300) as u64;
     let mut bx_style = BeamXStyle::from(BeamXMode::Triage);
-    bx_style.border_color = style.border_color;
-    bx_style.status_color = style.status_color;
-    bx_style.prism_color = style.prism_color;
+    let (b, s, p) = state.beamx_panel_theme.palette();
+    bx_style.border_color = b;
+    bx_style.status_color = s;
+    bx_style.prism_color = p;
     let beamx = BeamX {
         tick,
-        enabled: true,
+        enabled: state.beamx_panel_visible,
         mode: BeamXMode::Triage,
         style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,

--- a/src/routineforge.rs
+++ b/src/routineforge.rs
@@ -34,12 +34,13 @@ pub fn render_triage_panel(f: &mut PluginFrame<'_>, area: Rect, state: &mut AppS
         .unwrap_or_default()
         .as_millis() / 300) as u64;
     let mut bx_style = BeamXStyle::from(BeamXMode::Triage);
-    bx_style.border_color = style.border_color;
-    bx_style.status_color = style.status_color;
-    bx_style.prism_color = style.prism_color;
+    let (b, s, p) = state.beamx_panel_theme.palette();
+    bx_style.border_color = b;
+    bx_style.status_color = s;
+    bx_style.prism_color = p;
     let beamx = BeamX {
         tick,
-        enabled: true,
+        enabled: state.beamx_panel_visible,
         mode: BeamXMode::Triage,
         style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -435,12 +435,13 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             .as_millis() / 300) as u64
     };
     let mut bx_style = BeamXStyle::from(BeamXMode::Default);
-    bx_style.border_color = style.border_color;
-    bx_style.status_color = style.status_color;
-    bx_style.prism_color = style.prism_color;
+    let (b, s, p) = state.beamx_panel_theme.palette();
+    bx_style.border_color = b;
+    bx_style.status_color = s;
+    bx_style.prism_color = p;
     let beamx = BeamX {
         tick,
-        enabled: true,
+        enabled: state.beamx_panel_visible,
         mode: BeamXMode::Default,
         style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,6 +23,8 @@ pub struct UserSettings {
     pub zen_beam_color: BeamColor,
     pub triage_beam_color: BeamColor,
     pub settings_beam_color: BeamColor,
+    pub beamx_panel_theme: BeamColor,
+    pub beamx_panel_visible: bool,
 }
 
 impl Default for UserSettings {
@@ -35,6 +37,8 @@ impl Default for UserSettings {
             zen_beam_color: BeamColor::Prism,
             triage_beam_color: BeamColor::Prism,
             settings_beam_color: BeamColor::Prism,
+            beamx_panel_theme: BeamColor::Prism,
+            beamx_panel_visible: crate::state::default_beamx_panel_visible(),
         }
     }
 }
@@ -55,6 +59,8 @@ pub fn save_user_settings(state: &AppState) {
         zen_beam_color: state.zen_beam_color,
         triage_beam_color: state.triage_beam_color,
         settings_beam_color: state.settings_beam_color,
+        beamx_panel_theme: state.beamx_panel_theme,
+        beamx_panel_visible: state.beamx_panel_visible,
     };
     if let Ok(serialized) = toml::to_string(&config) {
         let _ = fs::create_dir_all("config");
@@ -111,6 +117,17 @@ fn toggle_settings_color(s: &mut AppState) {
     save_user_settings(s);
 }
 
+fn is_beamx_panel_visible(s: &AppState) -> bool { s.beamx_panel_visible }
+fn toggle_beamx_panel_visibility(s: &mut AppState) {
+    s.beamx_panel_visible = !s.beamx_panel_visible;
+    save_user_settings(s);
+}
+
+fn toggle_beamx_theme(s: &mut AppState) {
+    s.cycle_beamx_panel_theme();
+    save_user_settings(s);
+}
+
 pub const SETTING_TOGGLES: &[SettingToggle] = &[
     SettingToggle {
         label: "Auto-Arrange",
@@ -147,6 +164,16 @@ pub const SETTING_TOGGLES: &[SettingToggle] = &[
         is_enabled: |_| true,
         toggle: toggle_settings_color,
     },
+    SettingToggle {
+        label: "BeamX Panel",
+        is_enabled: is_beamx_panel_visible,
+        toggle: toggle_beamx_panel_visibility,
+    },
+    SettingToggle {
+        label: "BeamX Theme",
+        is_enabled: |_| true,
+        toggle: toggle_beamx_theme,
+    },
 ];
 
 pub const fn settings_len() -> usize {
@@ -169,6 +196,8 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppStat
                 label = format!("Triage Color: {}", state.triage_beam_color);
             } else if t.label.starts_with("Settings Color") {
                 label = format!("Settings Color: {}", state.settings_beam_color);
+            } else if t.label.starts_with("BeamX Theme") {
+                label = format!("BeamX Theme: {}", state.beamx_panel_theme);
             }
             let check = if enabled { "[x]" } else { "[ ]" };
             let prefix = if selected { "> " } else { "  " };

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -144,7 +144,20 @@ pub struct AppState {
     pub zen_beam_color: crate::beam_color::BeamColor,
     pub triage_beam_color: crate::beam_color::BeamColor,
     pub settings_beam_color: crate::beam_color::BeamColor,
+    pub beamx_panel_theme: crate::beam_color::BeamColor,
+    pub beamx_panel_visible: bool,
+}
 
+pub fn default_beamx_panel_visible() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(term) = std::env::var("TERM_PROGRAM") {
+            if term.to_lowercase().contains("iterm") {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 impl Default for AppState {
@@ -230,6 +243,8 @@ impl Default for AppState {
             zen_beam_color: crate::beam_color::BeamColor::Prism,
             triage_beam_color: crate::beam_color::BeamColor::Prism,
             settings_beam_color: crate::beam_color::BeamColor::Prism,
+            beamx_panel_theme: crate::beam_color::BeamColor::Prism,
+            beamx_panel_visible: default_beamx_panel_visible(),
 
         };
 
@@ -244,6 +259,8 @@ impl Default for AppState {
         state.zen_beam_color = config.zen_beam_color;
         state.triage_beam_color = config.triage_beam_color;
         state.settings_beam_color = config.settings_beam_color;
+        state.beamx_panel_theme = config.beamx_panel_theme;
+        state.beamx_panel_visible = config.beamx_panel_visible;
 
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {
@@ -358,6 +375,17 @@ impl AppState {
             "settings" => self.settings_beam_color = next(self.settings_beam_color),
             _ => {}
         }
+    }
+
+    pub fn cycle_beamx_panel_theme(&mut self) {
+        use crate::beam_color::BeamColor::*;
+        self.beamx_panel_theme = match self.beamx_panel_theme {
+            Prism => Infrared,
+            Infrared => Aqua,
+            Aqua => Emerald,
+            Emerald => Ice,
+            Ice => Prism,
+        };
     }
 
     pub fn beam_style_for_mode(&self, mode: &str) -> crate::beamx::BeamStyle {


### PR DESCRIPTION
## Summary
- add `beamx_panel_theme` and `beamx_panel_visible` settings
- expose toggles in Settings panel
- store panel preferences in config
- adjust BeamX rendering to use selected theme and visibility
- detect macOS/iTerm2 for default panel visibility

## Testing
- `cargo test --no-run`
- `cargo test -- --test-threads=1` *(fails: Broken pipe)*