### PR TITLE
Refactor triage into modular components

### DIFF
--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -32,7 +32,7 @@ impl<'a> Renderable for GemxRenderer<'a> {
     }
 
     fn tick(&mut self) {
-        crate::triage::logic::update_pipeline(self.state);
+        crate::triage::state::update_pipeline(self.state);
     }
 }
 

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -162,7 +162,7 @@ pub struct AppState {
     pub zen_compose_input: String,
     pub zen_journal_entries: Vec<ZenJournalEntry>,
     pub zen_tag_filter: Option<String>,
-    pub triage_entries: Vec<crate::triage::logic::TriageEntry>,
+    pub triage_entries: Vec<crate::triage::state::TriageEntry>,
     pub triage_summary: crate::state::view::TriageSummary,
     pub gemx_beam_color: crate::beam_color::BeamColor,
     pub zen_beam_color: crate::beam_color::BeamColor,

--- a/src/state/triage.rs
+++ b/src/state/triage.rs
@@ -1,4 +1,4 @@
-use crate::triage::logic::{capture_entry, handle_inline_command, TriageSource};
+use crate::triage::state::{capture_entry, handle_inline_command, TriageSource};
 use super::core::AppState;
 
 impl AppState {

--- a/src/triage/helpers.rs
+++ b/src/triage/helpers.rs
@@ -1,0 +1,35 @@
+use chrono::{NaiveDate, Datelike};
+use regex::Regex;
+use super::state::TriageEntry;
+
+/// Extract `#TAG` tokens from text.
+pub fn extract_tags(text: &str) -> Vec<String> {
+    let re = Regex::new(r"#\w+").unwrap();
+    re.find_iter(text)
+        .map(|m| m.as_str().to_string())
+        .collect()
+}
+
+/// Sort triage entries by priority tags.
+/// `#NOW` > `#TRITON` > `#TODO`/`#PRIORITY` > others.
+pub fn sort_by_priority(entries: &mut [TriageEntry]) {
+    fn priority(entry: &TriageEntry) -> u8 {
+        if entry.tags.iter().any(|t| t == "#NOW") {
+            0
+        } else if entry.tags.iter().any(|t| t == "#TRITON") {
+            1
+        } else if entry.tags.iter().any(|t| t == "#TODO" || t == "#PRIORITY") {
+            2
+        } else {
+            3
+        }
+    }
+    entries.sort_by_key(|e| priority(e));
+}
+
+/// Parse a YYYY-MM-DD date string from text.
+pub fn parse_due_date(text: &str) -> Option<NaiveDate> {
+    let re = Regex::new(r"(\d{4}-\d{2}-\d{2})").unwrap();
+    re.captures(text)
+        .and_then(|cap| NaiveDate::parse_from_str(&cap[1], "%Y-%m-%d").ok())
+}

--- a/src/triage/mod.rs
+++ b/src/triage/mod.rs
@@ -1,8 +1,8 @@
-pub mod panel;
-pub mod logic;
+pub mod state;
+pub mod view;
+pub mod helpers;
 
-pub use panel::render_triage_panel;
-pub use logic::{
+pub use state::{
     TriageEntry,
     TriageSource,
     handle_inline_command,
@@ -10,4 +10,6 @@ pub use logic::{
     update_pipeline,
     tag_counts,
 };
+pub use view::render_triage_panel;
+pub use helpers::{sort_by_priority, parse_due_date, extract_tags};
 

--- a/src/triage/state.rs
+++ b/src/triage/state.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Local};
-use regex::Regex;
 use crate::state::{AppState, ZenJournalEntry};
+use crate::triage::helpers::extract_tags;
 
 /// Tags that mark an entry for triage.
 const TRIAGE_TAGS: &[&str] = &["#TODO", "#TRITON", "#PRIORITY", "#NOW"];
@@ -36,13 +36,6 @@ impl TriageEntry {
             archived: false,
         }
     }
-}
-
-fn extract_tags(text: &str) -> Vec<String> {
-    let re = Regex::new(r"#\w+").unwrap();
-    re.find_iter(text)
-        .map(|m| m.as_str().to_string())
-        .collect()
 }
 
 /// Collect raw journal entries containing any triage tags.

--- a/src/triage/view.rs
+++ b/src/triage/view.rs
@@ -4,7 +4,7 @@ use ratatui::layout::{Layout, Constraint, Direction};
 use ratatui::text::{Line, Span};
 
 use crate::state::AppState;
-use crate::triage::logic::{TriageSource, tag_counts};
+use crate::triage::state::{TriageSource, tag_counts};
 use crate::ui::components::status::render_triage_status;
 use crate::beamx::render_full_border;
 


### PR DESCRIPTION
## Summary
- restructure triage module into helper, state and view files
- update module exports and references
- rename old logic and panel implementations

## Testing
- `cargo test` *(fails: tests hang, interrupted)*