### PR TITLE
Add plugin panel screen

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,6 +3,9 @@ use ratatui::layout::Rect;
 use std::collections::VecDeque;
 use std::time::{Duration, SystemTime};
 
+pub mod panel;
+pub mod registry;
+
 pub struct PluginHost {
     pub active: VecDeque<Box<dyn PluginRender>>,
 }

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1,0 +1,29 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::text::{Line, Span};
+
+use crate::state::AppState;
+use crate::plugin::registry::{registry, PluginEntry};
+
+pub fn render_plugin_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    let style = state.beam_style_for_mode("settings");
+    let entries = registry();
+
+    let mut lines: Vec<Line> = Vec::new();
+    for PluginEntry { name, description } in entries {
+        lines.push(Line::from(Span::styled(name, Style::default().add_modifier(Modifier::BOLD))));
+        lines.push(Line::from(description));
+        lines.push(Line::from(Span::styled("[install]", Style::default().fg(Color::DarkGray))));
+        lines.push(Line::from(""));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from("No plugins available"));
+    }
+
+    let para = Paragraph::new(lines)
+        .block(Block::default().title("Plugins").borders(Borders::NONE));
+
+    f.render_widget(para, area);
+    crate::beamx::render_full_border(f, area, &style, true, false);
+}

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, Copy)]
+pub struct PluginEntry {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+pub fn registry() -> Vec<PluginEntry> {
+    vec![
+        PluginEntry { name: "GemX", description: "Mindmap engine" },
+        PluginEntry { name: "Dashboard", description: "Project dashboard" },
+        PluginEntry { name: "Mindtrace", description: "AI memory system" },
+        PluginEntry { name: "RoutineForge", description: "Task & habit manager" },
+    ]
+}

--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -15,6 +15,7 @@ pub fn module_icon(mode: &str) -> &'static str {
         "triage" => "🧭",
         "spotlight" => "🔍",
         "settings" => "⚙️",
+        "plugin" => "🔌",
         _ => "❓",
     }
 }
@@ -26,6 +27,7 @@ pub fn module_label(mode: &str) -> &'static str {
         "triage" => "Triage",
         "spotlight" => "Spotlight",
         "settings" => "Settings",
+        "plugin" => "Plugins",
         _ => "Unknown",
     }
 }

--- a/src/render/module_switcher.rs
+++ b/src/render/module_switcher.rs
@@ -13,6 +13,7 @@ pub fn render_module_switcher<B: Backend>(f: &mut Frame<B>, area: Rect, index: u
         ("🧘", "Zen"),
         ("🧭", "Triage"),
         ("⚙️", "Settings"),
+        ("🔌", "Plugins"),
     ];
 
     let lines: Vec<Line> = modules

--- a/src/spotlight/commands.rs
+++ b/src/spotlight/commands.rs
@@ -11,6 +11,7 @@ pub fn command_preview(input: &str) -> Option<(&'static str, bool)> {
         "zen" => ("Opens Zen mode", true),
         "gemx" => ("Opens GemX mode", true),
         "settings" => ("Opens Settings panel", true),
+        "plugin" => ("Opens Plugin panel", true),
         _ => ("Unknown command", false),
     };
 

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -149,6 +149,7 @@ pub struct AppState {
     pub beamx_panel_theme: crate::beam_color::BeamColor,
     pub beamx_panel_visible: bool,
     pub triage_view_mode: crate::state::TriageViewMode,
+    pub plugin_view_mode: crate::state::PluginViewMode,
 }
 
 pub fn default_beamx_panel_visible() -> bool {
@@ -256,6 +257,7 @@ impl Default for AppState {
             beamx_panel_theme: crate::beam_color::BeamColor::Prism,
             beamx_panel_visible: default_beamx_panel_visible(),
             triage_view_mode: crate::state::TriageViewMode::default(),
+            plugin_view_mode: crate::state::PluginViewMode::default(),
         };
 
         let config = crate::settings::load_user_settings();

--- a/src/state/hotkeys.rs
+++ b/src/state/hotkeys.rs
@@ -23,6 +23,7 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("open_module_switcher".into(), "ctrl-space" .into());
     map.insert("start_drag".into(), "ctrl-r".into());
     map.insert("start_link".into(), "ctrl-l".into());
+    map.insert("toggle_plugin".into(), "ctrl-l".into());
     map.insert("toggle_link_mode".into(), "ctrl-b".into());
     map.insert("redo".into(), "ctrl-shift-z".into());
     map.insert("toggle_snap_grid".into(), "ctrl-g".into());

--- a/src/state/spotlight.rs
+++ b/src/state/spotlight.rs
@@ -78,6 +78,7 @@ impl AppState {
                 "zen" => self.mode = "zen".into(),
                 "settings" => self.mode = "settings".into(),
                 "gemx" => self.mode = "gemx".into(),
+                "plugin" => self.mode = "plugin".into(),
                 "toggle triage" => self.show_triage = !self.show_triage,
                 "toggle keymap" => self.show_keymap = !self.show_keymap,
                 "toggle spotlight" => self.show_spotlight = !self.show_spotlight,

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -19,3 +19,12 @@ pub enum TriageViewMode {
 impl Default for TriageViewMode {
     fn default() -> Self { Self::Feed }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PluginViewMode {
+    Registry,
+}
+
+impl Default for PluginViewMode {
+    fn default() -> Self { Self::Registry }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,6 +24,7 @@ fn rect_contains(rect: ratatui::layout::Rect, x: u16, y: u16) -> bool {
 }
 use crate::screen::render_gemx;
 use crate::settings::render_settings;
+use crate::ui::components::plugin::render_plugin;
 
 mod hotkeys;
 use hotkeys::match_hotkey;
@@ -63,6 +64,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, state: &mut AppState, _last_
             "gemx" => render_gemx(f, vertical[0], state),
             "settings" => render_settings(f, vertical[0], state),
             "triage" => render_triage(f, vertical[0], state),
+            "plugin" => render_plugin(f, vertical[0], state),
             _ => {
                 let fallback = Paragraph::new("Unknown mode");
                 f.render_widget(fallback, vertical[0]);
@@ -307,6 +309,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                     break;
                 } else if match_hotkey("toggle_triage", code, modifiers, &state) {
                     state.mode = "triage".into();
+                } else if match_hotkey("toggle_plugin", code, modifiers, &state) {
+                    state.mode = "plugin".into();
                 } else if match_hotkey("toggle_keymap", code, modifiers, &state) {
                     state.show_keymap = !state.show_keymap;
                 } else if match_hotkey("create_child", code, modifiers, &state) && state.mode == "gemx" {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,2 +1,3 @@
 pub mod spotlight;
 pub mod feed;
+pub mod plugin;

--- a/src/ui/components/plugin.rs
+++ b/src/ui/components/plugin.rs
@@ -1,0 +1,8 @@
+use ratatui::{backend::Backend, layout::Rect, Frame};
+
+use crate::state::AppState;
+use crate::plugin::panel::render_plugin_panel;
+
+pub fn render_plugin<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    render_plugin_panel(f, area, state);
+}


### PR DESCRIPTION
## Summary
- add plugin panel rendering and registry
- expose plugin component
- toggle plugin view with `/plugin` or `Ctrl+L`
- support plugin mode in module UI

## Testing
- `cargo check`
- `cargo test` *(fails: render_gemx_snapshot)*