### PR TITLE
Patch 25.55k – Zen Top-Right Icon Repair + Visual Polish

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -5,3 +5,5 @@ gemx_beam_color = "Prism"
 zen_beam_color = "Aqua"
 triage_beam_color = "Aqua"
 settings_beam_color = "Aqua"
+zen_icon_enabled = true
+zen_icon_glyph = ""

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,7 +1,9 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph}};
 use crate::state::{AppState, ZenSyntax, ZenTheme, ZenJournalView};
 use crate::beamx::render_full_border;
+use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 
+const TOP_BAR_HEIGHT: u16 = 5;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -43,6 +45,7 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
         ZenJournalView::Compose => render_compose(f, area, state, tick),
         ZenJournalView::Review => render_review(f, area, state),
     }
+    render_top_icon(f, area, state, tick);
 }
 
 fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
@@ -60,7 +63,7 @@ fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, ti
 fn render_review<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let padding = area.width / 4;
     let usable_width = area.width - padding * 2;
-    let mut y = area.y + 1;
+    let mut y = area.y + TOP_BAR_HEIGHT;
     for entry in state.zen_journal_entries.iter().rev() {
         let text = format!("\u{1F551} {}\n{}", entry.timestamp.format("%I:%M %p"), entry.text);
         let rect = Rect::new(area.x + padding, y, usable_width, 3);
@@ -70,6 +73,37 @@ fn render_review<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         if y > area.bottom() { break; }
     }
     render_full_border(f, area, &state.beam_style_for_mode(&state.mode), true, false);
+}
+
+fn render_top_icon<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
+    use ratatui::style::Modifier;
+    if !state.zen_icon_enabled {
+        let glyph = state.zen_icon_glyph.as_deref().unwrap_or("✦");
+        let style = Style::default().fg(Color::Gray);
+        let x = area.right().saturating_sub(glyph.len() as u16 + 1);
+        f.render_widget(Paragraph::new(glyph).style(style), Rect::new(x, area.y + 1, glyph.len() as u16, 1));
+        return;
+    }
+
+    if let Some(glyph) = &state.zen_icon_glyph {
+        let style = Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD);
+        let x = area.right().saturating_sub(glyph.len() as u16 + 1);
+        f.render_widget(Paragraph::new(glyph.as_str()).style(style), Rect::new(x, area.y + 1, glyph.len() as u16, 1));
+    } else {
+        let mut bx_style = BeamXStyle::from(BeamXMode::Zen);
+        let theme = state.beam_style_for_mode(&state.mode);
+        bx_style.border_color = theme.border_color;
+        bx_style.status_color = theme.status_color;
+        bx_style.prism_color = theme.prism_color;
+        let beamx = BeamX {
+            tick,
+            enabled: true,
+            mode: BeamXMode::Zen,
+            style: bx_style,
+            animation: BeamXAnimationMode::PulseEntryRadiate,
+        };
+        beamx.render(f, area);
+    }
 }
 
 fn parse_markdown_line(input: &str) -> Line {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,6 +23,8 @@ pub struct UserSettings {
     pub zen_beam_color: BeamColor,
     pub triage_beam_color: BeamColor,
     pub settings_beam_color: BeamColor,
+    pub zen_icon_enabled: bool,
+    pub zen_icon_glyph: Option<String>,
 }
 
 impl Default for UserSettings {
@@ -35,6 +37,8 @@ impl Default for UserSettings {
             zen_beam_color: BeamColor::Prism,
             triage_beam_color: BeamColor::Prism,
             settings_beam_color: BeamColor::Prism,
+            zen_icon_enabled: true,
+            zen_icon_glyph: None,
         }
     }
 }
@@ -55,6 +59,8 @@ pub fn save_user_settings(state: &AppState) {
         zen_beam_color: state.zen_beam_color,
         triage_beam_color: state.triage_beam_color,
         settings_beam_color: state.settings_beam_color,
+        zen_icon_enabled: state.zen_icon_enabled,
+        zen_icon_glyph: state.zen_icon_glyph.clone(),
     };
     if let Ok(serialized) = toml::to_string(&config) {
         let _ = fs::create_dir_all("config");

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -144,6 +144,8 @@ pub struct AppState {
     pub zen_beam_color: crate::beam_color::BeamColor,
     pub triage_beam_color: crate::beam_color::BeamColor,
     pub settings_beam_color: crate::beam_color::BeamColor,
+    pub zen_icon_enabled: bool,
+    pub zen_icon_glyph: Option<String>,
 
 }
 
@@ -230,6 +232,8 @@ impl Default for AppState {
             zen_beam_color: crate::beam_color::BeamColor::Prism,
             triage_beam_color: crate::beam_color::BeamColor::Prism,
             settings_beam_color: crate::beam_color::BeamColor::Prism,
+            zen_icon_enabled: true,
+            zen_icon_glyph: None,
 
         };
 
@@ -244,6 +248,8 @@ impl Default for AppState {
         state.zen_beam_color = config.zen_beam_color;
         state.triage_beam_color = config.triage_beam_color;
         state.settings_beam_color = config.settings_beam_color;
+        state.zen_icon_enabled = config.zen_icon_enabled;
+        state.zen_icon_glyph = config.zen_icon_glyph.clone();
 
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {


### PR DESCRIPTION
## Summary
- restore BeamX top-right icon in Zen mode
- allow fallback glyph or custom icon
- offset Zen review list below header area
- persist icon settings in config

## Testing
- `cargo check`