### PR TITLE
Patch 25.63c – triage layout cleanup

### DIFF
--- a/src/canvas/prism.rs
+++ b/src/canvas/prism.rs
@@ -1,6 +1,5 @@
 use ratatui::{backend::Backend, layout::Rect, Frame};
 
 /// Render a small PrismX emblem in the top-right corner of the canvas.
-pub fn render_prism<B: Backend>(_: &mut Frame<B>, _: Rect) {
-    // Icon rendering removed – previously drew a debug prism glyph
-}
+/// Disabled to prevent stray emoji bleed on some terminals.
+pub fn render_prism<B: Backend>(_: &mut Frame<B>, _: Rect) {}

--- a/src/triage/panel.rs
+++ b/src/triage/panel.rs
@@ -1,14 +1,38 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::layout::{Layout, Constraint, Direction};
 use ratatui::text::{Line, Span};
 
 use crate::state::AppState;
-use crate::triage::logic::{TriageSource, TriageEntry};
+use crate::triage::logic::TriageSource;
 use crate::beamx::render_full_border;
 
 pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let style = state.beam_style_for_mode("triage");
+    let block_style = Style::default().fg(style.border_color);
 
+    // Divide panel into summary (top) and two side zones.
+    let zones = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
+        .split(area);
+
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)].as_ref())
+        .split(zones[1]);
+
+    // --- Summary Bar ---
+    let open_count = state
+        .triage_entries
+        .iter()
+        .filter(|e| !e.archived && !e.resolved)
+        .count();
+    let summary = Paragraph::new(format!("{open_count} open entries"))
+        .block(Block::default().borders(Borders::NONE).style(block_style));
+    f.render_widget(summary, zones[0]);
+
+    // --- Left Feed ---
     let mut lines = Vec::new();
     for entry in &state.triage_entries {
         if entry.archived { continue; }
@@ -41,9 +65,30 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
         lines.push(Line::from("No triage entries"));
     }
 
-    let para = Paragraph::new(lines)
-        .block(Block::default().title("Triage").borders(Borders::NONE));
+    let feed = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE).style(block_style));
+    f.render_widget(feed, body[0]);
 
-    f.render_widget(para, area);
+    // --- Right Stats ---
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for entry in &state.triage_entries {
+        if entry.archived { continue; }
+        for tag in &entry.tags {
+            *counts.entry(tag.clone()).or_insert(0) += 1;
+        }
+    }
+    let mut stats_lines = Vec::new();
+    if counts.is_empty() {
+        stats_lines.push(Line::from(""));
+    } else {
+        for (tag, count) in counts {
+            stats_lines.push(Line::from(format!("{}: {}", tag, count)));
+        }
+    }
+    let stats = Paragraph::new(stats_lines)
+        .block(Block::default().borders(Borders::NONE).style(block_style));
+    f.render_widget(stats, body[1]);
+
     render_full_border(f, area, &style, true, false);
 }

--- a/tests/golden/gemx.snapshot
+++ b/tests/golden/gemx.snapshot
@@ -1,7 +1,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━           ┓
-┃[A] Auto-Arrange
-┃ Node A
-┃
+┃[A] Auto-Arrange                                 
+┃ Node A                                          
+┃                                                 
 ┃             Node B                             ┃
 ┃                             ╭──────────╮       ┃
 ┃                             │Zoom: 0.5x│       ┃


### PR DESCRIPTION
## Summary
- prepare PrismX canvas with placeholder `render_prism`
- add multi-zone layout for triage panel
- update golden snapshot for gemx view

## Testing
- `cargo check -q`
- `cargo test -q`