### PR TITLE
Patch 25.56j – Animated Prism emblem

### DIFF
--- a/src/canvas/prism.rs
+++ b/src/canvas/prism.rs
@@ -1,32 +1,21 @@
-use ratatui::{
-    backend::Backend,
-    layout::Rect,
-    style::{Color, Modifier, Style},
-    widgets::Paragraph,
-    Frame,
-};
+use std::time::{SystemTime, UNIX_EPOCH};
+use ratatui::{backend::Backend, layout::Rect, Frame};
+use crate::ui::render::draw_beam;
+use crate::ui::beamx::{BeamXStyle, BeamXMode};
+use std::env;
 
 /// Render a small PrismX emblem in the top-right corner of the canvas.
 /// Rendered only in modules that are not visually sensitive (e.g., not Triage).
 pub fn render_prism<B: Backend>(f: &mut Frame<B>, area: Rect) {
-    // Manual BeamX fallback – draws 6 arrows around a center star
-    let x = area.right().saturating_sub(12);
-    let y = area.top();
-
-    let border = Style::default().fg(Color::Magenta);
-    let status = Style::default().fg(Color::Cyan);
-    let prism = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
-
-    // Exit arrows
-    f.render_widget(Paragraph::new("⬉").style(border), Rect::new(x + 0, y + 0, 1, 1));
-    f.render_widget(Paragraph::new("⬉").style(border), Rect::new(x + 3, y + 1, 1, 1));
-    f.render_widget(Paragraph::new("⬊").style(border), Rect::new(x + 9, y + 3, 1, 1));
-    f.render_widget(Paragraph::new("⬊").style(border), Rect::new(x + 11, y + 4, 1, 1));
-
-    // Entry arrows
-    f.render_widget(Paragraph::new("⇙").style(status), Rect::new(x + 11, y + 0, 1, 1));
-    f.render_widget(Paragraph::new("⇙").style(status), Rect::new(x + 9, y + 1, 1, 1));
-
-    // Center
-    f.render_widget(Paragraph::new("✦").style(prism), Rect::new(x + 6, y + 2, 1, 1));
+    let tick = if env::var("PRISMX_TEST").is_ok() {
+        1
+    } else {
+        (SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            / 300) as u64
+    };
+    let style = BeamXStyle::from(BeamXMode::Default);
+    draw_beam(f, area, tick, &style);
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4,6 +4,10 @@ use super::beamx::{BeamXStyle, bright_color, render_glyph};
 
 /// Draw the BeamX emblem with directional arrows and animations.
 pub fn draw_beam<B: Backend>(f: &mut Frame<B>, area: Rect, tick: u64, style: &BeamXStyle) {
+    if area.width < 12 || area.height < 5 {
+        return; // Avoid drawing over small panels
+    }
+
     let frame = tick % 12;
     let beam_phase = frame % 4;
     let center_phase = tick % 8;
@@ -47,9 +51,9 @@ pub fn draw_beam<B: Backend>(f: &mut Frame<B>, area: Rect, tick: u64, style: &Be
     };
 
     let prism_color_cycle = match tick % 3 {
-        0 => style.prism_color,
+        0 => Color::White,
         1 => Color::Cyan,
-        _ => Color::Red,
+        _ => Color::Magenta,
     };
 
     let center_style = if center_glyph == "X" {


### PR DESCRIPTION
## Summary
- animate Prism icon with draw_beam and style cycle
- fade/shimmer using cyan, magenta and white
- avoid drawing over tiny panels

## Testing
- `cargo test --quiet`