### PR TITLE
Fix Enter/Tab insertion in mindmap

### DIFF
--- a/src/state/edit.rs
+++ b/src/state/edit.rs
@@ -5,7 +5,6 @@ use crate::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT};
 impl AppState {
     pub fn add_child(&mut self) { self.add_child_node(); }
     pub fn add_sibling(&mut self) { self.add_sibling_node(); }
-    pub fn handle_enter_key(&mut self) { self.add_sibling_node(); }
 
     pub fn add_child_node(&mut self) {
         let Some(parent_id) = self.selected else { return };

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,3 +13,15 @@ mod helpers;
 pub use core::*;
 
 pub use helpers::register_plugin_favorite;
+
+impl AppState {
+    /// Handle an Enter keypress in mindmap mode by creating a sibling node.
+    pub fn handle_enter_key(&mut self) {
+        self.add_sibling_node();
+    }
+
+    /// Handle a Tab keypress in mindmap mode by creating a child node.
+    pub fn handle_tab_key(&mut self) {
+        self.add_child_node();
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -281,9 +281,13 @@ pub fn launch_ui() -> std::io::Result<()> {
                 } else if match_hotkey("toggle_keymap", code, modifiers, &state) {
                     state.show_keymap = !state.show_keymap;
                 } else if match_hotkey("create_child", code, modifiers, &state) && state.mode == "gemx" {
-                    state.ensure_valid_roots();
-                    debug_assert!(!state.root_nodes.is_empty());
+                    state.push_undo();
+                    state.handle_tab_key();
+                    continue;
                 } else if match_hotkey("create_sibling", code, modifiers, &state) && state.mode == "gemx" {
+                    state.push_undo();
+                    state.handle_enter_key();
+                    continue;
                 } else if match_hotkey("add_free_node", code, modifiers, &state) {
                     state.push_undo();
                     crate::gemx::interaction::spawn_free_node(&mut state);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -84,3 +84,14 @@ fn handle_enter_creates_sibling() {
         assert!(state.root_nodes.contains(&new_id));
     }
 }
+
+#[test]
+fn handle_tab_creates_child() {
+    let mut state = AppState::default();
+    if let Some(b) = state.nodes.get_mut(&2) { b.x = 10; }
+    let parent = state.selected.unwrap();
+    state.handle_tab_key();
+    let child = state.selected.unwrap();
+    assert_eq!(state.nodes.get(&child).unwrap().parent, Some(parent));
+    assert!(state.nodes.get(&parent).unwrap().children.contains(&child));
+}


### PR DESCRIPTION
## Summary
- handle Enter and Tab keys when editing mind maps
- wire hotkeys so Enter creates a sibling and Tab creates a child
- add test coverage for handle_tab_key

## Testing
- `cargo test --test insertion --quiet`
- `cargo test simulate_command_parses_sequence --test simulate --quiet`
