### PR TITLE
Add prismx-wasm subcrate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ regex = "1"
 # [[bin]]
 # name = "wasm_build"
 # path = "build/wasm_build.rs"
+
+[workspace]
+members = [
+    "crates/prismx-wasm",
+    ".",
+]

--- a/crates/prismx-wasm/Cargo.toml
+++ b/crates/prismx-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prismx-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/crates/prismx-wasm/README.md
+++ b/crates/prismx-wasm/README.md
@@ -1,0 +1,11 @@
+# prismx-wasm
+
+WASM bindings for PrismX.
+
+## Building
+
+Install `wasm-pack` and then run:
+
+```bash
+wasm-pack build --target web
+```

--- a/crates/prismx-wasm/src/lib.rs
+++ b/crates/prismx-wasm/src/lib.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello from prismx-wasm".to_string()
+}


### PR DESCRIPTION
## Summary
- scaffold `prismx-wasm` subcrate for wasm usage
- set up workspace and default wasm build target
- provide example export and build instructions

## Testing
- `cargo test` *(fails: could not fetch crates)*