### PR TITLE
Modularize hotkeys

### DIFF
--- a/src/hotkeys/actions.rs
+++ b/src/hotkeys/actions.rs
@@ -1,0 +1,122 @@
+use crate::state::AppState;
+
+pub fn create_child(state: &mut AppState) {
+    state.push_undo();
+    state.handle_tab_key();
+}
+
+pub fn create_sibling(state: &mut AppState) {
+    state.push_undo();
+    state.handle_enter_key();
+}
+
+pub fn add_free_node(state: &mut AppState) {
+    state.push_undo();
+    crate::gemx::interaction::spawn_free_node(state);
+}
+
+pub fn delete_selected(state: &mut AppState) {
+    state.push_undo();
+    state.delete_node();
+}
+
+pub fn undo(state: &mut AppState) {
+    state.undo();
+}
+
+pub fn redo(state: &mut AppState) {
+    state.redo();
+}
+
+pub fn open_module_switcher(state: &mut AppState) {
+    state.module_switcher_open = true;
+    state.module_switcher_index = 0;
+}
+
+pub fn start_drag(state: &mut AppState) {
+    if state.selected_drag_source.is_some() {
+        if let Some(target) = state.selected {
+            state.push_undo();
+            state.complete_drag(target);
+        }
+    } else {
+        state.start_drag();
+    }
+}
+
+pub fn start_link(state: &mut AppState) {
+    if state.selected_drag_source.is_some() {
+        if let Some(target) = state.selected {
+            state.complete_link(target);
+        }
+    } else {
+        state.start_link();
+    }
+}
+
+pub fn toggle_link_mode(state: &mut AppState) {
+    state.link_mode = !state.link_mode;
+    crate::log_debug!(state, "link_mode toggled: {}", state.link_mode);
+}
+
+pub fn save(state: &mut AppState) {
+    state.export_zen_to_file();
+}
+
+pub fn mode_zen(state: &mut AppState) {
+    state.mode = "zen".into();
+}
+
+pub fn zen_toggle_theme(state: &mut AppState) {
+    state.cycle_zen_theme();
+}
+
+pub fn debug_snapshot(state: &mut AppState) {
+    crate::ui::components::debug::write_debug_snapshot(state);
+}
+
+pub fn debug_overlay(state: &mut AppState) {
+    state.debug_overlay = !state.debug_overlay;
+}
+
+pub fn debug_overlay_sticky(state: &mut AppState) {
+    state.debug_overlay_sticky = !state.debug_overlay_sticky;
+    state.debug_overlay = state.debug_overlay_sticky;
+}
+
+pub fn reload_plugins() {
+    crate::state::init::reload_plugins();
+}
+
+pub fn toggle_collapsed(state: &mut AppState) {
+    state.toggle_collapse();
+}
+
+pub fn drill_down(state: &mut AppState) {
+    state.drawing_root = state.selected;
+    state.fallback_this_frame = false;
+    state.clear_fallback_promotions();
+}
+
+pub fn pop_up(state: &mut AppState) {
+    state.drawing_root = None;
+    state.fallback_this_frame = false;
+    state.clear_fallback_promotions();
+}
+
+pub fn toggle_triage(state: &mut AppState) {
+    state.mode = "triage".into();
+}
+
+pub fn toggle_plugin(state: &mut AppState) {
+    state.mode = "plugin".into();
+}
+
+pub fn toggle_keymap(state: &mut AppState) {
+    state.show_keymap = !state.show_keymap;
+}
+
+pub fn toggle_settings(state: &mut AppState) {
+    state.mode = "settings".into();
+}
+

--- a/src/hotkeys/bindings.rs
+++ b/src/hotkeys/bindings.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+/// Input hotkey definitions for PrismX
+pub const SNAP_GRID_TOGGLE: &str = "Ctrl+G";
+
 
 pub fn load_default_hotkeys() -> HashMap<String, String> {
     let mut map = HashMap::new();

--- a/src/hotkeys/dispatcher.rs
+++ b/src/hotkeys/dispatcher.rs
@@ -36,7 +36,6 @@ pub fn match_hotkey(action: &str, code: KeyCode, mods: KeyModifiers, state: &App
             _ => false,
         };
 
-
         let code_match = match k {
             "tab" => code == KeyCode::Tab,
             "shift-tab" => matches!(code, KeyCode::BackTab | KeyCode::Tab) && mods.contains(KeyModifiers::SHIFT),
@@ -64,8 +63,6 @@ pub fn match_hotkey(action: &str, code: KeyCode, mods: KeyModifiers, state: &App
             "r" => code == KeyCode::Char('r'),
             "l" => code == KeyCode::Char('l'),
             "g" => code == KeyCode::Char('g'),
-
-
             _ => false,
         };
 

--- a/src/hotkeys/mod.rs
+++ b/src/hotkeys/mod.rs
@@ -1,0 +1,6 @@
+pub mod bindings;
+pub mod actions;
+pub mod dispatcher;
+
+pub use bindings::{load_default_hotkeys, load_hotkeys};
+pub use dispatcher::{match_hotkey, debug_input};

--- a/src/input/hotkeys.rs
+++ b/src/input/hotkeys.rs
@@ -1,2 +1,0 @@
-/// Input hotkey definitions for PrismX
-pub const SNAP_GRID_TOGGLE: &str = "Ctrl+G";

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,2 +1,1 @@
 pub mod mac_fallback;
-pub mod hotkeys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod gemx;
 pub mod routineforge;
 pub mod triage;
 pub mod settings;
+pub mod hotkeys;
 #[path = "state/mod.rs"]
 pub mod state;
 pub mod shortcuts;

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -5,7 +5,7 @@ use crate::layout::{GEMX_HEADER_HEIGHT, LayoutRole};
 use crate::plugin::PluginHost;
 pub use crate::state::zen::*;
 
-use super::hotkeys::load_hotkeys;
+use crate::hotkeys::load_hotkeys;
 
 #[derive(Clone, PartialEq)]
 pub struct LayoutSnapshot {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,3 @@
-pub mod hotkeys;
-pub use hotkeys::*;
 
 
 pub mod core;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -30,8 +30,7 @@ use crate::ui::components::debug::render_debug;
 use crate::ui::components::logs::render_logs;
 use crate::ui::input;
 
-mod hotkeys;
-use hotkeys::match_hotkey;
+use crate::hotkeys::match_hotkey;
 use crate::shortcuts::{match_shortcut, Shortcut};
 use std::time::Duration;
 
@@ -214,7 +213,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                 Event::Key(KeyEvent { code, modifiers, .. }) => {
                     last_key = format!("{:?} + {:?}", code, modifiers);
                     if state.debug_input_mode {
-                        crate::tui::hotkeys::debug_input(&mut state, code, modifiers);
+                        crate::hotkeys::debug_input(&mut state, code, modifiers);
                     }
                     if state.show_logs {
                         if input::handle_log_keys(&mut state, code, modifiers) {


### PR DESCRIPTION
## Summary
- move default hotkey bindings to `src/hotkeys/bindings.rs`
- extract dispatcher logic from TUI into `src/hotkeys/dispatcher.rs`
- add `src/hotkeys/actions.rs` with hotkey actions
- expose new modules via `src/hotkeys/mod.rs`
- wire modules through crate root and update imports
- remove old hotkeys modules

## Testing
- `cargo check` *(fails: rustfmt missing)*