### PR TITLE
Clean compile warnings

### DIFF
--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -106,7 +106,7 @@ pub fn apply_layout(nodes: &mut NodeMap, roots: &[NodeID]) {
                     let child_ids = n.children.clone();
                     let child_y = n.y;
                     i += 1;
-                    drop(n);
+                    let _ = n;
                     arrange_horizontally(
                         nodes,
                         &child_ids,

--- a/src/input/mac_fallback.rs
+++ b/src/input/mac_fallback.rs
@@ -3,17 +3,17 @@ use crate::state::AppState;
 
 /// Handle Cmd+Left/Right scrolling on macOS.
 /// Returns true if the event was handled.
-pub fn handle_cmd_arrows(code: KeyCode, modifiers: KeyModifiers, state: &mut AppState) -> bool {
+pub fn handle_cmd_arrows(_code: KeyCode, _modifiers: KeyModifiers, _state: &mut AppState) -> bool {
     #[cfg(target_os = "macos")]
     {
-        if modifiers.contains(KeyModifiers::SUPER) && state.mode == "gemx" {
-            match code {
+        if _modifiers.contains(KeyModifiers::SUPER) && _state.mode == "gemx" {
+            match _code {
                 KeyCode::Left => {
-                    state.scroll_x = state.scroll_x.saturating_sub(4);
+                    _state.scroll_x = _state.scroll_x.saturating_sub(4);
                     return true;
                 }
                 KeyCode::Right => {
-                    state.scroll_x = state.scroll_x.saturating_add(4);
+                    _state.scroll_x = _state.scroll_x.saturating_add(4);
                     return true;
                 }
                 _ => {}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -320,6 +320,7 @@ fn layout_recursive_safe(
     (max_y, min_x_span.min(x), max_x_span.max(x + label_width))
 }
 
+#[allow(dead_code)]
 fn shift_subtree(id: NodeID, dx: i16, out: &mut HashMap<NodeID, Coords>, nodes: &NodeMap) {
     if dx == 0 {
         return;

--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -2,7 +2,6 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Clear, Wrap};
 use ratatui::text::{Line, Span};
 use ratatui::style::{Color, Modifier, Style};
-use chrono::Datelike;
 
 use crate::state::{AppState, PluginTagFilter};
 use crate::plugin::registry::registry_filtered;

--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     backend::Backend,
     layout::Rect,
-    style::{Modifier, Style},
+    style::Modifier,
     widgets::{Block, Borders, Paragraph},
     Frame,
 };

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -4,7 +4,7 @@ use crate::layout::{
     layout_nodes, Coords, LayoutRole, PackRegion, GEMX_HEADER_HEIGHT,
     CHILD_SPACING_Y, subtree_span, subtree_depth, spacing_for_zoom,
     BASE_SPACING_X, BASE_SPACING_Y, SNAP_GRID_X, SNAP_GRID_Y,
-    RESERVED_ZONE_W, RESERVED_ZONE_H,
+    RESERVED_ZONE_W,
 };
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;

--- a/src/settings/layout.rs
+++ b/src/settings/layout.rs
@@ -1,5 +1,4 @@
 use ratatui::{layout::Rect, text::Line};
-use unicode_width::UnicodeWidthStr;
 
 /// Calculate centered rectangle for the settings panel based on content lines.
 pub fn settings_area(area: Rect, lines: &[Line]) -> Rect {

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -3,7 +3,6 @@ use std::time::Instant;
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{GEMX_HEADER_HEIGHT, LayoutRole};
 use crate::plugin::PluginHost;
-pub use crate::zen::state::*;
 
 use crate::hotkeys::load_hotkeys;
 

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -1,4 +1,4 @@
-use super::core::{AppState, FavoriteEntry, LayoutSnapshot, DockLayout, ZenSyntax};
+use super::core::{AppState, FavoriteEntry, ZenSyntax};
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT};
 use crossterm::terminal;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -16,7 +16,6 @@ pub use core::*;
 pub mod serialize;
 
 pub use helpers::register_plugin_favorite;
-pub use triage::*;
 pub use view::*;
 
 impl AppState {

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -1,5 +1,4 @@
 use super::core::AppState;
-use crate::node::NodeID;
 
 impl AppState {
     pub fn move_focus_up(&mut self) {

--- a/src/state/spotlight.rs
+++ b/src/state/spotlight.rs
@@ -1,5 +1,4 @@
 use super::core::{AppState, DockLayout, SimInput};
-use crate::state::{ZenViewMode, ZenMode};
 
 impl AppState {
     pub fn exit_spotlight(&mut self) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,14 +1,14 @@
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 use std::fs;
+use std::sync::Mutex;
 
-static mut CURRENT_THEME: &str = "dark";
+static CURRENT_THEME: Mutex<&str> = Mutex::new("dark");
 
 pub fn toggle_theme() {
-    unsafe {
-        CURRENT_THEME = if CURRENT_THEME == "dark" { "light" } else { "dark" };
-        tracing::debug!("[THEME] Switched to: {}", CURRENT_THEME);
-    }
+    let mut theme = CURRENT_THEME.lock().unwrap();
+    *theme = if *theme == "dark" { "light" } else { "dark" };
+    tracing::debug!("[THEME] Switched to: {}", *theme);
 }
 
 pub fn get_style(target: &str) -> Style {

--- a/src/triage/helpers.rs
+++ b/src/triage/helpers.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDate, Datelike};
+use chrono::NaiveDate;
 use regex::Regex;
 use super::state::TriageEntry;
 

--- a/src/triage/view.rs
+++ b/src/triage/view.rs
@@ -9,6 +9,7 @@ use crate::ui::components::status::render_triage_status;
 use crate::beamx::render_full_border;
 
 
+#[allow(dead_code)]
 fn draw_plain_border<B: Backend>(f: &mut Frame<B>, area: Rect, color: Color) {
     let style = Style::default().fg(color);
     let right = area.x + area.width.saturating_sub(1);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,9 +24,7 @@ fn rect_contains(rect: ratatui::layout::Rect, x: u16, y: u16) -> bool {
 }
 use crate::screen::render_gemx;
 use crate::render::render_settings;
-use crate::settings::{SETTING_TOGGLES, settings_len};
 use crate::ui::components::plugin::render_plugin;
-use crate::ui::components::debug::render_debug;
 use crate::ui::components::logs::render_logs;
 use crate::ui::input;
 

--- a/src/ui/components/debug.rs
+++ b/src/ui/components/debug.rs
@@ -17,7 +17,7 @@ use crate::layout::subtree_depth;
 
 /// Render debug information when [`AppState::debug_input_mode`] is enabled.
 pub fn render_debug<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
-    let plugins = registry_filtered(PluginTagFilter::All);
+    let _plugins = registry_filtered(PluginTagFilter::All);
     if !state.debug_input_mode {
         return;
     }

--- a/src/ui/components/feed.rs
+++ b/src/ui/components/feed.rs
@@ -26,7 +26,7 @@ pub fn render_feed<B: Backend>(
     let mut blocks: Vec<Vec<Line>> = Vec::new();
     let mut current_label = String::new();
 
-    for (idx, entry) in entries.iter().enumerate().rev() {
+    for (_idx, entry) in entries.iter().enumerate().rev() {
         // Filter by tag if present
         if let Some(tag) = tag_filter {
             if !extract_tags(&entry.text)

--- a/src/ui/components/plugin.rs
+++ b/src/ui/components/plugin.rs
@@ -1,14 +1,13 @@
 use ratatui::{
     backend::Backend,
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    style::{Color, Style},
+    widgets::Paragraph,
     Frame,
 };
 use crate::ui::layout::Rect;
 
 use crate::state::AppState;
-use crate::plugin::registry::{self, PluginManifest};
+use crate::plugin::registry::{self};
 use crate::plugin::panel::render_plugin_panel;
 
 /// Primary plugin module renderer.

--- a/src/zen/mod.rs
+++ b/src/zen/mod.rs
@@ -5,7 +5,6 @@ pub mod journal;
 pub mod utils;
 
 pub use editor::*;
-pub use state::*;
 pub use view::*;
 pub use journal::*;
 pub use utils::*;

--- a/src/zen/utils.rs
+++ b/src/zen/utils.rs
@@ -25,7 +25,6 @@ pub fn extract_tags(text: &str) -> Vec<String> {
 }
 
 pub fn highlight_tags_line(input: &str) -> Line<'static> {
-    use ratatui::text::{Span, Line};
     let mut spans = Vec::new();
     for token in input.split_whitespace() {
         if token.starts_with('#') {


### PR DESCRIPTION
## Summary
- remove unused imports across modules
- prefix unused debug variables
- clean up unused variables in mac fallback and feed
- replace invalid drop with let _ = value
- mark unused helpers with `#[allow(dead_code)]`
- guard theme state with `Mutex` instead of `static mut`

## Testing
- `cargo check --color=never`
- `cargo test --color=never` *(fails: tests hang after 60s)*