### PR TITLE
Patch 25.62f – Zen visual improvements

### DIFF
--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -6,6 +6,7 @@ pub struct ThemeConfig {
     pub dark_mode: bool,
     pub opacity: f32,
     pub zen_peaceful: bool,
+    pub zen_breathe: bool,
 }
 
 impl Default for ThemeConfig {
@@ -14,6 +15,7 @@ impl Default for ThemeConfig {
             dark_mode: true,
             opacity: 1.0,
             zen_peaceful: false,
+            zen_breathe: false,
         }
     }
 }
@@ -28,5 +30,9 @@ impl ThemeConfig {
 
     pub fn zen_peaceful(&self) -> bool {
         self.zen_peaceful
+    }
+
+    pub fn zen_breathe(&self) -> bool {
+        self.zen_breathe
     }
 }

--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -110,7 +110,7 @@ fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         let tag_line = if tags.is_empty() { None } else { Some(tags.join(" ")) };
         let mut lines: Vec<Line> = Vec::new();
         let ts = entry.timestamp.format("%b %d, %Y – %-I:%M%p").to_string();
-        lines.push(Line::from(Span::styled(ts, Style::default().fg(Color::Gray).add_modifier(Modifier::DIM))));
+        lines.push(Line::from(Span::styled(ts, Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM))));
         if let Some(t) = tag_line {
             lines.push(highlight_tags_line(&t));
         }
@@ -127,13 +127,15 @@ fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         let rect = Rect::new(area.x + padding, y, usable_width, h);
         let widget = Paragraph::new(block).block(Block::default().borders(Borders::NONE));
         f.render_widget(widget, rect);
+        if y > area.y { y -= 1; }
     }
 }
 
 fn render_input<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
     let padding = area.width / 4;
     let usable_width = area.width - padding * 2;
-    let caret = if tick % 2 == 0 { "|" } else { " " };
+    use crate::ui::animate::cursor_blink;
+    let caret = cursor_blink(tick);
     let timestamp = chrono::Local::now().format("%H:%M").to_string();
     let input = format!("{} {}{}", timestamp, state.zen_compose_input, caret);
     let input_rect = Rect::new(area.x + padding, area.bottom().saturating_sub(2), usable_width, 1);
@@ -151,7 +153,7 @@ fn render_review<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
         let ts = entry.timestamp.format("%I:%M %p").to_string();
         lines.push(Line::from(vec![
             Span::raw("\u{1F551} "),
-            Span::styled(ts, Style::default().fg(Color::Gray).add_modifier(Modifier::DIM)),
+            Span::styled(ts, Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM)),
         ]));
         for l in entry.text.lines() {
             lines.push(highlight_tags_line(l));

--- a/src/ui/animate.rs
+++ b/src/ui/animate.rs
@@ -37,3 +37,13 @@ pub fn breath_style(color: Color, tick: u64) -> Style {
         Style::default().fg(color)
     }
 }
+
+/// Return the cursor glyph for a simple blink animation.
+pub fn cursor_blink(tick: u64) -> &'static str {
+    if tick % 2 == 0 { "|" } else { " " }
+}
+
+/// Style that fades a cursor in and out using the breathing rhythm.
+pub fn cursor_fade(tick: u64) -> Style {
+    breath_style(Color::White, tick)
+}


### PR DESCRIPTION
## Summary
- add `zen_breathe` theme flag
- add cursor animation helpers
- soften timestamp style and add spacing in journal feed

## Testing
- `cargo test`