### PR TITLE
Patch 25.60a – Debug File Logging via Tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4"
 dirs = "4.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-tracing-appender = "0.2"
+tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
 

--- a/patches/patch-25.60a-debug-file-logging/CODE_CHANGES.md
+++ b/patches/patch-25.60a-debug-file-logging/CODE_CHANGES.md
@@ -3,4 +3,4 @@
 - Adds `logging.rs` to configure `tracing_subscriber`
 - Outputs to `logs/prismx.log.YYYY-MM-DD` via `tracing_appender`
 - `init_logger()` called during bootstrap
-- Reads `PRISMX_LOG` env var to determine verbosity
+- Reads `PRISMX_LOG` env var to determine verbosity (`debug`, `info`, or `off`)

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,3 +1,4 @@
 pub fn start() -> std::io::Result<()> {
+    crate::logging::init_logger();
     crate::tui::launch_ui()
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,14 +1,29 @@
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
+/// Initialize global logger for PrismX.
+///
+/// The log level is controlled by the `PRISMX_LOG` environment variable.
+/// Supported values are `debug`, `info`, and `off`.
+/// Log files are written to `logs/prismx.log.YYYY-MM-DD`.
 pub fn init_logger() {
+    let _ = std::fs::create_dir_all("logs");
+
     let file_appender = tracing_appender::rolling::daily("logs", "prismx.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
+    let level = std::env::var("PRISMX_LOG").unwrap_or_else(|_| "info".to_string());
+    let filter = match level.to_lowercase().as_str() {
+        "debug" => "debug",
+        "off" => "off",
+        _ => "info",
+    };
+
     tracing_subscriber::registry()
-        .with(EnvFilter::from_default_env())
+        .with(EnvFilter::new(filter))
         .with(fmt::Layer::default().with_writer(non_blocking))
         .init();
 }
+
 
 #[macro_export]
 macro_rules! log_debug {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
 fn main() -> std::io::Result<()> {
-    prismx::logging::init_logger();
     prismx::bootstrap::start()
 }

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -7,8 +7,9 @@ pub fn init() {
     if plugins.is_empty() {
         tracing::info!("[INIT] no dynamic plugins found");
     } else {
+        tracing::info!("[INIT] {} plugins discovered", plugins.len());
         for plug in &plugins {
-            tracing::info!("[INIT] plugin available: {}", plug.path.display());
+            tracing::debug!("[INIT] plugin available: {}", plug.path.display());
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize logging via `tracing_subscriber` in `bootstrap::start()`
- support log level control with `PRISMX_LOG`
- write logs to `logs/prismx.log.YYYY-MM-DD`
- add plugin discovery debug output

## Testing
- `cargo test`