### PR TITLE
Refactor settings into submodules

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -9,7 +9,6 @@ pub mod module_icon;
 pub mod favorites;
 pub mod zoom_overlay;
 pub mod traits;
-pub mod settings;
 
 pub use crate::zen::render::render_zen;
 pub use status::render_status_bar;
@@ -21,6 +20,6 @@ pub use module_icon::render_module_icon;
 pub use favorites::render_favorites_dock;
 pub use zoom_overlay::render_zoom_overlay;
 pub use traits::Renderable;
-pub use crate::render::settings::render_settings;
+pub use crate::settings::render::render_settings;
 pub use crate::settings::{SETTING_TOGGLES, SettingToggle, settings_len};
 

--- a/src/settings/layout.rs
+++ b/src/settings/layout.rs
@@ -1,0 +1,18 @@
+use ratatui::{layout::Rect, text::Line};
+use unicode_width::UnicodeWidthStr;
+
+/// Calculate centered rectangle for the settings panel based on content lines.
+pub fn settings_area(area: Rect, lines: &[Line]) -> Rect {
+    let content_width = lines
+        .iter()
+        .map(|l| l.width() as u16)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(4);
+
+    let width = content_width.min(area.width);
+    let height = lines.len() as u16 + 2;
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    Rect::new(x, y, width, height)
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,0 +1,79 @@
+// src/settings.rs
+use crate::beam_color::BeamColor;
+use crate::state::AppState;
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserSettings {
+    pub auto_arrange: bool,
+    pub debug_input_mode: bool,
+    pub dock_layout: String,
+    pub gemx_beam_color: BeamColor,
+    pub zen_beam_color: BeamColor,
+    pub triage_beam_color: BeamColor,
+    pub settings_beam_color: BeamColor,
+    pub zen_icon_enabled: bool,
+    pub zen_icon_glyph: Option<String>,
+    pub beamx_panel_theme: BeamColor,
+    pub beamx_panel_visible: bool,
+    pub mindmap_lanes: bool,
+}
+
+impl Default for UserSettings {
+    fn default() -> Self {
+        Self {
+            auto_arrange: true,
+            debug_input_mode: true,
+            dock_layout: "vertical".into(),
+            gemx_beam_color: BeamColor::Prism,
+            zen_beam_color: BeamColor::Prism,
+            triage_beam_color: BeamColor::Prism,
+            settings_beam_color: BeamColor::Prism,
+            zen_icon_enabled: true,
+            zen_icon_glyph: None,
+            beamx_panel_theme: BeamColor::Prism,
+            beamx_panel_visible: crate::state::default_beamx_panel_visible(),
+            mindmap_lanes: true,
+        }
+    }
+}
+
+pub fn load_user_settings() -> UserSettings {
+    if std::env::var("PRISMX_TEST").is_ok() {
+        return UserSettings::default();
+    }
+    fs::read_to_string("config/settings.toml")
+        .ok()
+        .and_then(|s| toml::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_user_settings(state: &AppState) {
+    let config = UserSettings {
+        auto_arrange: state.auto_arrange,
+        debug_input_mode: state.debug_input_mode,
+        dock_layout: format!("{:?}", state.favorite_dock_layout).to_lowercase(),
+        gemx_beam_color: state.gemx_beam_color,
+        zen_beam_color: state.zen_beam_color,
+        triage_beam_color: state.triage_beam_color,
+        settings_beam_color: state.settings_beam_color,
+        zen_icon_enabled: state.zen_icon_enabled,
+        zen_icon_glyph: state.zen_icon_glyph.clone(),
+        beamx_panel_theme: state.beamx_panel_theme,
+        beamx_panel_visible: state.beamx_panel_visible,
+        mindmap_lanes: state.mindmap_lanes,
+    };
+
+    if let Ok(serialized) = toml::to_string(&config) {
+        let _ = fs::create_dir_all("config");
+        let _ = fs::write("config/settings.toml", serialized);
+    }
+}
+
+
+pub mod toggle;
+pub mod layout;
+pub mod render;
+
+pub use toggle::{SettingToggle, SETTING_TOGGLES, settings_len, current_theme};

--- a/src/settings/render.rs
+++ b/src/settings/render.rs
@@ -1,4 +1,3 @@
-// src/render/settings.rs
 use ratatui::{
     backend::Backend,
     layout::Rect,
@@ -10,7 +9,7 @@ use ratatui::{
 
 use crate::state::AppState;
 use crate::config::theme::ThemeConfig;
-use crate::settings::{SETTING_TOGGLES, settings_len};
+use super::{layout::settings_area, toggle::SETTING_TOGGLES};
 
 pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let theme = ThemeConfig::load();
@@ -40,26 +39,15 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppStat
             Span::styled(format!("{} {} {}", check, t.icon, label), style),
         ]));
 
-        // Spacer lines after specific entries
         if i == 2 || i == 3 {
             lines.push(Line::default());
         }
     }
 
-    let content_width = lines
-        .iter()
-        .map(|l| l.width() as u16)
-        .max()
-        .unwrap_or(0)
-        .saturating_add(4);
-
-    let width = content_width.min(area.width);
-    let height = lines.len() as u16 + 2;
-    let x = area.x + (area.width.saturating_sub(width)) / 2;
-    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    let rect = settings_area(area, &lines);
 
     let block = Block::default().title("Settings").borders(Borders::ALL);
     let content = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
 
-    f.render_widget(content, Rect::new(x, y, width, height));
+    f.render_widget(content, rect);
 }

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -1,77 +1,7 @@
-// src/settings.rs
 use crate::beam_color::BeamColor;
 use crate::state::AppState;
