### PR TITLE
Implement basic no_std gating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
 
+[features]
+default = ["std"]
+std = []
+
 # [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm-bindgen = "0.2"
 # console_error_panic_hook = "0.1"

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -6,7 +6,7 @@ use crate::layout::{
     subtree_depth, spacing_for_zoom,
 };
 use crossterm::terminal;
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 use std::time::Instant;
 
 /// Toggle snap-to-grid mode
@@ -27,7 +27,7 @@ pub fn spawn_free_node(state: &mut AppState) {
     let mut node = Node::new(new_id, "Free Node", None);
 
     if !state.auto_arrange {
-        use std::collections::HashSet;
+        use alloc::collections::HashSet;
 
         let (tw, th) = terminal::size().unwrap_or((80, 20));
         let used: HashSet<(i16, i16)> =

--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -1,6 +1,6 @@
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
-use std::collections::HashSet;
+use alloc::collections::HashSet;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 /// Layout mode selector for GemX.

--- a/src/hotkeys/bindings.rs
+++ b/src/hotkeys/bindings.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 
 /// Input hotkey definitions for PrismX
 pub const SNAP_GRID_TOGGLE: &str = "Ctrl+G";

--- a/src/layout/fallback.rs
+++ b/src/layout/fallback.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use alloc::collections::{HashMap, HashSet};
 use crate::state::AppState;
 use crate::node::NodeID;
 use crate::layout::{Coords, LayoutRole, GEMX_HEADER_HEIGHT};
@@ -39,7 +39,7 @@ pub fn promote_unreachable(
         state.fallback_this_frame = true;
         state.fallback_promoted_this_session.insert(id);
 
-        use std::collections::HashSet;
+        use alloc::collections::HashSet;
         let filled: HashSet<(i16, i16)> =
             state.nodes.values().map(|n| (n.x, n.y)).collect();
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use alloc::collections::{HashMap, HashSet};
 use crate::node::{NodeID, NodeMap};
 
 pub mod roles;
@@ -201,7 +201,7 @@ pub fn layout_nodes(
     }
 
     if auto_arrange {
-        use std::collections::HashSet;
+        use alloc::collections::HashSet;
         let mut used: HashSet<(i16, i16)> = HashSet::new();
         let mut offset_y: i16 = 0;
         for pos in coords.values_mut() {
@@ -382,7 +382,7 @@ pub fn avoid_reserved_zone_map(map: &mut HashMap<NodeID, Coords>, term_width: i1
 /// Works for both auto-arrange and manual layout modes. When zoom is locked by
 /// the user, scrolling only occurs if the node would otherwise be off-screen.
 pub fn center_on_node(state: &mut crate::state::AppState, node_id: NodeID) {
-    use std::collections::HashMap;
+    use alloc::collections::HashMap;
 
     if !state.nodes.contains_key(&node_id) {
         return;

--- a/src/layout/roles.rs
+++ b/src/layout/roles.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 use crate::node::NodeID;
 use crate::state::AppState;
 use crate::layout::{LayoutRole, CHILD_SPACING_Y};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 #[macro_use]
 pub mod logger;
 pub mod node;
 pub mod layout;
+#[cfg(std)]
 pub mod screen;
 pub mod bootstrap;
 pub mod config;
 pub mod plugin;
 pub mod plugins;
+#[cfg(std)]
 pub mod tui;
 pub mod trust;
 pub mod federation;
@@ -19,10 +25,12 @@ pub mod clipboard;
 pub mod input;
 pub mod dashboard;
 pub mod zen;
+#[cfg(std)]
 pub mod render;
 pub mod beamx;
 pub mod canvas;
 pub mod beam_color;
+#[cfg(std)]
 pub mod ui;
 pub mod gemx;
 pub mod routineforge;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 
 pub type NodeID = u64;
 

--- a/src/plugins/state.rs
+++ b/src/plugins/state.rs
@@ -1,6 +1,6 @@
 use crate::plugins::{PluginFrame, PluginRender, PomodoroPlugin, CountdownPlugin};
 use ratatui::layout::Rect;
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
 use std::time::{Duration, SystemTime};
 
 pub struct PluginHost {

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -12,7 +12,7 @@ use crate::canvas::prism::render_prism;
 use crate::beamx::render_full_border;
 use crate::ui::beamx::{BeamX, BeamXStyle, BeamXMode, BeamXAnimationMode};
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::collections::{HashMap, HashSet};
+use alloc::collections::{HashMap, HashSet};
 
 fn node_in_cycle(nodes: &NodeMap, start: NodeID) -> bool {
     let mut current = start;
@@ -177,7 +177,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
         return;
     }
 
-    use std::collections::HashSet;
+    use alloc::collections::HashSet;
     let reachable_ids: HashSet<NodeID> = drawn_at.keys().copied().collect();
 
     if state.auto_arrange {

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use alloc::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{GEMX_HEADER_HEIGHT, LayoutRole};
@@ -109,7 +109,7 @@ pub struct AppState {
     pub redo_stack: Vec<LayoutSnapshot>,
     pub view_stack: Vec<Option<NodeID>>,
     pub selected_drag_source: Option<NodeID>,
-    pub link_map: std::collections::HashMap<NodeID, Vec<NodeID>>,
+    pub link_map: alloc::collections::HashMap<NodeID, Vec<NodeID>>,
     pub auto_arrange: bool,
     pub zoom_scale: f32,
     pub zoom_locked_by_user: bool,
@@ -180,7 +180,7 @@ pub struct AppState {
 }
 
 pub fn default_beamx_panel_visible() -> bool {
-    #[cfg(target_os = "macos")]
+    #[cfg(all(std, target_os = "macos"))]
     {
         if let Ok(term) = std::env::var("TERM_PROGRAM") {
             if term.to_lowercase().contains("iterm") {
@@ -232,7 +232,7 @@ impl Default for AppState {
             redo_stack: Vec::new(),
             view_stack: Vec::new(),
             selected_drag_source: None,
-            link_map: std::collections::HashMap::new(),
+            link_map: alloc::collections::HashMap::new(),
             auto_arrange: true,
             zoom_scale: 1.0,
             zoom_locked_by_user: false,
@@ -251,7 +251,16 @@ impl Default for AppState {
             layout_warning_logged: false,
             layout_fail_count: 0,
             debug_input_mode: true,
-            debug_border: std::env::var("PRISMX_DEBUG_BORDER").is_ok(),
+            debug_border: {
+                #[cfg(std)]
+                {
+                    std::env::var("PRISMX_DEBUG_BORDER").is_ok()
+                }
+                #[cfg(not(std))]
+                {
+                    false
+                }
+            },
             debug_overlay: false,
             debug_overlay_sticky: false,
             mindmap_lanes: true,

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -2,7 +2,7 @@ use super::core::{AppState, FavoriteEntry, LayoutSnapshot, DockLayout, ZenSyntax
 use crate::node::{Node, NodeID, NodeMap};
 use crate::layout::{SIBLING_SPACING_X, CHILD_SPACING_Y, GEMX_HEADER_HEIGHT};
 use crossterm::terminal;
-use std::collections::HashSet;
+use alloc::collections::HashSet;
 use std::time::Instant;
 
 impl AppState {
@@ -148,7 +148,7 @@ impl AppState {
     }
 
     pub fn audit_node_graph(&mut self) {
-        use std::collections::VecDeque;
+        use alloc::collections::VecDeque;
         for (&id, node) in &self.nodes {
             if node.label.trim().is_empty() {
                 crate::log_debug!(self, "⚠ Node {} has no label", id);

--- a/src/state/serialize.rs
+++ b/src/state/serialize.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Deserialize};
 use crate::state::core::AppState;
 use crate::node::{Node, NodeID};
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct NodeData {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
 use ratatui::style::{Color, Style};
-use std::collections::HashMap;
+use alloc::collections::HashMap;
 use std::fs;
 
 static mut CURRENT_THEME: &str = "dark";

--- a/src/triage/view.rs
+++ b/src/triage/view.rs
@@ -105,7 +105,7 @@ pub fn render_triage_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut
     f.render_widget(feed, body[0]);
 
     // --- Right Stats ---
-    use std::collections::BTreeMap;
+    use alloc::collections::BTreeMap;
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
     for entry in &state.triage_entries {
         if entry.archived { continue; }


### PR DESCRIPTION
## Summary
- add `std` feature flags
- allow building without the standard library
- update imports for `alloc::collections`
- guard certain runtime modules with `#[cfg(std)]`
- adapt state defaults for `no_std` environments

## Testing
- `cargo check --no-default-features` *(fails: use of undeclared types and cfg(std) warnings)*