### PR TITLE
Patch 25.63e – Triage Tag Promotion Pipeline

### DIFF
--- a/src/triage/logic.rs
+++ b/src/triage/logic.rs
@@ -124,7 +124,18 @@ pub fn archive(state: &mut AppState, id: usize) {
 /// Simple pipeline updates. Entries tagged #NOW move to #TRITON after ~60s.
 pub fn update_pipeline(state: &mut AppState) {
     for entry in &mut state.triage_entries {
-        if entry.resolved { continue; }
+        // Promote resolved #TRITON entries to #DONE
+        if entry.resolved && entry.tags.contains(&"#TRITON".to_string()) {
+            entry.tags.retain(|t| t != "#TRITON");
+            entry.tags.push("#DONE".into());
+            continue;
+        }
+
+        if entry.resolved {
+            continue;
+        }
+
+        // Auto-promote #NOW to #TRITON after ~60s
         if entry.tags.contains(&"#NOW".to_string()) {
             let since = Local::now().signed_duration_since(entry.created).num_seconds();
             if since > 60 {

--- a/src/triage/panel.rs
+++ b/src/triage/panel.rs
@@ -63,7 +63,9 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
 
         let mut entry_style = Style::default();
         if entry.resolved {
-            entry_style = entry_style.fg(Color::DarkGray);
+            entry_style = entry_style
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM);
         }
 
         let src = match entry.source {
@@ -78,9 +80,14 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
             Span::styled(&entry.text, entry_style),
         ]));
 
-        lines.push(Line::from(
-            Span::styled("[r]esolve [d]ismiss [a]rchive", Style::default().fg(Color::Blue)),
-        ));
+        if !entry.resolved {
+            lines.push(Line::from(
+                Span::styled(
+                    "[r]esolve [d]ismiss [a]rchive",
+                    Style::default().fg(Color::Blue),
+                ),
+            ));
+        }
 
         lines.push(Line::from(""));
     }

--- a/src/ui/components/feed.rs
+++ b/src/ui/components/feed.rs
@@ -1,6 +1,6 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Style, Modifier};
 use ratatui::text::{Line, Span};
 use crate::state::ZenJournalEntry;
 use crate::zen::journal::extract_tags;
@@ -38,7 +38,18 @@ pub fn render_feed<B: Backend>(
             let mut spans = Vec::new();
             for token in line.split_whitespace() {
                 if token.starts_with('#') {
-                    spans.push(Span::styled(token, Style::default().fg(Color::Blue)));
+                    if token.eq_ignore_ascii_case("#DONE") {
+                        spans.push(
+                            Span::styled(
+                                token,
+                                Style::default()
+                                    .fg(Color::DarkGray)
+                                    .add_modifier(Modifier::DIM),
+                            ),
+                        );
+                    } else {
+                        spans.push(Span::styled(token, Style::default().fg(Color::Blue)));
+                    }
                 } else {
                     spans.push(Span::raw(token));
                 }


### PR DESCRIPTION
## Summary
- auto promote `#TRITON` to `#DONE` when resolved
- dim resolved entries in triage panel
- fade `#DONE` tags in feed

## Testing
- `cargo test`