### PR TITLE
Add canvas animation engine foundation

### DIFF
--- a/src/canvas/engine.rs
+++ b/src/canvas/engine.rs
@@ -1,0 +1,18 @@
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+static START: OnceLock<Instant> = OnceLock::new();
+
+fn start() -> Instant {
+    *START.get_or_init(Instant::now)
+}
+
+/// Return the current tick based on the given interval in milliseconds.
+pub fn tick(interval_ms: u64) -> u64 {
+    start().elapsed().as_millis() as u64 / interval_ms
+}
+
+/// Access the elapsed time since the engine was first used.
+pub fn elapsed() -> Duration {
+    start().elapsed()
+}

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -1,0 +1,1 @@
+pub mod engine;

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,3 +23,5 @@ pub fn load_locked_registry() -> Result<PluginRegistry, Box<dyn std::error::Erro
     }
     Ok(registry)
 }
+
+pub mod theme;

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ThemeConfig {
+    pub dark_mode: bool,
+    pub opacity: f32,
+}
+
+impl Default for ThemeConfig {
+    fn default() -> Self {
+        Self {
+            dark_mode: true,
+            opacity: 1.0,
+        }
+    }
+}
+
+impl ThemeConfig {
+    pub fn load() -> Self {
+        fs::read_to_string("config/theme.toml")
+            .ok()
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod input;
 pub mod dashboard;
 pub mod render;
 pub mod beamx;
+pub mod canvas;
 pub mod beam_color;
 pub mod ui;
 pub mod gemx;

--- a/src/ui/animate.rs
+++ b/src/ui/animate.rs
@@ -1,0 +1,30 @@
+use ratatui::style::{Color, Style};
+
+/// Cycle through a pulse sequence based on the provided tick.
+pub fn pulse<'a>(frames: &'a [&'a str], tick: u64) -> &'a str {
+    if frames.is_empty() {
+        return "";
+    }
+    let i = tick as usize % frames.len();
+    frames[i]
+}
+
+/// Simple shimmer effect that brightens a color every other tick.
+pub fn shimmer(color: Color, tick: u64) -> Style {
+    let style = Style::default().fg(color);
+    if tick % 2 == 0 {
+        style
+    } else {
+        style.add_modifier(ratatui::style::Modifier::BOLD)
+    }
+}
+
+/// Oscillate a value between 0.0 and 1.0 producing a breathing effect.
+pub fn breath(tick: u64) -> f32 {
+    let phase = (tick % 20) as f32 / 20.0;
+    if phase < 0.5 {
+        phase * 2.0
+    } else {
+        (1.0 - phase) * 2.0
+    }
+}


### PR DESCRIPTION
## Summary
- add `CanvasEngine` with global tick helpers
- implement basic `pulse`, `shimmer`, and `breath` effects
- expose theme configuration for dark mode and opacity

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo test` *(fails/hangs at some tests)*