### PR TITLE
Manual UI fixes for BeamX, Spotlight, and Triage

### DIFF
--- a/src/canvas/prism.rs
+++ b/src/canvas/prism.rs
@@ -1,6 +1,31 @@
-use ratatui::{backend::Backend, layout::Rect, Frame};
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+    Frame,
+};
 
 /// Render a small PrismX emblem in the top-right corner of the canvas.
-pub fn render_prism<B: Backend>(_: &mut Frame<B>, _: Rect) {
-    // Icon rendering removed – previously drew a debug prism glyph
+pub fn render_prism<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    // Manual BeamX fallback – draws 6 arrows around a center star
+    let x = area.right().saturating_sub(12);
+    let y = area.top();
+
+    let border = Style::default().fg(Color::Magenta);
+    let status = Style::default().fg(Color::Cyan);
+    let prism = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
+
+    // Exit arrows
+    f.render_widget(Paragraph::new("⬉").style(border), Rect::new(x + 0, y + 0, 1, 1));
+    f.render_widget(Paragraph::new("⬉").style(border), Rect::new(x + 3, y + 1, 1, 1));
+    f.render_widget(Paragraph::new("⬊").style(border), Rect::new(x + 9, y + 3, 1, 1));
+    f.render_widget(Paragraph::new("⬊").style(border), Rect::new(x + 11, y + 4, 1, 1));
+
+    // Entry arrows
+    f.render_widget(Paragraph::new("⇙").style(status), Rect::new(x + 11, y + 0, 1, 1));
+    f.render_widget(Paragraph::new("⇙").style(status), Rect::new(x + 9, y + 1, 1, 1));
+
+    // Center
+    f.render_widget(Paragraph::new("✦").style(prism), Rect::new(x + 6, y + 2, 1, 1));
 }

--- a/src/render/triage.rs
+++ b/src/render/triage.rs
@@ -20,7 +20,7 @@ pub fn render_triage<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState)
     bx_style.prism_color = p;
     let beamx = BeamX {
         tick,
-        enabled: state.beamx_panel_visible,
+        enabled: false,
         mode: BeamXMode::Triage,
         style: bx_style,
         animation: BeamXAnimationMode::PulseEntryRadiate,

--- a/src/triage/panel.rs
+++ b/src/triage/panel.rs
@@ -6,6 +6,21 @@ use crate::state::AppState;
 use crate::triage::logic::{TriageSource, TriageEntry};
 use crate::beamx::render_full_border;
 
+fn draw_plain_border<B: Backend>(f: &mut Frame<B>, area: Rect, color: Color) {
+    let style = Style::default().fg(color);
+    let right = area.x + area.width.saturating_sub(1);
+    let bottom = area.y + area.height.saturating_sub(1);
+
+    for x in area.x + 1..right {
+        f.render_widget(Paragraph::new("─").style(style), Rect::new(x, area.y, 1, 1));
+        f.render_widget(Paragraph::new("─").style(style), Rect::new(x, bottom, 1, 1));
+    }
+    for y in area.y + 1..bottom {
+        f.render_widget(Paragraph::new("│").style(style), Rect::new(area.x, y, 1, 1));
+        f.render_widget(Paragraph::new("│").style(style), Rect::new(right, y, 1, 1));
+    }
+}
+
 pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let style = state.beam_style_for_mode("triage");
 
@@ -45,5 +60,5 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
         .block(Block::default().title("Triage").borders(Borders::NONE));
 
     f.render_widget(para, area);
-    render_full_border(f, area, &style, true, false);
+    draw_plain_border(f, area, style.border_color);
 }

--- a/src/ui/components/spotlight.rs
+++ b/src/ui/components/spotlight.rs
@@ -13,6 +13,7 @@ use crate::theme;
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;
+    let display_input = if input.is_empty() { "<type command>" } else { input };
     let base_width = area.width.min(60);
     let scale = if state.spotlight_just_opened {
         match state.spotlight_animation_frame {
@@ -24,7 +25,8 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         1.0
     };
     let width = ((base_width as f32) * scale) as u16;
-    let width = width.max(3).min(base_width);
+    let min_width = display_input.chars().count() as u16 + 3; // "> " + input + padding
+    let width = width.max(min_width).max(3).min(base_width);
     let x_offset = area.x + (area.width.saturating_sub(width)) / 2;
     let y_offset = area.y + area.height / 3;
 
@@ -55,7 +57,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let spot_style = theme::get_style("spotlight").fg(Color::White);
     let mut lines = vec![
         Line::styled(
-            format!("> {}", input),
+            format!("> {}", display_input),
             spot_style
                 .add_modifier(Modifier::BOLD),
         ),
@@ -99,7 +101,7 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         if y >= area.y + area.height.saturating_sub(1) {
             break;
         }
-        let mut style = spot_style;
+        let mut style = spot_style.fg(Color::White);
         if Some(i) == state.spotlight_suggestion_index {
             style = style.fg(Color::Black).bg(Color::White);
         }


### PR DESCRIPTION
## Summary
- tweak Spotlight input rendering
- restore BeamX arrows using manual fallback
- draw simple borders for Triage panel and disable BeamX animation

## Testing
- `cargo test` *(fails: render_gemx_snapshot::gemx_renders_correctly)*
- `cargo check`