### PR TITLE
Implement Renderable trait for Zen and GemX

### DIFF
--- a/src/gemx.rs
+++ b/src/gemx.rs
@@ -1,3 +1,4 @@
 pub mod nodes;
 pub mod state;
 pub mod interaction;
+pub mod render;

--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -1,0 +1,25 @@
+use ratatui::{prelude::*, Frame};
+
+use crate::state::AppState;
+use crate::render::traits::Renderable;
+use crate::screen::gemx::render_gemx;
+
+/// Wrapper implementing [`Renderable`] for the GemX screen.
+pub struct GemxRenderer<'a> {
+    pub state: &'a mut AppState,
+}
+
+impl<'a> GemxRenderer<'a> {
+    pub fn new(state: &'a mut AppState) -> Self {
+        Self { state }
+    }
+}
+
+impl<'a> Renderable for GemxRenderer<'a> {
+    fn render_frame<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+        render_gemx(f, area, self.state);
+    }
+
+    fn tick(&mut self) {}
+}
+

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -7,6 +7,7 @@ pub mod module_switcher;
 pub mod module_icon;
 pub mod favorites;
 pub mod zoom_overlay;
+pub mod traits;
 
 pub use zen::render_zen_journal;
 pub use status::render_status_bar;
@@ -17,3 +18,4 @@ pub use module_switcher::render_module_switcher;
 pub use module_icon::render_module_icon;
 pub use favorites::render_favorites_dock;
 pub use zoom_overlay::render_zoom_overlay;
+pub use traits::Renderable;

--- a/src/render/traits.rs
+++ b/src/render/traits.rs
@@ -1,0 +1,11 @@
+use ratatui::{prelude::*, Frame};
+
+/// Trait for types that can render a UI frame and progress animations.
+pub trait Renderable {
+    /// Render the component to the given area.
+    fn render_frame<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect);
+
+    /// Advance internal state for the next frame.
+    fn tick(&mut self);
+}
+

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -2,10 +2,29 @@ use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph}};
 use crate::state::{AppState, ZenSyntax, ZenTheme, ZenJournalView};
 use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
+use crate::render::traits::Renderable;
 
 const TOP_BAR_HEIGHT: u16 = 5;
 
 use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct ZenRenderer<'a> {
+    pub state: &'a AppState,
+}
+
+impl<'a> ZenRenderer<'a> {
+    pub fn new(state: &'a AppState) -> Self {
+        Self { state }
+    }
+}
+
+impl<'a> Renderable for ZenRenderer<'a> {
+    fn render_frame<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+        render_zen_journal(f, area, self.state);
+    }
+
+    fn tick(&mut self) {}
+}
 
 pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let mut style = state.beam_style_for_mode(&state.mode);


### PR DESCRIPTION
## Summary
- create `Renderable` trait with `render_frame` and `tick`
- export trait from render mod
- implement `ZenRenderer` in existing zen renderer module
- add new GemxRenderer implementing `Renderable`
- expose GemX render module

## Testing
- `cargo check`
- `cargo test drill_pop -- --test-threads=1`