### PR TITLE
Add prismx-wasm subcrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ git clone https://github.com/your-org/prismx
 cd prismx
 cargo build --release
 ./target/release/prismx
+### Build (WebAssembly)
+
+```bash
+cd crates/prismx-wasm
+wasm-pack build --target web
+```
+
+See [crates/prismx-wasm](crates/prismx-wasm) for source.
+
 Prebuilt binaries coming soon for Linux (deb/rpm), macOS (arm64/x64), and Windows.
 ⚙️ Quick Start
 

--- a/crates/prismx-wasm/Cargo.toml
+++ b/crates/prismx-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prismx-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/crates/prismx-wasm/src/lib.rs
+++ b/crates/prismx-wasm/src/lib.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn init() {
+    // TODO: integrate with PrismX core
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,15 @@ git clone https://github.com/your-org/prismx
 cd prismx
 cargo build --release
 ./target/release/prismx
+### Build (WebAssembly)
+
+```bash
+cd crates/prismx-wasm
+wasm-pack build --target web
+```
+
+See [crates/prismx-wasm](../crates/prismx-wasm) for source.
+
 Prebuilt binaries coming soon for Linux (deb/rpm), macOS (arm64/x64), and Windows.
 ⚙️ Quick Start
 


### PR DESCRIPTION
## Summary
- create `prismx-wasm` crate for wasm builds
- expose dummy `init()` function via `wasm-bindgen`
- document wasm build steps in README and docs

## Testing
- `cargo check --manifest-path Cargo.toml`
- `cargo check --manifest-path crates/prismx-wasm/Cargo.toml` *(fails: could not download wasm-bindgen)*