### PR TITLE
Patch 25.60h – Enable Runtime Tracing Logs

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,4 +1,6 @@
 pub fn start() -> std::io::Result<()> {
     crate::logging::init_logger();
+    tracing::info!("PrismX logging started");
+    tracing::info!("Application bootstrap");
     crate::tui::launch_ui()
 }

--- a/src/layout/fallback.rs
+++ b/src/layout/fallback.rs
@@ -55,7 +55,7 @@ pub fn promote_unreachable(
 
                 while filled.contains(&(x, y)) {
                     if state.debug_input_mode {
-                        eprintln!("↪ collision at {},{}", x, y);
+                        tracing::debug!("↪ collision at {},{}", x, y);
                     }
                     y += step_y;
                     if y > max_y {
@@ -70,13 +70,13 @@ pub fn promote_unreachable(
                 state.fallback_next_y = y + step_y;
 
                 if state.debug_input_mode {
-                    eprintln!("\u{1F4D0} Placed Node {} at x={}, y={}", id, n.x, n.y);
+                    tracing::debug!("\u{1F4D0} Placed Node {} at x={}, y={}", id, n.x, n.y);
                 }
             }
             drawn_at.insert(id, Coords { x: n.x, y: n.y });
             node_roles.insert(id, LayoutRole::Root);
         } else {
-            eprintln!("❌ Fallback failed: Node {} not found.", id);
+            tracing::error!("❌ Fallback failed: Node {} not found.", id);
         }
 
         crate::log_debug!(state, "\u{26a0} Promoted Node {} to root (label-safe)", id);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -145,6 +145,7 @@ pub fn layout_nodes(
     term_height: i16,
     auto_arrange: bool,
 ) -> (HashMap<NodeID, Coords>, HashMap<NodeID, LayoutRole>) {
+    tracing::debug!("[LAYOUT] layout_nodes root {} auto_arrange {}", root_id, auto_arrange);
     if nodes.is_empty() {
         tracing::debug!("layout_nodes: skip -- empty node map");
         return (HashMap::new(), HashMap::new());
@@ -233,6 +234,7 @@ fn layout_recursive_safe(
     depth: usize,
 ) -> (i16, i16, i16) {
     if !visited.insert(node_id) || depth > MAX_DEPTH {
+        tracing::error!("[LAYOUT] recursion clamp at node {} depth {}", node_id, depth);
         crate::log_warn!(
             "⚠ Recursion halted: Node {} (depth {})",
             node_id,

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -136,6 +136,7 @@ impl AppState {
                         "\u{26a0} root_nodes was empty — promoted Node {} to root",
                         first_id
                     );
+                    tracing::debug!("[STATE] promoted node {} to root", first_id);
                 }
             }
             if self.root_nodes.is_empty() {

--- a/src/tui/hotkeys.rs
+++ b/src/tui/hotkeys.rs
@@ -69,7 +69,11 @@ pub fn match_hotkey(action: &str, code: KeyCode, mods: KeyModifiers, state: &App
             _ => false,
         };
 
-        mod_match && code_match
+        let matched = mod_match && code_match;
+        if matched {
+            tracing::debug!("[INPUT] hotkey match: {} => {}", action, binding);
+        }
+        matched
     } else {
         false
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -301,6 +301,10 @@ pub fn launch_ui() -> std::io::Result<()> {
                     && modifiers == KeyModifiers::ALT
                 {
                     state.show_spotlight = !state.show_spotlight;
+                    tracing::info!(
+                        "[INPUT] spotlight {}",
+                        if state.show_spotlight { "opened" } else { "closed" }
+                    );
                     state.spotlight_history_index = None;
                     draw(&mut terminal, &mut state, &last_key)?;
                     continue;
@@ -322,13 +326,16 @@ pub fn launch_ui() -> std::io::Result<()> {
                     match code {
                         KeyCode::Tab => {
                             state.module_switcher_index = (state.module_switcher_index + 1) % 4;
+                            tracing::debug!("[INPUT] module switcher index {}", state.module_switcher_index);
                         }
                         KeyCode::Enter => {
                             state.mode = state.get_module_by_index().into();
                             state.module_switcher_open = false;
+                            tracing::info!("[INPUT] mode switched to {}", state.mode);
                         }
                         KeyCode::Esc => {
                             state.module_switcher_open = false;
+                            tracing::debug!("[INPUT] module switcher closed");
                         }
                         _ => {}
                     }
@@ -347,8 +354,10 @@ pub fn launch_ui() -> std::io::Result<()> {
                     break;
                 } else if match_hotkey("toggle_triage", code, modifiers, &state) {
                     state.mode = "triage".into();
+                    tracing::info!("[INPUT] mode switched to triage");
                 } else if match_hotkey("toggle_plugin", code, modifiers, &state) {
                     state.mode = "plugin".into();
+                    tracing::info!("[INPUT] mode switched to plugin");
                 } else if match_hotkey("toggle_keymap", code, modifiers, &state) {
                     state.show_keymap = !state.show_keymap;
                 } else if match_hotkey("create_child", code, modifiers, &state) && state.mode == "gemx" {
@@ -373,6 +382,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                 } else if match_hotkey("open_module_switcher", code, modifiers, &state) {
                     state.module_switcher_open = true;
                     state.module_switcher_index = 0;
+                    tracing::info!("[INPUT] module switcher opened");
                 } else if match_hotkey("start_drag", code, modifiers, &state) {
                     if state.selected_drag_source.is_some() {
                         if let Some(target) = state.selected {
@@ -397,6 +407,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.export_zen_to_file();
                 } else if match_hotkey("mode_zen", code, modifiers, &state) {
                     state.mode = "zen".into();
+                    tracing::info!("[INPUT] mode switched to zen");
                 } else if match_hotkey("zen_toggle_theme", code, modifiers, &state) && state.mode == "zen" {
                     state.cycle_zen_theme();
                 } else if match_hotkey("debug_snapshot", code, modifiers, &state) {
@@ -437,8 +448,10 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.clear_fallback_promotions();
                 } else if match_hotkey("toggle_settings", code, modifiers, &state) {
                     state.mode = "settings".into();
+                    tracing::info!("[INPUT] mode switched to settings");
                 } else if code == KeyCode::Char('.') && modifiers == KeyModifiers::CONTROL {
                     state.mode = "settings".into();
+                    tracing::info!("[INPUT] mode switched to settings");
                 }
 
                 // 🍎 macOS fallback for Cmd+Arrow scrolling
@@ -465,6 +478,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                             state.show_plugin_preview = false;
                         } else {
                             state.mode = "gemx".into();
+                            tracing::info!("[INPUT] mode switched to gemx");
                             state.show_keymap = false;
                             state.show_spotlight = false;
                         }


### PR DESCRIPTION
## Summary
- start logger in bootstrap and announce startup
- output plugin discovery and load status
- trace layout recursion clamps and fallback placements
- show root promotions in state helpers
- log hotkey matches and UI mode switches

## Testing
- `cargo test` *(fails: some tests hang)*