-use crate::config::theme::ThemeConfig;
-use serde::{Deserialize, Serialize};
-use std::fs;
+use super::save_user_settings;
 use std::sync::atomic::{AtomicU8, Ordering};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserSettings {
-    pub auto_arrange: bool,
-    pub debug_input_mode: bool,
-    pub dock_layout: String,
-    pub gemx_beam_color: BeamColor,
-    pub zen_beam_color: BeamColor,
-    pub triage_beam_color: BeamColor,
-    pub settings_beam_color: BeamColor,
-    pub zen_icon_enabled: bool,
-    pub zen_icon_glyph: Option<String>,
-    pub beamx_panel_theme: BeamColor,
-    pub beamx_panel_visible: bool,
-    pub mindmap_lanes: bool,
-}
-
-impl Default for UserSettings {
-    fn default() -> Self {
-        Self {
-            auto_arrange: true,
-            debug_input_mode: true,
-            dock_layout: "vertical".into(),
-            gemx_beam_color: BeamColor::Prism,
-            zen_beam_color: BeamColor::Prism,
-            triage_beam_color: BeamColor::Prism,
-            settings_beam_color: BeamColor::Prism,
-            zen_icon_enabled: true,
-            zen_icon_glyph: None,
-            beamx_panel_theme: BeamColor::Prism,
-            beamx_panel_visible: crate::state::default_beamx_panel_visible(),
-            mindmap_lanes: true,
-        }
-    }
-}
-
-pub fn load_user_settings() -> UserSettings {
-    if std::env::var("PRISMX_TEST").is_ok() {
-        return UserSettings::default();
-    }
-    fs::read_to_string("config/settings.toml")
-        .ok()
-        .and_then(|s| toml::from_str(&s).ok())
-        .unwrap_or_default()
-}
-
-pub fn save_user_settings(state: &AppState) {
-    let config = UserSettings {
-        auto_arrange: state.auto_arrange,
-        debug_input_mode: state.debug_input_mode,
-        dock_layout: format!("{:?}", state.favorite_dock_layout).to_lowercase(),
-        gemx_beam_color: state.gemx_beam_color,
-        zen_beam_color: state.zen_beam_color,
-        triage_beam_color: state.triage_beam_color,
-        settings_beam_color: state.settings_beam_color,
-        zen_icon_enabled: state.zen_icon_enabled,
-        zen_icon_glyph: state.zen_icon_glyph.clone(),
-        beamx_panel_theme: state.beamx_panel_theme,
-        beamx_panel_visible: state.beamx_panel_visible,
-        mindmap_lanes: state.mindmap_lanes,
-    };
-
-    if let Ok(serialized) = toml::to_string(&config) {
-        let _ = fs::create_dir_all("config");
-        let _ = fs::write("config/settings.toml", serialized);
-    }
-}
 
 // Theme preset logic
 static THEME_INDEX: AtomicU8 = AtomicU8::new(0);


### PR DESCRIPTION
## Summary
- create `settings` directory with `mod.rs`
- move toggle logic into `settings/toggle.rs`
- add settings layout helper
- move settings rendering into `settings/render.rs`
- update re-exports in `render/mod.rs`

## Testing
- `cargo check`
- `cargo test --no-run`
