### PR TITLE
Patch 25.44e – GemX Zoom Preview Overlay

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,6 +6,7 @@ pub mod triage;
 pub mod module_switcher;
 pub mod module_icon;
 pub mod favorites;
+pub mod zoom_overlay;
 
 pub use zen::render_zen_journal;
 pub use status::render_status_bar;
@@ -15,3 +16,4 @@ pub use triage::render_triage;
 pub use module_switcher::render_module_switcher;
 pub use module_icon::render_module_icon;
 pub use favorites::render_favorites_dock;
+pub use zoom_overlay::render_zoom_overlay;

--- a/src/render/zoom_overlay.rs
+++ b/src/render/zoom_overlay.rs
@@ -1,0 +1,15 @@
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Style},
+    widgets::Paragraph,
+    Frame,
+};
+
+pub fn render_zoom_overlay<B: Backend>(f: &mut Frame<B>, area: Rect, zoom: f32) {
+    let text = format!("[ Zoom: {:.1}x ]", zoom);
+    let width = text.len() as u16;
+    let rect = Rect::new(area.x + 1, area.bottom().saturating_sub(2), width, 1);
+    let style = Style::default().fg(Color::White).bg(Color::DarkGray);
+    f.render_widget(Paragraph::new(text).style(style), rect);
+}

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -425,6 +425,15 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         f.render_widget(indicator, Rect::new(area.x + 1, area.y + 1, 20, 1));
     }
 
+    let show_zoom = state.debug_input_mode
+        || state
+            .zoom_preview_last
+            .map(|t| t.elapsed() < std::time::Duration::from_secs(2))
+            .unwrap_or(false);
+    if show_zoom {
+        crate::render::render_zoom_overlay(f, area, state.zoom_scale);
+    }
+
     render_full_border(f, area, &style, true, !state.debug_border);
     let tick = if std::env::var("PRISMX_TEST").is_ok() {
         0

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::Instant;
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{ SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT, LayoutRole };
 use crossterm::terminal;
@@ -118,6 +119,7 @@ pub struct AppState {
     pub simulate_input_queue: VecDeque<SimInput>,
     pub status_message: String,
     pub status_message_last_updated: Option<std::time::Instant>,
+    pub zoom_preview_last: Option<Instant>,
     pub plugin_host: PluginHost,
     pub plugin_favorites: Vec<FavoriteEntry>,
     pub favorite_dock_limit: usize,
@@ -204,6 +206,7 @@ impl Default for AppState {
             simulate_input_queue: VecDeque::new(),
             status_message: String::new(),
             status_message_last_updated: None,
+            zoom_preview_last: None,
             plugin_host: PluginHost::new(),
             plugin_favorites: Vec::new(),
             favorite_dock_limit: 3,
@@ -987,6 +990,7 @@ impl AppState {
     pub fn zoom_in(&mut self) {
         self.zoom_scale = (self.zoom_scale + 0.1).min(1.5);
         self.zoom_locked_by_user = true;
+        self.zoom_preview_last = Some(Instant::now());
         if let Some(id) = self.selected {
             crate::layout::zoom_to_anchor(self, id);
         }
@@ -995,6 +999,7 @@ impl AppState {
     pub fn zoom_out(&mut self) {
         self.zoom_scale = (self.zoom_scale - 0.1).max(0.5);
         self.zoom_locked_by_user = true;
+        self.zoom_preview_last = Some(Instant::now());
         if let Some(id) = self.selected {
             crate::layout::zoom_to_anchor(self, id);
         }
@@ -1003,6 +1008,7 @@ impl AppState {
     pub fn zoom_reset(&mut self) {
         self.zoom_scale = 1.0;
         self.zoom_locked_by_user = false;
+        self.zoom_preview_last = Some(Instant::now());
         if let Some(id) = self.selected {
             crate::layout::zoom_to_anchor(self, id);
         }


### PR DESCRIPTION
## Summary
- add zoom overlay renderer
- expose overlay render function
- show overlay in GemX view when zoom changes or in debug mode
- track last zoom change on state

## Testing
- `cargo check --quiet`
- `cargo test --quiet` *(fails: tests hang or require network)*