### PR TITLE
Add plugin preview UI with navigation

### DIFF
--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -1,5 +1,5 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Clear, Wrap};
 use ratatui::text::{Line, Span};
 
 use crate::state::AppState;
@@ -10,9 +10,18 @@ pub fn render_plugin_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
     let entries = registry();
 
     let mut lines: Vec<Line> = Vec::new();
-    for PluginEntry { name, description } in entries {
-        lines.push(Line::from(Span::styled(name, Style::default().add_modifier(Modifier::BOLD))));
-        lines.push(Line::from(description));
+    for (i, PluginEntry { name, description, .. }) in entries.iter().enumerate() {
+        let selected = i == state.plugin_registry_index;
+        let prefix = if selected { "> " } else { "  " };
+        let mut style_line = Style::default();
+        if selected {
+            style_line = style_line.fg(Color::Cyan).add_modifier(Modifier::BOLD);
+        }
+        lines.push(Line::from(vec![
+            Span::styled(prefix.to_string(), style_line),
+            Span::styled(*name, style_line.add_modifier(Modifier::BOLD)),
+        ]));
+        lines.push(Line::from(Span::styled(*description, Style::default().fg(Color::Gray))));
         lines.push(Line::from(Span::styled("[install]", Style::default().fg(Color::DarkGray))));
         lines.push(Line::from(""));
     }
@@ -26,4 +35,42 @@ pub fn render_plugin_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
 
     f.render_widget(para, area);
     crate::beamx::render_full_border(f, area, &style, true, false);
+
+    if state.show_plugin_preview {
+        if let Some(entry) = entries.get(state.plugin_registry_index) {
+            let mut details = vec![
+                Line::from(Span::styled(
+                    entry.name,
+                    Style::default().add_modifier(Modifier::BOLD),
+                )),
+                Line::from(format!("Version: {}", entry.version)),
+                Line::from(entry.description),
+                Line::from(format!(
+                    "Trusted: {}",
+                    if entry.trusted { "yes" } else { "no" }
+                )),
+                Line::from(format!("Trust chain: {}", entry.trust_chain)),
+                Line::from(Span::styled("[Install]", Style::default().fg(Color::DarkGray))),
+            ];
+
+            let content_width = details
+                .iter()
+                .map(|l| l.width() as u16)
+                .max()
+                .unwrap_or(0)
+                .saturating_add(4);
+            let width = content_width.min(area.width);
+            let mut height = details.len() as u16 + 2;
+            height = height.min(area.height.saturating_sub(1));
+
+            let x = area.x + (area.width.saturating_sub(width)) / 2;
+            let y = area.y + (area.height.saturating_sub(height)) / 2;
+
+            let block = Block::default().title("Plugin Preview").borders(Borders::ALL);
+            let rect = Rect::new(x, y, width, height);
+            f.render_widget(Clear, rect);
+            let para = Paragraph::new(details).block(block).wrap(Wrap { trim: false });
+            f.render_widget(para, rect);
+        }
+    }
 }

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -1,14 +1,41 @@
 #[derive(Clone, Copy)]
 pub struct PluginEntry {
     pub name: &'static str,
+    pub version: &'static str,
     pub description: &'static str,
+    pub trusted: bool,
+    pub trust_chain: &'static str,
 }
 
 pub fn registry() -> Vec<PluginEntry> {
     vec![
-        PluginEntry { name: "GemX", description: "Mindmap engine" },
-        PluginEntry { name: "Dashboard", description: "Project dashboard" },
-        PluginEntry { name: "Mindtrace", description: "AI memory system" },
-        PluginEntry { name: "RoutineForge", description: "Task & habit manager" },
+        PluginEntry {
+            name: "GemX",
+            version: "0.1.0",
+            description: "Mindmap engine",
+            trusted: true,
+            trust_chain: "PrismX Core",
+        },
+        PluginEntry {
+            name: "Dashboard",
+            version: "0.1.0",
+            description: "Project dashboard",
+            trusted: true,
+            trust_chain: "PrismX Core",
+        },
+        PluginEntry {
+            name: "Mindtrace",
+            version: "0.1.0",
+            description: "AI memory system",
+            trusted: false,
+            trust_chain: "unknown",
+        },
+        PluginEntry {
+            name: "RoutineForge",
+            version: "0.1.0",
+            description: "Task & habit manager",
+            trusted: false,
+            trust_chain: "unknown",
+        },
     ]
 }

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -152,6 +152,8 @@ pub struct AppState {
     pub beamx_panel_visible: bool,
     pub triage_view_mode: crate::state::TriageViewMode,
     pub plugin_view_mode: crate::state::PluginViewMode,
+    pub plugin_registry_index: usize,
+    pub show_plugin_preview: bool,
 }
 
 pub fn default_beamx_panel_visible() -> bool {
@@ -262,6 +264,8 @@ impl Default for AppState {
             beamx_panel_visible: default_beamx_panel_visible(),
             triage_view_mode: crate::state::TriageViewMode::default(),
             plugin_view_mode: crate::state::PluginViewMode::default(),
+            plugin_registry_index: 0,
+            show_plugin_preview: false,
         };
 
         let config = crate::settings::load_user_settings();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -430,9 +430,13 @@ pub fn launch_ui() -> std::io::Result<()> {
                 // ⌨️ Navigation + Typing
                 match code {
                     KeyCode::Esc => {
-                        state.mode = "gemx".into();
-                        state.show_keymap = false;
-                        state.show_spotlight = false;
+                        if state.mode == "plugin" && state.show_plugin_preview {
+                            state.show_plugin_preview = false;
+                        } else {
+                            state.mode = "gemx".into();
+                            state.show_keymap = false;
+                            state.show_spotlight = false;
+                        }
                     }
 
                     KeyCode::Left if state.mode == "gemx" && modifiers == KeyModifiers::CONTROL => {
@@ -464,6 +468,26 @@ pub fn launch_ui() -> std::io::Result<()> {
                     KeyCode::Enter | KeyCode::Char(' ') if state.mode == "settings" => {
                         let idx = state.settings_focus_index % crate::settings::settings_len();
                         (crate::settings::SETTING_TOGGLES[idx].toggle)(&mut state);
+                    }
+
+                    KeyCode::Up if state.mode == "plugin" && !state.show_plugin_preview => {
+                        let len = crate::plugin::registry::registry().len();
+                        if len > 0 {
+                            if state.plugin_registry_index == 0 {
+                                state.plugin_registry_index = len - 1;
+                            } else {
+                                state.plugin_registry_index -= 1;
+                            }
+                        }
+                    }
+                    KeyCode::Down if state.mode == "plugin" && !state.show_plugin_preview => {
+                        let len = crate::plugin::registry::registry().len();
+                        if len > 0 {
+                            state.plugin_registry_index = (state.plugin_registry_index + 1) % len;
+                        }
+                    }
+                    KeyCode::Enter if state.mode == "plugin" && !state.show_plugin_preview => {
+                        state.show_plugin_preview = true;
                     }
 
                     KeyCode::Up if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {


### PR DESCRIPTION
## Summary
- enable selection of registry plugins and preview details
- add trust fields to plugin registry entries
- track plugin selection state
- handle keyboard navigation in plugin module

## Testing
- `cargo check` *(fails: warnings only)*