### PR TITLE
Patch 25.61g – WASM Target Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 authors = ["Brandon Essex"]
 description = "PrismX: Offline-first planning engine with trust, federation, and plugin runtime."
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 # Serialization and config
 serde = { version = "1.0", features = ["derive"] }
@@ -21,3 +24,16 @@ dirs = "4.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"
+web-sys = { version = "0.3", features = ["console"] }
+
+[[bin]]
+name = "prismx_wasm"
+path = "wasm/entry.rs"
+
+[[bin]]
+name = "wasm_build"
+path = "build/wasm_build.rs"

--- a/build/wasm_build.rs
+++ b/build/wasm_build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+    let target = "wasm32-unknown-unknown";
+    let status = Command::new("cargo")
+        .args(["build", "--release", "--target", target])
+        .status()
+        .expect("failed to execute cargo build");
+    if !status.success() {
+        panic!("wasm build failed");
+    }
+}

--- a/wasm/entry.rs
+++ b/wasm/entry.rs
@@ -1,0 +1,9 @@
+use wasm_bindgen::prelude::*;
+use web_sys::console;
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+    console::log_1(&"PrismX WASM preview".into());
+    // TODO: integrate preview renderer
+}


### PR DESCRIPTION
## Summary
- enable building `prismx` for `wasm32-unknown-unknown`
- add basic WASM entry point
- provide helper build script for the WASM target

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `console_error_panic_hook`)*