### PR TITLE
Enable no_std for core modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
 
+[features]
+default = ["std"]
+std = []
+
 # [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm-bindgen = "0.2"
 # console_error_panic_hook = "0.1"

--- a/src/core/layout/fallback.rs
+++ b/src/core/layout/fallback.rs
@@ -1,16 +1,17 @@
-use std::collections::{HashMap, HashSet};
-use crate::state::AppState;
-use crate::node::NodeID;
-use crate::layout::{Coords, LayoutRole, GEMX_HEADER_HEIGHT};
+#![cfg(feature = "std")]
 
-/// Promote unreachable nodes to root positions when auto-arrange is enabled.
-/// This helps recover nodes that would otherwise be lost off-screen.
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
+use crate::state::AppState;
+use crate::core::node::NodeID;
+use crate::core::layout::{Coords, LayoutRole, GEMX_HEADER_HEIGHT};
+
 #[allow(clippy::too_many_arguments)]
 pub fn promote_unreachable(
     state: &mut AppState,
-    reachable_ids: &HashSet<NodeID>,
-    drawn_at: &mut HashMap<NodeID, Coords>,
-    node_roles: &mut HashMap<NodeID, LayoutRole>,
+    reachable_ids: &BTreeSet<NodeID>,
+    drawn_at: &mut BTreeMap<NodeID, Coords>,
+    node_roles: &mut BTreeMap<NodeID, LayoutRole>,
     area_height: i16,
 ) {
     let node_ids: Vec<NodeID> = state.nodes.keys().copied().collect();
@@ -39,13 +40,11 @@ pub fn promote_unreachable(
         state.fallback_this_frame = true;
         state.fallback_promoted_this_session.insert(id);
 
-        use std::collections::HashSet;
-        let filled: HashSet<(i16, i16)> =
+        let filled: BTreeSet<(i16, i16)> =
             state.nodes.values().map(|n| (n.x, n.y)).collect();
 
         if let Some(n) = state.nodes.get_mut(&id) {
             if n.x == 0 && n.y == 0 {
-
                 let step_x = 20;
                 let step_y = 3;
                 let base_y = GEMX_HEADER_HEIGHT + 2;

--- a/src/core/layout/snapshot.rs
+++ b/src/core/layout/snapshot.rs
@@ -1,10 +1,14 @@
+#[cfg(feature = "std")]
 use crate::state::core::AppState;
+#[cfg(feature = "std")]
 use crate::state::serialize::{capture, apply, PersistedLayout};
 
+#[cfg(feature = "std")]
 pub fn save_layout(state: &AppState) -> PersistedLayout {
     capture(state)
 }
 
+#[cfg(feature = "std")]
 pub fn load_layout(state: &mut AppState, snap: PersistedLayout) {
     apply(state, snap);
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+pub mod node;
+pub mod layout;

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 pub type NodeID = u64;
 
@@ -19,7 +21,7 @@ impl Node {
             id,
             label: label.to_string(),
             parent,
-            children: vec![],
+            children: Vec::new(),
             collapsed: false,
             x: 0,
             y: 0,
@@ -27,5 +29,5 @@ impl Node {
     }
 }
 
-pub type NodeMap = HashMap<NodeID, Node>;
+pub type NodeMap = BTreeMap<NodeID, Node>;
 pub type Selection = Option<NodeID>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,83 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {};
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => {};
+}
+
+pub mod core;
+
+pub use core::{layout, node};
+
+#[cfg(feature = "std")]
 #[macro_use]
 pub mod logger;
-pub mod node;
-pub mod layout;
+
+#[cfg(feature = "std")]
 pub mod screen;
+#[cfg(feature = "std")]
 pub mod bootstrap;
+#[cfg(feature = "std")]
 pub mod config;
+#[cfg(feature = "std")]
 pub mod plugin;
+#[cfg(feature = "std")]
 pub mod plugins;
+#[cfg(feature = "std")]
 pub mod tui;
+#[cfg(feature = "std")]
 pub mod trust;
+#[cfg(feature = "std")]
 pub mod federation;
+#[cfg(feature = "std")]
 pub mod snapshot;
+#[cfg(feature = "std")]
 pub mod retire;
+#[cfg(feature = "std")]
 pub mod keymap;
+#[cfg(feature = "std")]
 pub mod spotlight;
+#[cfg(feature = "std")]
 pub mod theme;
+#[cfg(feature = "std")]
 pub mod clipboard;
+#[cfg(feature = "std")]
 pub mod input;
+#[cfg(feature = "std")]
 pub mod dashboard;
+#[cfg(feature = "std")]
 pub mod zen;
+#[cfg(feature = "std")]
 pub mod render;
+#[cfg(feature = "std")]
 pub mod beamx;
+#[cfg(feature = "std")]
 pub mod canvas;
+#[cfg(feature = "std")]
 pub mod beam_color;
+#[cfg(feature = "std")]
 pub mod ui;
+#[cfg(feature = "std")]
 pub mod gemx;
+#[cfg(feature = "std")]
 pub mod routineforge;
+#[cfg(feature = "std")]
 pub mod triage;
+#[cfg(feature = "std")]
 pub mod settings;
+#[cfg(feature = "std")]
 pub mod hotkeys;
+#[cfg(feature = "std")]
 #[path = "state/mod.rs"]
 pub mod state;
+#[cfg(feature = "std")]
 pub mod shortcuts;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "std")]
 fn main() -> std::io::Result<()> {
     prismx::bootstrap::start()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -12,11 +12,11 @@ use crate::canvas::prism::render_prism;
 use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::collections::{HashMap, HashSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 fn node_in_cycle(nodes: &NodeMap, start: NodeID) -> bool {
     let mut current = start;
-    let mut visited = HashSet::new();
+    let mut visited = BTreeSet::new();
     while let Some(pid) = nodes.get(&current).and_then(|n| n.parent) {
         if pid == start {
             return true;
@@ -88,8 +88,8 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         state.root_nodes.clone()
     };
 
-    let mut drawn_at = HashMap::new();
-    let mut node_roles = HashMap::new();
+    let mut drawn_at = BTreeMap::new();
+    let mut node_roles = BTreeMap::new();
     if state.auto_arrange {
         let mut pack = PackRegion::new(area.width as i16 - RESERVED_ZONE_W, GEMX_HEADER_HEIGHT);
         for &root_id in &roots {
@@ -124,7 +124,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
             node_roles.extend(roles);
         }
     } else {
-        fn collect(nodes: &NodeMap, id: NodeID, out: &mut HashMap<NodeID, Coords>) {
+        fn collect(nodes: &NodeMap, id: NodeID, out: &mut BTreeMap<NodeID, Coords>) {
             if let Some(n) = nodes.get(&id) {
                 out.insert(id, Coords { x: n.x, y: n.y });
                 if !n.collapsed {
@@ -177,12 +177,11 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         return;
     }
 
-    use std::collections::HashSet;
-    let reachable_ids: HashSet<NodeID> = drawn_at.keys().copied().collect();
+    let reachable_ids: BTreeSet<NodeID> = drawn_at.keys().copied().collect();
 
     if state.auto_arrange {
         let node_ids: Vec<NodeID> = state.nodes.keys().copied().collect();
-        let filled: HashSet<(i16, i16)> = state.nodes.values().map(|n| (n.x, n.y)).collect();
+        let filled: BTreeSet<(i16, i16)> = state.nodes.values().map(|n| (n.x, n.y)).collect();
 
         for id in node_ids {
             if let Some(n) = state.nodes.get_mut(&id) {

--- a/src/state/serialize.rs
+++ b/src/state/serialize.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Deserialize};
 use crate::state::core::AppState;
 use crate::node::{Node, NodeID};
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct NodeData {
@@ -70,7 +70,7 @@ pub fn apply(state: &mut AppState, snap: PersistedLayout) {
         .nodes
         .into_iter()
         .map(|n| (n.id, Node::from(n)))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
     state.root_nodes = snap.root_nodes;
     state.selected = snap.selected;
     state.zoom_scale = snap.zoom;


### PR DESCRIPTION
## Summary
- introduce `core` module with portable logic
- swap `std` collections for `alloc` in core
- gate non-core modules behind `std` feature
- allow compiling without default features

## Testing
- `cargo check --no-default-features`
- `cargo check`