### PR TITLE
Implement serde-based user config loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2" # file logging via PRISMX_LOG
 libloading = "0.7"
 regex = "1"
+once_cell = "1"
 
 # [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm-bindgen = "0.2"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+theme = "dark"
+default_module = "gemx"
+log_level = "info"

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,4 +1,11 @@
 pub fn start() -> std::io::Result<()> {
+    let cfg = crate::config::load_config();
+    if let Some(level) = cfg.log_level.as_deref() {
+        std::env::set_var("PRISMX_LOG", level);
+    }
+    if let Some(theme) = cfg.theme.as_deref() {
+        crate::theme::set_theme(theme);
+    }
     crate::logger::init_logger();
     tracing::info!("PrismX logging started");
     tracing::info!("Application bootstrap");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct PrismXConfig {
+    pub theme: Option<String>,
+    pub default_module: Option<String>,
+    pub log_level: Option<String>,
+}
+
+pub fn load_config() -> PrismXConfig {
+    fs::read_to_string("config.toml")
+        .ok()
+        .and_then(|s| toml::from_str(&s).ok())
+        .unwrap_or_default()
+}

--- a/src/gemx/render.rs
+++ b/src/gemx/render.rs
@@ -5,7 +5,7 @@ use crate::render::traits::Renderable;
 use crate::screen::gemx::render_gemx;
 use crate::layout::BASE_SPACING_X;
 use crate::gemx::layout::{apply_layout, set_mode};
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 
 /// Wrapper implementing [`Renderable`] for the GemX screen.
 pub struct GemxRenderer<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ pub mod node;
 pub mod layout;
 pub mod screen;
 pub mod bootstrap;
+#[path = "config/mod.rs"]
+pub mod config_store;
+#[path = "config.rs"]
 pub mod config;
 pub mod plugin;
 pub mod plugins;

--- a/src/settings/render.rs
+++ b/src/settings/render.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::state::AppState;
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 use super::{layout::settings_area, toggle::SETTING_TOGGLES};
 
 pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -319,6 +319,10 @@ impl Default for AppState {
         state.beamx_panel_visible = config.beamx_panel_visible;
         state.mindmap_lanes = config.mindmap_lanes;
 
+        if let Some(module) = crate::config::load_config().default_module {
+            state.mode = module;
+        }
+
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {
                 node.label = node.label.replacen("[F] ", "", 1);
@@ -329,7 +333,7 @@ impl Default for AppState {
         state.load_today_journal();
         state.audit_node_graph();
 
-        if let Some(layout) = crate::config::load_config().layout {
+        if let Some(layout) = crate::config_store::load_config().layout {
             crate::state::serialize::apply(&mut state, layout);
         }
 

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -397,8 +397,8 @@ pub fn register_plugin_favorite(state: &mut AppState, icon: &'static str, comman
 impl AppState {
     pub fn save_layout_config(&self) {
         let layout = crate::state::serialize::capture(self);
-        let mut cfg = crate::config::load_config();
+        let mut cfg = crate::config_store::load_config();
         cfg.layout = Some(layout);
-        crate::config::save_config(&cfg);
+        crate::config_store::save_config(&cfg);
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,14 +1,25 @@
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 use std::fs;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
-static mut CURRENT_THEME: &str = "dark";
+static CURRENT_THEME: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new("dark".to_string()));
 
 pub fn toggle_theme() {
-    unsafe {
-        CURRENT_THEME = if CURRENT_THEME == "dark" { "light" } else { "dark" };
-        tracing::debug!("[THEME] Switched to: {}", CURRENT_THEME);
+    let mut theme = CURRENT_THEME.lock().unwrap();
+    if theme.as_str() == "dark" {
+        *theme = "light".to_string();
+    } else {
+        *theme = "dark".to_string();
     }
+    tracing::debug!("[THEME] Switched to: {}", *theme);
+}
+
+pub fn set_theme(theme: &str) {
+    let mut current = CURRENT_THEME.lock().unwrap();
+    *current = theme.to_string();
+    tracing::debug!("[THEME] Set to: {}", *current);
 }
 
 pub fn get_style(target: &str) -> Style {

--- a/src/ui/components/feed.rs
+++ b/src/ui/components/feed.rs
@@ -9,7 +9,7 @@ use crate::ui::layout::Rect;
 
 use crate::state::ZenJournalEntry;
 use crate::ui::animate::fade_line;
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 use crate::zen::utils::extract_tags;
 use chrono::Datelike;
 

--- a/src/ui/components/module.rs
+++ b/src/ui/components/module.rs
@@ -9,7 +9,7 @@ use crate::ui::layout::Rect;
 
 use crate::state::AppState;
 use crate::ui::animate;
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 
 pub fn render_module_switcher<B: Backend>(
     f: &mut Frame<B>,

--- a/src/ui/components/spotlight.rs
+++ b/src/ui/components/spotlight.rs
@@ -11,7 +11,7 @@ use crate::state::AppState;
 use crate::spotlight::{command_preview, command_suggestions_scored};
 use crate::spotlight::result::command_icon;
 use crate::theme;
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 
 pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     let input = &state.spotlight_input;

--- a/src/ui/components/theme.rs
+++ b/src/ui/components/theme.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 use crate::ui::layout::Rect;
 
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 
 /// Render the theme editor panel.
 /// This is a simple UI for adjusting brightness, contrast

--- a/src/zen/editor.rs
+++ b/src/zen/editor.rs
@@ -27,7 +27,7 @@ pub fn handle_key(state: &mut AppState, key: KeyCode) {
                 state.zen_draft.text.clear();
             } else {
                 if !text.is_empty() {
-                    if crate::config::theme::ThemeConfig::load().zen_breathe() {
+                    if crate::config_store::theme::ThemeConfig::load().zen_breathe() {
                         std::thread::sleep(std::time::Duration::from_millis(150));
                     }
                     let entry = ZenJournalEntry {

--- a/src/zen/journal.rs
+++ b/src/zen/journal.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use chrono::{Datelike, Local};
-use crate::config::theme::ThemeConfig;
+use crate::config_store::theme::ThemeConfig;
 use crate::state::AppState;
 use crate::state::view::ZenViewMode;
 use crate::zen::utils::{highlight_tags_line, extract_tags};


### PR DESCRIPTION
## Summary
- add `PrismXConfig` using serde
- load config at startup to set log level and theme
- respect default module when creating `AppState`
- expose `set_theme` for runtime theme changes
- include example `config.toml`
- hold theme setting in a mutex instead of a mutable static

## Testing
- `cargo check`
- `cargo test` *(fails: some tests hang >60s)*