### PR TITLE
Patch 25.51u-o – Add Mindmap Lanes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use crate::state::serialize::PersistedLayout;
 
+pub mod theme;
+
 pub const CONFIG_VERSION: u32 = 1;
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use ratatui::style::Color;
 use std::fs;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -34,5 +35,9 @@ impl ThemeConfig {
 
     pub fn zen_breathe(&self) -> bool {
         self.zen_breathe
+    }
+
+    pub fn dim_color(&self) -> Color {
+        if self.dark_mode { Color::DarkGray } else { Color::Gray }
     }
 }

--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -1,8 +1,10 @@
-use ratatui::{prelude::*, Frame};
+use ratatui::{prelude::*, widgets::{Block, Paragraph}, Frame};
 
 use crate::state::AppState;
 use crate::render::traits::Renderable;
 use crate::screen::gemx::render_gemx;
+use crate::layout::BASE_SPACING_X;
+use crate::config::theme::ThemeConfig;
 
 /// Wrapper implementing [`Renderable`] for the GemX screen.
 pub struct GemxRenderer<'a> {
@@ -17,12 +19,45 @@ impl<'a> GemxRenderer<'a> {
 
 impl<'a> Renderable for GemxRenderer<'a> {
     fn render_frame<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
+        if self.state.mindmap_lanes {
+            draw_lanes(f, area);
+        }
         // Render main GemX view
         render_gemx(f, area, self.state);
     }
 
     fn tick(&mut self) {
         crate::triage::logic::update_pipeline(self.state);
+    }
+}
+
+fn draw_lanes<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    let theme = ThemeConfig::load();
+    let lane_color = theme.dim_color();
+    let lane_style = Style::default().bg(lane_color);
+    let lane_height = 3u16;
+
+    let mut toggle = false;
+    let mut y = 0u16;
+    while y < area.height {
+        if toggle {
+            let h = lane_height.min(area.height - y);
+            let rect = Rect::new(area.x, area.y + y, area.width, h);
+            f.render_widget(Block::default().style(lane_style), rect);
+        }
+        toggle = !toggle;
+        y += lane_height;
+    }
+
+    let dot = Paragraph::new("┆").style(Style::default().fg(lane_color));
+    let step = BASE_SPACING_X as u16;
+    let mut x = step;
+    while x < area.width.saturating_sub(1) {
+        for row in 0..area.height {
+            let rect = Rect::new(area.x + x, area.y + row, 1, 1);
+            f.render_widget(dot.clone(), rect);
+        }
+        x += step;
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,7 @@ pub struct UserSettings {
     pub zen_icon_glyph: Option<String>,
     pub beamx_panel_theme: BeamColor,
     pub beamx_panel_visible: bool,
+    pub mindmap_lanes: bool,
 }
 
 use ratatui::{
@@ -44,6 +45,7 @@ impl Default for UserSettings {
             zen_icon_glyph: None,
             beamx_panel_theme: BeamColor::Prism,
             beamx_panel_visible: crate::state::default_beamx_panel_visible(),
+            mindmap_lanes: true,
         }
     }
 }
@@ -71,6 +73,7 @@ pub fn save_user_settings(state: &AppState) {
         zen_icon_glyph: state.zen_icon_glyph.clone(),
         beamx_panel_theme: state.beamx_panel_theme,
         beamx_panel_visible: state.beamx_panel_visible,
+        mindmap_lanes: state.mindmap_lanes,
     };
 
     if let Ok(serialized) = toml::to_string(&config) {
@@ -134,6 +137,12 @@ fn toggle_beamx_panel_visibility(s: &mut AppState) {
     save_user_settings(s);
 }
 
+fn is_mindmap_lanes(s: &AppState) -> bool { s.mindmap_lanes }
+fn toggle_mindmap_lanes(s: &mut AppState) {
+    s.mindmap_lanes = !s.mindmap_lanes;
+    save_user_settings(s);
+}
+
 fn toggle_beamx_theme(s: &mut AppState) {
     s.cycle_beamx_panel_theme();
     save_user_settings(s);
@@ -166,6 +175,11 @@ pub const SETTING_TOGGLES: &[SettingToggle] = &[
         toggle: toggle_beamx_panel_visibility,
     },
     SettingToggle {
+        label: "Mindmap Lanes",
+        is_enabled: is_mindmap_lanes,
+        toggle: toggle_mindmap_lanes,
+    },
+    SettingToggle {
         label: "BeamX Theme",
         is_enabled: |_| true,
         toggle: toggle_beamx_theme,
@@ -196,6 +210,8 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppStat
                 label = format!("Settings Color: {}", state.settings_beam_color);
             } else if t.label.starts_with("BeamX Theme") {
                 label = format!("BeamX Theme: {}", state.beamx_panel_theme);
+            } else if t.label.starts_with("Mindmap Lanes") {
+                label = "Mindmap Lanes".into();
             }
 
             let check = if enabled { "[x]" } else { "[ ]" };

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -116,6 +116,7 @@ pub struct AppState {
     pub debug_border: bool,
     pub debug_overlay: bool,
     pub debug_overlay_sticky: bool,
+    pub mindmap_lanes: bool,
     pub simulate_input_queue: VecDeque<SimInput>,
     pub status_message: String,
     pub status_message_last_updated: Option<std::time::Instant>,
@@ -231,6 +232,7 @@ impl Default for AppState {
             debug_border: std::env::var("PRISMX_DEBUG_BORDER").is_ok(),
             debug_overlay: false,
             debug_overlay_sticky: false,
+            mindmap_lanes: true,
             simulate_input_queue: VecDeque::new(),
             status_message: String::new(),
             status_message_last_updated: None,
@@ -289,6 +291,7 @@ impl Default for AppState {
         state.zen_icon_glyph = config.zen_icon_glyph.clone();
         state.beamx_panel_theme = config.beamx_panel_theme;
         state.beamx_panel_visible = config.beamx_panel_visible;
+        state.mindmap_lanes = config.mindmap_lanes;
 
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {


### PR DESCRIPTION
## Summary
- support alternating lane striping and column guides in GemX
- expose lane dim color in theme config
- allow toggling "Mindmap Lanes" in settings

## Testing
- `cargo test`