### PR TITLE
Implement plugin card UI with tag filter

### DIFF
--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -5,6 +5,7 @@ pub struct PluginEntry {
     pub description: &'static str,
     pub trusted: bool,
     pub trust_chain: &'static str,
+    pub tags: &'static [&'static str],
 }
 
 pub fn registry() -> Vec<PluginEntry> {
@@ -15,6 +16,7 @@ pub fn registry() -> Vec<PluginEntry> {
             description: "Mindmap engine",
             trusted: true,
             trust_chain: "PrismX Core",
+            tags: &["editor", "trusted"],
         },
         PluginEntry {
             name: "Dashboard",
@@ -22,6 +24,7 @@ pub fn registry() -> Vec<PluginEntry> {
             description: "Project dashboard",
             trusted: true,
             trust_chain: "PrismX Core",
+            tags: &["utility", "trusted"],
         },
         PluginEntry {
             name: "Mindtrace",
@@ -29,6 +32,7 @@ pub fn registry() -> Vec<PluginEntry> {
             description: "AI memory system",
             trusted: false,
             trust_chain: "unknown",
+            tags: &["debug"],
         },
         PluginEntry {
             name: "RoutineForge",
@@ -36,6 +40,20 @@ pub fn registry() -> Vec<PluginEntry> {
             description: "Task & habit manager",
             trusted: false,
             trust_chain: "unknown",
+            tags: &["utility"],
         },
     ]
+}
+
+use crate::state::PluginTagFilter;
+
+pub fn registry_filtered(filter: PluginTagFilter) -> Vec<PluginEntry> {
+    registry()
+        .into_iter()
+        .filter(|p| match filter {
+            PluginTagFilter::All => true,
+            PluginTagFilter::Trusted => p.trusted,
+            PluginTagFilter::Debug => p.tags.iter().any(|t| *t == "debug"),
+        })
+        .collect()
 }

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -155,6 +155,7 @@ pub struct AppState {
     pub beamx_panel_visible: bool,
     pub triage_view_mode: crate::state::TriageViewMode,
     pub plugin_view_mode: crate::state::PluginViewMode,
+    pub plugin_tag_filter: crate::state::PluginTagFilter,
     pub plugin_registry_index: usize,
     pub show_plugin_preview: bool,
 }
@@ -270,6 +271,7 @@ impl Default for AppState {
             beamx_panel_visible: default_beamx_panel_visible(),
             triage_view_mode: crate::state::TriageViewMode::default(),
             plugin_view_mode: crate::state::PluginViewMode::default(),
+            plugin_tag_filter: crate::state::PluginTagFilter::default(),
             plugin_registry_index: 0,
             show_plugin_preview: false,
         };

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -43,6 +43,27 @@ impl Default for PluginViewMode {
     fn default() -> Self { Self::Registry }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PluginTagFilter {
+    All,
+    Trusted,
+    Debug,
+}
+
+impl Default for PluginTagFilter {
+    fn default() -> Self { Self::All }
+}
+
+impl PluginTagFilter {
+    pub fn next(self) -> Self {
+        match self {
+            PluginTagFilter::All => PluginTagFilter::Trusted,
+            PluginTagFilter::Trusted => PluginTagFilter::Debug,
+            PluginTagFilter::Debug => PluginTagFilter::All,
+        }
+    }
+}
+
 #[derive(Clone, serde::Serialize)]
 pub struct DebugSnapshot {
     pub active_module: String,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -516,7 +516,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     }
 
                     KeyCode::Up if state.mode == "plugin" && !state.show_plugin_preview => {
-                        let len = crate::plugin::registry::registry().len();
+                        let len = crate::plugin::registry::registry_filtered(state.plugin_tag_filter).len();
                         if len > 0 {
                             if state.plugin_registry_index == 0 {
                                 state.plugin_registry_index = len - 1;
@@ -526,13 +526,17 @@ pub fn launch_ui() -> std::io::Result<()> {
                         }
                     }
                     KeyCode::Down if state.mode == "plugin" && !state.show_plugin_preview => {
-                        let len = crate::plugin::registry::registry().len();
+                        let len = crate::plugin::registry::registry_filtered(state.plugin_tag_filter).len();
                         if len > 0 {
                             state.plugin_registry_index = (state.plugin_registry_index + 1) % len;
                         }
                     }
                     KeyCode::Enter if state.mode == "plugin" && !state.show_plugin_preview => {
                         state.show_plugin_preview = true;
+                    }
+                    KeyCode::Tab if state.mode == "plugin" && !state.show_plugin_preview => {
+                        state.plugin_tag_filter = state.plugin_tag_filter.next();
+                        state.plugin_registry_index = 0;
                     }
 
                     KeyCode::Up if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {


### PR DESCRIPTION
## Summary
- add tags to `PluginEntry` and helper filtering function
- introduce `PluginTagFilter` and state field
- render plugin cards with tags and filter label
- cycle plugin tag filter with <Tab>

## Testing
- `cargo check`