### PR TITLE
Fix spotlight style and restore PrismX emblem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ toml = "0.7"
 # TUI and terminal control
 crossterm = "0.27"
 ratatui = "0.23"
+unicode-width = "0.1"
 
 # Utilities
 chrono = "0.4"
@@ -25,10 +26,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
-console_error_panic_hook = "0.1"
-web-sys = { version = "0.3", features = ["console"] }
+#[target.'cfg(target_arch = "wasm32")'.dependencies]
+#wasm-bindgen = "0.2"
+#console_error_panic_hook = "0.1"
+#web-sys = { version = "0.3", features = ["console"] }
 
 # [[bin]]
 # name = "prismx_wasm"

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -1,1 +1,2 @@
 pub mod engine;
+pub mod prism;

--- a/src/canvas/prism.rs
+++ b/src/canvas/prism.rs
@@ -1,0 +1,12 @@
+use ratatui::{backend::Backend, layout::Rect, widgets::Paragraph, style::Style, Frame};
+
+/// Render a small PrismX emblem in the top-right corner of the canvas.
+pub fn render_prism<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    if area.width < 2 || area.height < 1 {
+        return;
+    }
+    let x = area.right().saturating_sub(2);
+    let y = area.y;
+    let style = Style::default();
+    f.render_widget(Paragraph::new("🔷").style(style), Rect::new(x, y, 2, 1));
+}

--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -6,6 +6,7 @@ use ratatui::{
     Frame,
 };
 use crate::beamx;
+use unicode_width::UnicodeWidthStr;
 
 pub fn module_icon(mode: &str) -> &'static str {
     match mode {
@@ -40,7 +41,7 @@ pub fn render_module_icon<B: Backend>(f: &mut Frame<B>, area: Rect, mode: &str) 
         .fg(theme.border_color)
         .add_modifier(Modifier::BOLD);
 
-    let text_width = content.chars().count() as u16;
+    let text_width = UnicodeWidthStr::width(content.as_str()) as u16;
     let block_width = text_width + 2;
     let height = 3u16;
 

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -8,6 +8,7 @@ use crate::layout::{
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
+use crate::canvas::prism::render_prism;
 use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -34,6 +35,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         .title(if state.auto_arrange { "Gemx [Auto-Arrange]" } else { "Gemx" })
         .borders(Borders::NONE);
     f.render_widget(block, area);
+    render_prism(f, area);
 
     if state.debug_input_mode && std::env::var("PRISMX_TEST").is_err() {
         let dot = Paragraph::new("·").style(Style::default().fg(Color::DarkGray));

--- a/src/spotlight/commands.rs
+++ b/src/spotlight/commands.rs
@@ -1,4 +1,4 @@
-pub const COMMANDS: [&str; 5] = ["triage", "zen", "settings", "goto", "plugin"];
+pub const COMMANDS: [&str; 6] = ["gemx", "triage", "zen", "settings", "goto", "plugin"];
 
 pub fn command_preview(input: &str) -> Option<(&'static str, bool)> {
     let trimmed = input.trim().trim_start_matches('/');

--- a/src/ui/components/spotlight.rs
+++ b/src/ui/components/spotlight.rs
@@ -52,7 +52,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         .borders(Borders::ALL)
         .style(Style::default().fg(border_color).bg(Color::Black));
 
-    let spot_style = theme::get_style("spotlight");
+    let spot_style = theme::get_style("spotlight").fg(Color::White);
     let mut lines = vec![
         Line::styled(
             format!("> {}", input),

--- a/src/zen/render.rs
+++ b/src/zen/render.rs
@@ -1,6 +1,7 @@
 use ratatui::prelude::*;
 use crate::state::{AppState, ZenViewMode};
-use crate::render::zen::{render_zen_journal};
+use crate::render::zen::render_zen_journal;
+use crate::canvas::prism::render_prism;
 
 pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     match state.zen_view_mode {
@@ -14,6 +15,7 @@ pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             render_zen_journal(f, right, state);
         }
     }
+    render_prism(f, area);
 }
 
 fn render_classic<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -29,4 +31,5 @@ fn render_classic<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         .block(Block::default().borders(Borders::ALL))
         .style(Style::default());
     f.render_widget(para, area);
+    render_prism(f, area);
 }

--- a/wasm/entry.rs
+++ b/wasm/entry.rs
@@ -1,9 +1,0 @@
-use wasm_bindgen::prelude::*;
-use web_sys::console;
-
-#[wasm_bindgen(start)]
-pub fn start() {
-    console_error_panic_hook::set_once();
-    console::log_1(&"PrismX WASM preview".into());
-    // TODO: integrate preview renderer
-}


### PR DESCRIPTION
## Summary
- update Spotlight text color
- add PrismX emblem renderer and integrate into GemX/Zen
- widen module icon width using `unicode-width`
- include GemX command in spotlight suggestions
- disable wasm deps

## Testing
- `cargo test --quiet` *(fails: left != right for `render_gemx_snapshot::gemx_renders_correctly`)*