### PR TITLE
Implement async task dispatcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
 
+# Async runtime
+tokio = { version = "1", features = ["rt", "macros"] }
+crossbeam-channel = "0.5"
+once_cell = "1"
+
 # [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm-bindgen = "0.2"
 # console_error_panic_hook = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,4 @@ pub mod hotkeys;
 #[path = "state/mod.rs"]
 pub mod state;
 pub mod shortcuts;
+pub mod tasks;

--- a/src/tasks/dispatcher.rs
+++ b/src/tasks/dispatcher.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{atomic::{AtomicU64, Ordering}, Mutex};
+
+use once_cell::sync::Lazy;
+use crossbeam_channel::{unbounded, Sender};
+use tokio::runtime::{Handle, Runtime};
+
+use crate::tasks::types::{TaskId, TaskHandle};
+
+static TASK_COUNTER: AtomicU64 = AtomicU64::new(1);
+static TASK_REGISTRY: Lazy<Mutex<HashMap<TaskId, (String, TaskHandle)>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+struct FallbackTask {
+    id: TaskId,
+    name: String,
+    fut: Box<dyn Future<Output = ()> + Send + 'static>,
+}
+
+static FALLBACK_SENDER: Lazy<Sender<FallbackTask>> = Lazy::new(|| {
+    let (tx, rx) = unbounded::<FallbackTask>();
+    std::thread::Builder::new()
+        .name("task-worker".into())
+        .spawn(move || {
+            let rt = Runtime::new().expect("runtime");
+            for task in rx {
+                tracing::info!("[task] executing {}: {}", task.id, task.name);
+                rt.block_on(task.fut);
+                TASK_REGISTRY.lock().unwrap().remove(&task.id);
+            }
+        })
+        .expect("spawn worker thread");
+    tx
+});
+
+/// Spawn an asynchronous task and track it in the registry.
+pub fn spawn_task<Fut>(name: impl Into<String>, fut: Fut) -> TaskId
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let id = TASK_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let name_str = name.into();
+    tracing::info!("[task] launch {}: {}", id, name_str);
+
+    if Handle::try_current().is_ok() {
+        let handle = tokio::spawn(fut);
+        TASK_REGISTRY
+            .lock()
+            .unwrap()
+            .insert(id, (name_str, TaskHandle::Tokio(handle)));
+    } else {
+        FALLBACK_SENDER
+            .send(FallbackTask {
+                id,
+                name: name_str.clone(),
+                fut: Box::new(fut),
+            })
+            .expect("send to worker");
+        TASK_REGISTRY
+            .lock()
+            .unwrap()
+            .insert(id, (name_str, TaskHandle::Fallback));
+    }
+
+    id
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,0 +1,5 @@
+pub mod dispatcher;
+pub mod types;
+
+pub use dispatcher::spawn_task;
+pub use types::{TaskHandle, TaskId};

--- a/src/tasks/types.rs
+++ b/src/tasks/types.rs
@@ -1,0 +1,12 @@
+use tokio::task::JoinHandle;
+
+/// Identifier for a spawned async task.
+pub type TaskId = u64;
+
+/// Handle to a running task, used for bookkeeping.
+pub enum TaskHandle {
+    /// Task running on the Tokio runtime.
+    Tokio(JoinHandle<()>),
+    /// Task executed via the fallback worker thread.
+    Fallback,
+}


### PR DESCRIPTION
## Summary
- add dependencies for async runtime
- provide task handle types
- implement task dispatcher with Tokio or crossbeam fallback
- expose tasks module

## Testing
- `cargo check` *(fails: failed to download crates)*