### PR TITLE
Move module indicator to bottom-right

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -1,4 +1,11 @@
-use ratatui::{backend::Backend, layout::Rect, style::{Color, Style, Modifier}, widgets::Paragraph, Frame};
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use crate::beamx;
 
 pub fn module_icon(mode: &str) -> &'static str {
     match mode {
@@ -13,8 +20,33 @@ pub fn module_icon(mode: &str) -> &'static str {
 
 pub fn render_module_icon<B: Backend>(f: &mut Frame<B>, area: Rect, mode: &str) {
     let glyph = module_icon(mode);
-    let style = Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD);
-    let x = area.x + 1;
-    let y = area.y;
-    f.render_widget(Paragraph::new(glyph).style(style), Rect::new(x, y, 2, 1));
+    let label = match mode {
+        "gemx" => "GEMX",
+        "zen" => "ZEN",
+        "triage" => "TRIAGE",
+        "spotlight" => "SPOTLIGHT",
+        "settings" => "SETTINGS",
+        _ => "UNKNOWN",
+    };
+
+    let content = format!("{} {}", glyph, label);
+
+    let theme = beamx::style_for_mode(mode);
+    let style = Style::default()
+        .fg(theme.border_color)
+        .add_modifier(Modifier::BOLD);
+
+    let text_width = content.chars().count() as u16;
+    let block_width = text_width + 2;
+    let height = 3u16;
+
+    let x = area.width.saturating_sub(block_width + 1);
+    let y = area.height.saturating_sub(height + 4);
+
+    let border = Block::default().borders(Borders::ALL).style(style);
+    f.render_widget(border, Rect::new(x, y, block_width, height));
+    f.render_widget(
+        Paragraph::new(content).style(style),
+        Rect::new(x + 1, y + 1, text_width, 1),
+    );
 }


### PR DESCRIPTION
## Summary
- move module icon overlay to bottom-right corner
- display block with icon and mode label

## Testing
- `cargo test --test module_icon`
- `cargo test -- --test-threads=1` *(fails: environment issues)*