### PR TITLE
Add spotlight result icons and scores

### DIFF
--- a/src/spotlight/mod.rs
+++ b/src/spotlight/mod.rs
@@ -2,6 +2,7 @@ use crate::node::NodeID;
 
 pub mod parser;
 pub mod commands;
+pub mod render;
 
 pub use commands::{COMMANDS, command_preview};
 
@@ -34,6 +35,14 @@ fn fuzzy_score(candidate: &str, query: &str) -> Option<usize> {
 /// Return command suggestions using the predictive ranking parser.
 pub fn command_suggestions(input: &str) -> Vec<&'static str> {
     parser::rank(input.trim_start_matches('/'), &COMMANDS)
+        .into_iter()
+        .take(5)
+        .collect()
+}
+
+/// Return command suggestions along with fuzzy match scores.
+pub fn command_suggestions_scored(input: &str) -> Vec<(&'static str, usize)> {
+    parser::rank_with_scores(input.trim_start_matches('/'), &COMMANDS)
         .into_iter()
         .take(5)
         .collect()

--- a/src/spotlight/parser.rs
+++ b/src/spotlight/parser.rs
@@ -21,3 +21,13 @@ pub fn rank<'a>(query: &str, items: &'a [&'a str]) -> Vec<&'a str> {
     scored.sort_by_key(|t| t.0);
     scored.into_iter().map(|t| t.1).collect()
 }
+
+pub fn rank_with_scores<'a>(query: &str, items: &'a [&'a str]) -> Vec<(&'a str, usize)> {
+    let query = query.trim_start_matches('/');
+    let mut scored: Vec<(usize, &str)> = items
+        .iter()
+        .filter_map(|c| fuzzy_score(c, query).map(|s| (s, *c)))
+        .collect();
+    scored.sort_by_key(|t| t.0);
+    scored.into_iter().map(|t| (t.1, t.0)).collect()
+}

--- a/src/spotlight/render.rs
+++ b/src/spotlight/render.rs
@@ -1,0 +1,11 @@
+pub fn command_icon(cmd: &str) -> &'static str {
+    match cmd {
+        "zen" => "📄",
+        "settings" => "⚙️",
+        "triage" => "🧭",
+        "gemx" => "💭",
+        "plugin" => "🔌",
+        "search" => "🔍",
+        _ => "🔍",
+    }
+}

--- a/src/ui/components/spotlight.rs
+++ b/src/ui/components/spotlight.rs
@@ -8,7 +8,8 @@ use ratatui::{
 };
 
 use crate::state::AppState;
-use crate::spotlight::{command_preview, command_suggestions};
+use crate::spotlight::{command_preview, command_suggestions_scored};
+use crate::spotlight::render::command_icon;
 use crate::theme;
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
@@ -31,12 +32,12 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let y_offset = area.y + area.height / 3;
 
     let preview = command_preview(input);
-    let matches = command_suggestions(input);
+    let matches = command_suggestions_scored(input);
     let mut height = if preview.is_some() { 4 } else { 3 };
     // Ensure Spotlight stays above the status bar
     height = height.min(area.height.saturating_sub(1));
     let suggestion_count = matches.len().min(5) as u16;
-    let total_height = height + suggestion_count;
+    let total_height = height + suggestion_count * 2;
     let spotlight_area = Rect::new(x_offset, y_offset, width, height);
 
     let border_color = if state.spotlight_just_opened {
@@ -96,8 +97,8 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
 
     f.render_widget(paragraph, spotlight_area);
 
-    for (i, suggestion) in matches.iter().take(5).enumerate() {
-        let y = y_offset + 2 + i as u16;
+    for (i, (suggestion, score)) in matches.iter().take(5).enumerate() {
+        let y = y_offset + 2 + (i as u16 * 2);
         if y >= area.y + area.height.saturating_sub(1) {
             break;
         }
@@ -105,8 +106,16 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
         if Some(i) == state.spotlight_suggestion_index {
             style = style.fg(Color::Black).bg(Color::White);
         }
+        let icon = command_icon(suggestion);
+        let mut spans = vec![Span::styled(icon, style) , Span::raw(" "), Span::styled(*suggestion, style)];
+        #[cfg(debug_assertions)]
+        {
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(format!("{}", score), style.add_modifier(Modifier::DIM)));
+        }
+        let line = Line::from(spans);
         f.render_widget(
-            Paragraph::new(*suggestion).style(style),
+            Paragraph::new(line).style(style),
             Rect::new(x_offset, y, width, 1),
         );
     }


### PR DESCRIPTION
## Summary
- add command icon lookup for Spotlight results
- expose scored suggestions helper
- display icons and optional fuzzy scores in Spotlight panel

## Testing
- `cargo test --quiet -- --test-threads=1` *(fails: tests hang or run indefinitely)*