### PR TITLE
Enable dynamic plugin loading

### DIFF
--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -1,4 +1,4 @@
-use libloading::Library;
+use libloading::{Library, Symbol};
 use std::path::{Path, PathBuf};
 
 pub trait PluginEntry {
@@ -14,26 +14,40 @@ pub struct LoadedPlugin {
     lib: Library,
 }
 
+/// Safely open a dynamic library. This wraps the unsafe `Library::new` call
+/// behind a safe function boundary.
+fn open_library(path: &Path) -> Result<Library, libloading::Error> {
+    // SAFETY: Loading a library is unsafe because the caller must uphold that
+    // the loaded library is a valid shared object for the duration of the
+    // `Library` handle. We only expose a safe API and keep the `Library`
+    // owned by `LoadedPlugin`, ensuring it lives as long as needed.
+    unsafe { Library::new(path) }
+}
+
 /// Attempt to load a single plugin library and validate that it exposes the
 /// required `prismx_plugin_entry` symbol.
-pub fn load_plugin(path: &str) -> Option<LoadedPlugin> {
-    tracing::debug!("[PLUGIN] attempting {}", path);
-    unsafe {
-        match Library::new(path) {
-            Ok(lib) => {
-                let has_entry = lib.get::<libloading::Symbol<unsafe extern "C" fn()>>(b"prismx_plugin_entry").is_ok();
-                if has_entry {
-                    tracing::info!("[PLUGIN] loaded {}", path);
-                    Some(LoadedPlugin { path: PathBuf::from(path), lib })
-                } else {
-                    tracing::error!("[PLUGIN] missing entry symbol in {}", path);
+pub fn load_plugin(path: &Path) -> Option<LoadedPlugin> {
+    tracing::debug!("[PLUGIN] attempting {}", path.display());
+    match open_library(path) {
+        Ok(lib) => {
+            // SAFETY: the symbol type matches the expected `register` signature
+            // provided by plugins.
+            let register: Result<Symbol<unsafe extern "C" fn()>, _> = unsafe { lib.get(b"register") };
+            match register {
+                Ok(func) => {
+                    unsafe { func() };
+                    tracing::info!("[PLUGIN] loaded {}", path.display());
+                    Some(LoadedPlugin { path: path.to_path_buf(), lib })
+                }
+                Err(err) => {
+                    tracing::error!("[PLUGIN] missing register() in {}: {}", path.display(), err);
                     None
                 }
             }
-            Err(err) => {
-                tracing::error!("[PLUGIN] failed to load {}: {}", path, err);
-                None
-            }
+        }
+        Err(err) => {
+            tracing::error!("[PLUGIN] failed to load {}: {}", path.display(), err);
+            None
         }
     }
 }
@@ -48,7 +62,7 @@ pub fn discover_plugins(dir: &Path) -> Vec<LoadedPlugin> {
             let path = entry.path();
             if matches!(path.extension().and_then(|e| e.to_str()), Some("so") | Some("dylib")) {
                 tracing::debug!("[PLUGIN] loading {}", path.display());
-                match unsafe { Library::new(&path) } {
+                match open_library(&path) {
                     Ok(lib) => {
                         tracing::info!("[PLUGIN] discovered {}", path.display());
                         plugins.push(LoadedPlugin { path, lib });
@@ -60,6 +74,24 @@ pub fn discover_plugins(dir: &Path) -> Vec<LoadedPlugin> {
                             err
                         );
                     }
+                }
+            }
+        }
+    }
+    plugins
+}
+
+/// Load all plugins within a directory and invoke their `register` functions.
+/// Returns a vector of successfully loaded plugins.
+pub fn load_plugins(dir: &Path) -> Vec<LoadedPlugin> {
+    tracing::debug!("[PLUGIN] loading from {}", dir.display());
+    let mut plugins = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if matches!(path.extension().and_then(|e| e.to_str()), Some("so") | Some("dylib")) {
+                if let Some(plugin) = load_plugin(&path) {
+                    plugins.push(plugin);
                 }
             }
         }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,6 +6,7 @@ pub mod countdown;
 pub mod pomodoro;
 
 pub use interface::{PluginFrame, PluginRender};
+pub use loader::{load_plugin, load_plugins, discover_plugins, LoadedPlugin};
 pub use state::PluginHost;
 
 pub use countdown::CountdownPlugin;

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -4,7 +4,7 @@ use crate::plugin::registry;
 /// Initialize runtime features on startup.
 pub fn init() {
     let plugin_dir = std::path::Path::new("plugins");
-    let plugins = loader::discover_plugins(plugin_dir);
+    let plugins = loader::load_plugins(plugin_dir);
     if plugins.is_empty() {
         tracing::info!("[INIT] no dynamic plugins found");
     } else {
@@ -20,14 +20,5 @@ pub fn init() {
 /// files are loaded.
 pub fn reload_plugins() {
     let plugin_dir = std::path::Path::new("plugins");
-    if let Ok(entries) = std::fs::read_dir(plugin_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if matches!(path.extension().and_then(|e| e.to_str()), Some("so") | Some("dylib")) {
-                if let Some(p) = path.to_str() {
-                    let _ = loader::load_plugin(p);
-                }
-            }
-        }
-    }
+    let _ = loader::load_plugins(plugin_dir);
 }


### PR DESCRIPTION
## Summary
- wrap `libloading::Library::new` in a safe helper
- load `register()` from dynamic libraries
- add loader functions to scan the `plugins` folder and register
- expose new loader API
- use loader during init and reload

## Testing
- `cargo test` *(fails: tests hang or timeout)*