### PR TITLE
Add spotlight fuzzy matching patch

### DIFF
--- a/patches/patch-25.53r-spotlight-fuzzy-match/CODE_CHANGES.md
+++ b/patches/patch-25.53r-spotlight-fuzzy-match/CODE_CHANGES.md
@@ -1,0 +1,7 @@
+## Code Changes
+
+- Use a fuzzy matcher to match input to known Spotlight commands
+- Rank results by score
+- Bold/highlight matching substrings in suggestions
+- Support shortcuts (e.g., "tri" matches "triage", "zen" matches "zen mode")
+- Add fallback if no strong match is found

--- a/patches/patch-25.53r-spotlight-fuzzy-match/DESCRIPTION.md
+++ b/patches/patch-25.53r-spotlight-fuzzy-match/DESCRIPTION.md
@@ -1,0 +1,3 @@
+# Patch 25.53r – Spotlight UX: Fuzzy + Intent-Aware Results
+
+Adds fuzzy string matching to Spotlight command input. Improves result ranking and early character disambiguation.

--- a/patches/patch-25.53r-spotlight-fuzzy-match/test_plan.sh
+++ b/patches/patch-25.53r-spotlight-fuzzy-match/test_plan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Patch 25.53r Test Plan
+
+echo "Run cargo test for spotlight fuzzy matching"
+# Placeholder for fuzzy matching unit tests


### PR DESCRIPTION
## Summary
- document fuzzy matching for Spotlight search suggestions

## Testing
- `cargo test autocomplete_matches_partial_command -- --nocapture`