### PR TITLE
Implement Zen dual view toggle

### DIFF
--- a/src/render/zen.rs
+++ b/src/render/zen.rs
@@ -1,5 +1,5 @@
 use ratatui::{prelude::*, widgets::{Block, Borders, Paragraph}, style::Modifier};
-use crate::state::{AppState, ZenSyntax, ZenTheme, ZenJournalView, ZenViewMode};
+use crate::state::{AppState, ZenSyntax, ZenTheme, ZenViewMode, ZenMode};
 use crate::zen::journal::extract_tags;
 use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
@@ -61,9 +61,9 @@ pub fn render_zen_journal<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppS
     let bg = Block::default().style(Style::default().bg(bg_color));
     f.render_widget(bg, area);
 
-    match state.zen_journal_view {
-        ZenJournalView::Compose => render_compose(f, area, state, tick),
-        ZenJournalView::Review => render_review(f, area, state),
+    match state.zen_mode {
+        ZenMode::Compose => render_compose(f, area, state, tick),
+        ZenMode::Scroll => render_review(f, area, state),
     }
     render_top_icon(f, area, state, tick);
 }

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -54,9 +54,13 @@ pub enum ZenTheme {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ZenJournalView {
+pub enum ZenMode {
     Compose,
-    Review,
+    Scroll,
+}
+
+impl Default for ZenMode {
+    fn default() -> Self { Self::Compose }
 }
 
 #[derive(Clone)]
@@ -139,7 +143,7 @@ pub struct AppState {
     pub zen_word_count: usize,
     pub zen_current_syntax: ZenSyntax,
     pub zen_theme: ZenTheme,
-    pub zen_journal_view: ZenJournalView,
+    pub zen_mode: crate::state::ZenMode,
     pub zen_view_mode: crate::state::ZenViewMode,
     pub zen_compose_input: String,
     pub zen_journal_entries: Vec<ZenJournalEntry>,
@@ -254,7 +258,7 @@ impl Default for AppState {
             zen_word_count: 0,
             zen_current_syntax: ZenSyntax::Markdown,
             zen_theme: ZenTheme::DarkGray,
-            zen_journal_view: ZenJournalView::Compose,
+            zen_mode: crate::state::ZenMode::default(),
             zen_view_mode: crate::state::ZenViewMode::default(),
             zen_compose_input: String::new(),
             zen_journal_entries: Vec::new(),

--- a/src/state/spotlight.rs
+++ b/src/state/spotlight.rs
@@ -1,5 +1,5 @@
 use super::core::{AppState, DockLayout, SimInput};
-use crate::state::ZenViewMode;
+use crate::state::{ZenViewMode, ZenMode};
 
 impl AppState {
     pub fn exit_spotlight(&mut self) {
@@ -101,6 +101,9 @@ impl AppState {
                 }
                 "zen summary" => {
                     self.toggle_summary_view();
+                }
+                "zen view toggle" => {
+                    crate::ui::input::toggle_zen_view(self);
                 }
                 _ if cmd.starts_with("open ") => {
                     let path = cmd.trim_start_matches("open ").trim();

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -43,6 +43,7 @@ impl Default for PluginViewMode {
     fn default() -> Self { Self::Registry }
 }
 
+
 #[derive(Clone, serde::Serialize)]
 pub struct DebugSnapshot {
     pub active_module: String,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -425,6 +425,11 @@ pub fn launch_ui() -> std::io::Result<()> {
                 {
                     state.zen_toolbar_open = !state.zen_toolbar_open;
                     state.zen_toolbar_index = 0;
+                } else if code == KeyCode::Tab
+                    && modifiers == KeyModifiers::ALT
+                    && state.mode == "zen"
+                {
+                    input::toggle_zen_view(&mut state);
                 } else if match_hotkey("toggle_collapsed", code, modifiers, &state) && state.mode == "gemx" {
                     state.toggle_collapse();
                 } else if match_hotkey("drill_down", code, modifiers, &state) {
@@ -559,15 +564,15 @@ pub fn launch_ui() -> std::io::Result<()> {
                         }
                     }
 
-                    KeyCode::Char(c) if state.mode == "zen" && state.zen_journal_view == crate::state::ZenJournalView::Compose => {
+                    KeyCode::Char(c) if state.mode == "zen" && state.zen_mode == crate::state::ZenMode::Compose => {
                         state.zen_compose_input.push(c);
                     }
 
-                    KeyCode::Backspace if state.mode == "zen" && state.zen_journal_view == crate::state::ZenJournalView::Compose => {
+                    KeyCode::Backspace if state.mode == "zen" && state.zen_mode == crate::state::ZenMode::Compose => {
                         state.zen_compose_input.pop();
                     }
 
-                    KeyCode::Enter if state.mode == "zen" && state.zen_journal_view == crate::state::ZenJournalView::Compose => {
+                    KeyCode::Enter if state.mode == "zen" && state.zen_mode == crate::state::ZenMode::Compose => {
                         let text = state.zen_compose_input.trim().to_string();
                         if !text.is_empty() {
                             let entry = crate::state::ZenJournalEntry { timestamp: chrono::Local::now(), text: text.clone() };

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -29,3 +29,11 @@ pub fn handle_log_keys(state: &mut AppState, code: KeyCode, mods: KeyModifiers) 
         _ => false,
     }
 }
+
+/// Toggle Zen compose/scroll view.
+pub fn toggle_zen_view(state: &mut AppState) {
+    state.zen_mode = match state.zen_mode {
+        crate::state::ZenMode::Compose => crate::state::ZenMode::Scroll,
+        crate::state::ZenMode::Scroll => crate::state::ZenMode::Compose,
+    };
+}


### PR DESCRIPTION
## Summary
- add ZenMode enum and track compose vs scroll
- toggle Zen view via `/zen view toggle` command or Alt+Tab hotkey
- render compose or scroll view depending on zen_mode

## Testing
- `cargo check`
- `cargo test` *(fails: tests hang >60s)*