### PR TITLE
Implement triage panel with task actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ dirs = "4.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
+regex = "1"
 
 #[target.'cfg(target_arch = "wasm32")'.dependencies]
 #wasm-bindgen = "0.2"

--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -20,6 +20,8 @@ impl<'a> Renderable for GemxRenderer<'a> {
         render_gemx(f, area, self.state);
     }
 
-    fn tick(&mut self) {}
+    fn tick(&mut self) {
+        crate::triage::logic::update_pipeline(self.state);
+    }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ui;
 pub mod gemx;
 pub mod routineforge;
 pub mod settings;
+pub mod triage;
 #[path = "state/mod.rs"]
 pub mod state;
 pub mod shortcuts;

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -138,6 +138,7 @@ pub struct AppState {
     pub zen_view_mode: crate::state::ZenViewMode,
     pub zen_compose_input: String,
     pub zen_journal_entries: Vec<ZenJournalEntry>,
+    pub triage_entries: Vec<crate::triage::logic::TriageEntry>,
     pub gemx_beam_color: crate::beam_color::BeamColor,
     pub zen_beam_color: crate::beam_color::BeamColor,
     pub triage_beam_color: crate::beam_color::BeamColor,
@@ -146,6 +147,7 @@ pub struct AppState {
     pub zen_icon_glyph: Option<String>,
     pub beamx_panel_theme: crate::beam_color::BeamColor,
     pub beamx_panel_visible: bool,
+    pub triage_view_mode: crate::state::TriageViewMode,
 }
 
 pub fn default_beamx_panel_visible() -> bool {
@@ -242,6 +244,7 @@ impl Default for AppState {
             zen_view_mode: crate::state::ZenViewMode::default(),
             zen_compose_input: String::new(),
             zen_journal_entries: Vec::new(),
+            triage_entries: Vec::new(),
             gemx_beam_color: crate::beam_color::BeamColor::Prism,
             zen_beam_color: crate::beam_color::BeamColor::Prism,
             triage_beam_color: crate::beam_color::BeamColor::Prism,
@@ -250,6 +253,7 @@ impl Default for AppState {
             zen_icon_glyph: None,
             beamx_panel_theme: crate::beam_color::BeamColor::Prism,
             beamx_panel_visible: default_beamx_panel_visible(),
+            triage_view_mode: crate::state::TriageViewMode::default(),
         };
 
         let config = crate::settings::load_user_settings();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -9,11 +9,13 @@ mod spotlight;
 mod history;
 mod drag;
 mod helpers;
+mod triage;
 mod view;
 
 pub use core::*;
 
 pub use helpers::register_plugin_favorite;
+pub use triage::*;
 
 pub use view::*;
 

--- a/src/state/triage.rs
+++ b/src/state/triage.rs
@@ -1,0 +1,10 @@
+use crate::triage::logic::{capture_entry, handle_inline_command, TriageSource};
+use super::core::AppState;
+
+impl AppState {
+    /// Capture potential triage entry from text.
+    pub fn triage_capture_text(&mut self, text: &str, source: TriageSource) {
+        if handle_inline_command(self, text) { return; }
+        capture_entry(self, source, text);
+    }
+}

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -8,3 +8,13 @@ pub enum ZenViewMode {
 impl Default for ZenViewMode {
     fn default() -> Self { Self::Journal }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TriageViewMode {
+    Feed,
+    Actions,
+}
+
+impl Default for TriageViewMode {
+    fn default() -> Self { Self::Feed }
+}

--- a/src/triage/logic.rs
+++ b/src/triage/logic.rs
@@ -1,0 +1,118 @@
+use chrono::{DateTime, Local};
+use regex::Regex;
+use crate::state::AppState;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TriageSource {
+    Zen,
+    Gemx,
+    Spotlight,
+}
+
+#[derive(Clone, Debug)]
+pub struct TriageEntry {
+    pub id: usize,
+    pub text: String,
+    pub tags: Vec<String>,
+    pub source: TriageSource,
+    pub created: DateTime<Local>,
+    pub resolved: bool,
+    pub archived: bool,
+}
+
+impl TriageEntry {
+    pub fn new(id: usize, text: &str, source: TriageSource) -> Self {
+        let tags = extract_tags(text);
+        Self {
+            id,
+            text: text.to_string(),
+            tags,
+            source,
+            created: Local::now(),
+            resolved: false,
+            archived: false,
+        }
+    }
+}
+
+fn extract_tags(text: &str) -> Vec<String> {
+    let re = Regex::new(r"#\\w+").unwrap();
+    re.find_iter(text)
+        .map(|m| m.as_str().to_string())
+        .collect()
+}
+
+pub fn capture_entry(state: &mut AppState, source: TriageSource, text: &str) {
+    if text.contains("#TODO") || text.contains("#NOW") || text.contains("#TRITON") {
+        let id = state.triage_entries.len();
+        let entry = TriageEntry::new(id, text, source);
+        state.triage_entries.push(entry);
+    }
+}
+
+pub fn handle_inline_command(state: &mut AppState, text: &str) -> bool {
+    let mut parts = text.trim().split_whitespace();
+    let cmd = parts.next().unwrap_or("");
+    match cmd {
+        "/resolve" => {
+            if let Some(id) = parts.next().and_then(|v| v.parse::<usize>().ok()) {
+                resolve(state, id);
+            }
+            true
+        }
+        "/dismiss" => {
+            if let Some(id) = parts.next().and_then(|v| v.parse::<usize>().ok()) {
+                dismiss(state, id);
+            }
+            true
+        }
+        "/archive" => {
+            if let Some(id) = parts.next().and_then(|v| v.parse::<usize>().ok()) {
+                archive(state, id);
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+pub fn resolve(state: &mut AppState, id: usize) {
+    if let Some(entry) = state.triage_entries.get_mut(id) {
+        entry.resolved = true;
+        if entry.tags.contains(&"#TRITON".to_string()) {
+            entry.tags.retain(|t| t != "#TRITON");
+            entry.tags.push("#DONE".into());
+        } else if entry.tags.contains(&"#NOW".to_string()) {
+            entry.tags.retain(|t| t != "#NOW");
+            entry.tags.push("#TRITON".into());
+        }
+    }
+}
+
+pub fn dismiss(state: &mut AppState, id: usize) {
+    if let Some(entry) = state.triage_entries.get_mut(id) {
+        entry.archived = true;
+    }
+}
+
+pub fn archive(state: &mut AppState, id: usize) {
+    if let Some(entry) = state.triage_entries.get_mut(id) {
+        entry.archived = true;
+        entry.resolved = true;
+    }
+}
+
+/// Simple pipeline updates. Entries tagged #NOW move to #TRITON after creation
+/// delay (~60s) or if resolve() is called. Resolved #TRITON entries become #DONE.
+pub fn update_pipeline(state: &mut AppState) {
+    for entry in &mut state.triage_entries {
+        if entry.resolved { continue; }
+        if entry.tags.contains(&"#NOW".to_string()) {
+            let since = Local::now().signed_duration_since(entry.created).num_seconds();
+            if since > 60 {
+                entry.tags.retain(|t| t != "#NOW");
+                entry.tags.push("#TRITON".into());
+            }
+        }
+    }
+}

--- a/src/triage/mod.rs
+++ b/src/triage/mod.rs
@@ -1,0 +1,5 @@
+pub mod panel;
+pub mod logic;
+
+pub use panel::render_triage_panel;
+pub use logic::{TriageEntry, TriageSource, handle_inline_command, capture_entry, update_pipeline};

--- a/src/triage/panel.rs
+++ b/src/triage/panel.rs
@@ -1,0 +1,30 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::text::{Line, Span};
+use crate::state::AppState;
+use crate::triage::logic::TriageSource;
+
+pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    let mut lines = Vec::new();
+    for entry in &state.triage_entries {
+        if entry.archived { continue; }
+        let mut style = Style::default();
+        if entry.resolved {
+            style = style.fg(Color::DarkGray);
+        }
+        let src = match entry.source {
+            TriageSource::Zen => "Zen",
+            TriageSource::Gemx => "GemX",
+            TriageSource::Spotlight => "Spotlight",
+        };
+        lines.push(Line::from(vec![Span::styled(format!("[{}] {}", entry.id, src), style), Span::raw(" "), Span::styled(&entry.text, style)]));
+        lines.push(Line::from(Span::styled("[r]esolve [d]ismiss [a]rchive", Style::default().fg(Color::Blue))));
+        lines.push(Line::from(""));
+    }
+    if lines.is_empty() {
+        lines.push(Line::from("No triage entries"));
+    }
+    let para = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE));
+    f.render_widget(para, area);
+}

--- a/src/zen/journal.rs
+++ b/src/zen/journal.rs
@@ -15,6 +15,7 @@ impl AppState {
     pub fn add_journal_text(&mut self, text: &str) {
         for block in split_blocks(text) {
             if block.trim().is_empty() { continue; }
+            self.triage_capture_text(&block, crate::triage::logic::TriageSource::Zen);
             let entry = ZenJournalEntry { timestamp: Local::now(), text: block };
             self.zen_journal_entries.push(entry);
         }


### PR DESCRIPTION
## Summary
- add triage module with panel rendering and basic logic
- store triage entries on application state
- capture tagged journal text as triage tasks
- expose triage pipeline updates during GemX ticks
- add view modes for triage panel

## Testing
- `cargo build --quiet`
- `cargo test --quiet`
- `cargo test --quiet --test golden` *(fails: render_gemx_snapshot::gemx_renders_correctly)*