### PR TITLE
Add PrismX WASM subcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
 
-# [target.'cfg(target_arch = "wasm32")'.dependencies]
-# wasm-bindgen = "0.2"
-# console_error_panic_hook = "0.1"
-# web-sys = { version = "0.3", features = ["console"] }
+# Build dependencies when targeting WebAssembly
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"
+web-sys = { version = "0.3", features = ["console"] }
 
 # [[bin]]
 # name = "prismx_wasm"
@@ -41,3 +42,6 @@ regex = "1"
 # [[bin]]
 # name = "wasm_build"
 # path = "build/wasm_build.rs"
+
+[workspace]
+members = ["crates/prismx-wasm"]

--- a/crates/prismx-wasm/Cargo.toml
+++ b/crates/prismx-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prismx-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/crates/prismx-wasm/src/lib.rs
+++ b/crates/prismx-wasm/src/lib.rs
@@ -1,0 +1,16 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn test_function() -> String {
+    "PrismX WASM ready".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(test_function(), "PrismX WASM ready");
+    }
+}


### PR DESCRIPTION
## Summary
- add new `prismx-wasm` subcrate exposing a simple wasm entrypoint
- enable wasm specific deps and declare workspace membership

## Testing
- `cargo test --quiet` *(fails: could not download `wasm-bindgen` crates due to missing network access)*