### PR TITLE
Implement plugin registry checksum sync

### DIFF
--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -7,6 +7,73 @@ pub struct PluginEntry {
     pub trust_chain: &'static str,
 }
 
+use std::sync::OnceLock;
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+struct RegistryState {
+    last_hash: Option<String>,
+    last_check: Instant,
+    last_sync: Option<Instant>,
+}
+
+static REGISTRY_STATE: OnceLock<Mutex<RegistryState>> = OnceLock::new();
+
+fn compute_hash() -> Option<String> {
+    let output = Command::new("sha256sum")
+        .arg("config/plugin.json")
+        .output()
+        .ok()?;
+    let hash = String::from_utf8_lossy(&output.stdout);
+    hash.split_whitespace().next().map(|s| s.to_string())
+}
+
+fn init_state() -> RegistryState {
+    RegistryState {
+        last_hash: compute_hash(),
+        last_check: Instant::now(),
+        last_sync: None,
+    }
+}
+
+/// Initialize plugin registry sync state.
+pub fn init() {
+    REGISTRY_STATE.get_or_init(|| Mutex::new(init_state()));
+}
+
+/// Check registry file for updates. Should be called periodically.
+pub fn tick() {
+    let lock = REGISTRY_STATE.get_or_init(|| Mutex::new(init_state()));
+    let mut state = lock.lock().unwrap();
+    if state.last_check.elapsed() < Duration::from_secs(2) {
+        return;
+    }
+    state.last_check = Instant::now();
+    let new_hash = match compute_hash() {
+        Some(h) => h,
+        None => return,
+    };
+    if state.last_hash.as_deref() != Some(&new_hash) {
+        state.last_hash = Some(new_hash);
+        if crate::config::load_locked_registry().is_ok() {
+            tracing::info!("[PLUGIN] registry synchronized");
+        }
+        state.last_sync = Some(Instant::now());
+    }
+}
+
+/// Returns true if a sync occurred recently.
+pub fn sync_badge() -> bool {
+    if let Some(lock) = REGISTRY_STATE.get() {
+        let state = lock.lock().unwrap();
+        if let Some(t) = state.last_sync {
+            return t.elapsed() < Duration::from_secs(3);
+        }
+    }
+    false
+}
+
 pub fn registry() -> Vec<PluginEntry> {
     vec![
         PluginEntry {

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -1,4 +1,5 @@
 use crate::plugin::loader;
+use crate::plugin::registry;
 
 /// Initialize runtime features on startup.
 pub fn init() {
@@ -12,6 +13,7 @@ pub fn init() {
             tracing::debug!("[INIT] plugin available: {}", plug.path.display());
         }
     }
+    registry::init();
 }
 
 /// Reload all plugins in the `plugins/` directory. Only `.so` and `.dylib`

--- a/src/ui/components/plugin.rs
+++ b/src/ui/components/plugin.rs
@@ -2,7 +2,16 @@ use ratatui::{backend::Backend, layout::Rect, Frame};
 
 use crate::state::AppState;
 use crate::plugin::panel::render_plugin_panel;
+use crate::plugin::registry;
+use ratatui::widgets::Paragraph;
+use ratatui::style::{Style, Color};
 
 pub fn render_plugin<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    registry::tick();
     render_plugin_panel(f, area, state);
+    if registry::sync_badge() {
+        let label = Paragraph::new("[sync]").style(Style::default().fg(Color::Green));
+        let width = 6u16;
+        f.render_widget(label, Rect::new(area.right().saturating_sub(width + 1), area.y, width, 1));
+    }
 }


### PR DESCRIPTION
## Summary
- monitor `config/plugin.json` hash for changes
- load checksum on app init
- display `[sync]` badge in plugin panel when registry file is reloaded

## Testing
- `cargo check`
- `cargo test` *(fails: tests hang at some point)*