### PR TITLE
Add node graph audit check

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -74,6 +74,9 @@ pub fn spawn_free_node(state: &mut AppState) {
     state.nodes.insert(new_id, node);
     state.root_nodes.push(new_id);
     state.set_selected(Some(new_id));
+    crate::layout::roles::recalculate_roles(state);
+    state.ensure_valid_roots();
+    state.audit_node_graph();
 }
 
 /// Determine which node is at the given coordinates considering current layout.


### PR DESCRIPTION
## Summary
- implement `AppState::audit_node_graph` for verifying node structure
- call audit on startup and after new node creation
- invoke audit after spawning free nodes

## Testing
- `cargo test --quiet` *(fails: tests hang in this environment)*