### PR TITLE
Add Scroll Review mode

### DIFF
--- a/golden/src.snapshot/render/zen.rs
+++ b/golden/src.snapshot/render/zen.rs
@@ -57,7 +57,7 @@ pub fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
         let mut lines: Vec<Line> = Vec::new();
 
         // Time-grouped label
-        if matches!(state.zen_view_mode, crate::state::view::ZenViewMode::Summary) {
+        if matches!(state.zen_layout_mode, crate::state::view::ZenLayoutMode::Summary) {
             let label = match state.zen_summary_mode {
                 crate::state::ZenSummaryMode::Weekly => {
                     format!("Week {}", entry.timestamp.iso_week().week())

--- a/golden/src.snapshot/state/core.rs
+++ b/golden/src.snapshot/state/core.rs
@@ -55,13 +55,13 @@ pub enum ZenTheme {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ZenMode {
-    Compose,
-    Scroll,
+pub enum ZenViewMode {
+    Write,
+    Review,
 }
 
-impl Default for ZenMode {
-    fn default() -> Self { Self::Compose }
+impl Default for ZenViewMode {
+    fn default() -> Self { Self::Write }
 }
 
 #[derive(Clone)]
@@ -155,8 +155,8 @@ pub struct AppState {
     pub zen_word_count: usize,
     pub zen_current_syntax: ZenSyntax,
     pub zen_theme: ZenTheme,
-    pub zen_mode: crate::state::ZenMode,
     pub zen_view_mode: crate::state::ZenViewMode,
+    pub zen_layout_mode: crate::state::ZenLayoutMode,
     pub zen_draft: DraftState,
     pub zen_summary_mode: crate::state::ZenSummaryMode,
     pub zen_compose_input: String,
@@ -278,8 +278,8 @@ impl Default for AppState {
             zen_word_count: 0,
             zen_current_syntax: ZenSyntax::Markdown,
             zen_theme: ZenTheme::DarkGray,
-            zen_mode: crate::state::ZenMode::default(),
             zen_view_mode: crate::state::ZenViewMode::default(),
+            zen_layout_mode: crate::state::ZenLayoutMode::default(),
             zen_draft: DraftState::default(),
             zen_summary_mode: crate::state::ZenSummaryMode::default(),
             zen_compose_input: String::new(),

--- a/golden/src.snapshot/state/spotlight.rs
+++ b/golden/src.snapshot/state/spotlight.rs
@@ -1,5 +1,5 @@
 use super::core::{AppState, DockLayout, SimInput};
-use crate::state::{ZenViewMode, ZenMode};
+use crate::state::{ZenLayoutMode, ZenViewMode};
 
 impl AppState {
     pub fn exit_spotlight(&mut self) {

--- a/golden/src.snapshot/state/view.rs
+++ b/golden/src.snapshot/state/view.rs
@@ -1,7 +1,7 @@
 use super::core::AppState;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ZenViewMode {
+pub enum ZenLayoutMode {
     Journal,
     Classic,
     Split,
@@ -9,7 +9,7 @@ pub enum ZenViewMode {
     Compose,
 }
 
-impl Default for ZenViewMode {
+impl Default for ZenLayoutMode {
     fn default() -> Self { Self::Journal }
 }
 

--- a/golden/src.snapshot/state/zen.rs
+++ b/golden/src.snapshot/state/zen.rs
@@ -198,19 +198,19 @@ impl AppState {
     }
 
     pub fn toggle_summary_view(&mut self) {
-        use crate::state::{ZenSummaryMode, ZenViewMode};
-        match self.zen_view_mode {
-            ZenViewMode::Summary => {
+        use crate::state::{ZenSummaryMode, ZenLayoutMode};
+        match self.zen_layout_mode {
+            ZenLayoutMode::Summary => {
                 self.zen_summary_mode = match self.zen_summary_mode {
                     ZenSummaryMode::Daily => ZenSummaryMode::Weekly,
                     ZenSummaryMode::Weekly => {
-                        self.zen_view_mode = ZenViewMode::Journal;
+                        self.zen_layout_mode = ZenLayoutMode::Journal;
                         ZenSummaryMode::Daily
                     }
                 };
             }
             _ => {
-                self.zen_view_mode = ZenViewMode::Summary;
+                self.zen_layout_mode = ZenLayoutMode::Summary;
                 self.zen_summary_mode = ZenSummaryMode::Daily;
             }
         }

--- a/golden/src.snapshot/tui/mod.rs
+++ b/golden/src.snapshot/tui/mod.rs
@@ -6,8 +6,8 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::io::stdout;
-use crate::state::view::ZenViewMode;
-use crate::state::{AppState, SimInput};
+use crate::state::view::ZenLayoutMode;
+use crate::state::{AppState, SimInput, ZenViewMode};
 use crate::render::{
     render_status_bar,
     render_zen,
@@ -443,12 +443,12 @@ pub fn launch_ui() -> std::io::Result<()> {
                     && modifiers.contains(KeyModifiers::SHIFT)
                     && state.mode == "zen"
                 {
-                    state.zen_view_mode = match state.zen_view_mode {
-                        ZenViewMode::Journal => ZenViewMode::Classic,
-                        ZenViewMode::Classic => ZenViewMode::Split,
-                        ZenViewMode::Split => ZenViewMode::Summary,
-                        ZenViewMode::Summary => ZenViewMode::Journal,
-                        ZenViewMode::Compose => ZenViewMode::Journal,
+                    state.zen_layout_mode = match state.zen_layout_mode {
+                        ZenLayoutMode::Journal => ZenLayoutMode::Classic,
+                        ZenLayoutMode::Classic => ZenLayoutMode::Split,
+                        ZenLayoutMode::Split => ZenLayoutMode::Summary,
+                        ZenLayoutMode::Summary => ZenLayoutMode::Journal,
+                        ZenLayoutMode::Compose => ZenLayoutMode::Journal,
                     };
                 } else if code == KeyCode::Char('t')
                     && modifiers == KeyModifiers::CONTROL
@@ -457,7 +457,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.zen_toolbar_open = !state.zen_toolbar_open;
                     state.zen_toolbar_index = 0;
                 } else if code == KeyCode::Tab
-                    && modifiers == KeyModifiers::ALT
+                    && modifiers == KeyModifiers::CONTROL
                     && state.mode == "zen"
                 {
                     input::toggle_zen_view(&mut state);
@@ -500,7 +500,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                 match code {
                     KeyCode::Esc => {
                         if state.mode == "zen"
-                            && state.zen_view_mode == ZenViewMode::Compose
+                            && state.zen_layout_mode == ZenLayoutMode::Compose
+                            && state.zen_view_mode == ZenViewMode::Write
                             && state.zen_draft.editing.is_some()
                         {
                             state.cancel_edit_journal_entry();
@@ -611,21 +612,24 @@ pub fn launch_ui() -> std::io::Result<()> {
 
                     KeyCode::Char(c)
                         if state.mode == "zen"
-                            && state.zen_view_mode == ZenViewMode::Compose =>
+                            && state.zen_layout_mode == ZenLayoutMode::Compose
+                            && state.zen_view_mode == ZenViewMode::Write =>
                     {
                         state.zen_draft.text.push(c);
                     }
 
                     KeyCode::Backspace
                         if state.mode == "zen"
-                            && state.zen_view_mode == ZenViewMode::Compose =>
+                            && state.zen_layout_mode == ZenLayoutMode::Compose
+                            && state.zen_view_mode == ZenViewMode::Write =>
                     {
                         state.zen_draft.text.pop();
                     }
 
                     KeyCode::Enter
                         if state.mode == "zen"
-                            && state.zen_view_mode == ZenViewMode::Compose =>
+                            && state.zen_layout_mode == ZenLayoutMode::Compose
+                            && state.zen_view_mode == ZenViewMode::Write =>
                     {
                         let text = state.zen_draft.text.trim().to_string();
 

--- a/golden/src.snapshot/zen/journal.rs
+++ b/golden/src.snapshot/zen/journal.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use chrono::{Datelike, Local};
 use crate::config::theme::ThemeConfig;
 use crate::state::AppState;
-use crate::state::view::ZenViewMode;
+use crate::state::view::ZenLayoutMode;
 use crate::zen::utils::{highlight_tags_line, extract_tags};
 use crate::beamx::render_full_border;
 
@@ -39,7 +39,7 @@ pub fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
     for (idx, entry) in entries.iter().enumerate().rev() {
         let mut lines: Vec<Line> = Vec::new();
 
-        if matches!(state.zen_view_mode, ZenViewMode::Summary) {
+        if matches!(state.zen_layout_mode, ZenLayoutMode::Summary) {
             let label = match state.zen_summary_mode {
                 crate::state::ZenSummaryMode::Weekly => {
                     format!("Week {}", entry.timestamp.iso_week().week())

--- a/golden/src.snapshot/zen/render.rs
+++ b/golden/src.snapshot/zen/render.rs
@@ -2,23 +2,23 @@
 use ratatui::prelude::*;
 use crate::canvas::prism::render_prism;
 use crate::state::{AppState};
-use crate::state::view::ZenViewMode;
+use crate::state::view::ZenLayoutMode;
 use crate::zen::journal::{render_zen_journal, render_history};
 use crate::beamx::render_full_border;
 
 /// Dispatches the correct Zen view mode renderer
 pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     match state.zen_view_mode {
-        ZenViewMode::Journal => {
+        ZenLayoutMode::Journal => {
             render_zen_journal(f, area, state);
         }
-        ZenViewMode::Classic => {
+        ZenLayoutMode::Classic => {
             render_classic(f, area, state);
         }
-        ZenViewMode::Summary => {
+        ZenLayoutMode::Summary => {
             render_zen_journal(f, area, state);
         }
-        ZenViewMode::Split => {
+        ZenLayoutMode::Split => {
             let mid = area.width / 2;
             let left = Rect {
                 x: area.x,
@@ -35,7 +35,7 @@ pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             render_classic(f, left, state);
             render_zen_journal(f, right, state);
         }
-        ZenViewMode::Compose => {
+        ZenLayoutMode::Compose => {
             let tick = (std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -55,13 +55,13 @@ pub enum ZenTheme {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ZenMode {
-    Compose,
-    Scroll,
+pub enum ZenViewMode {
+    Write,
+    Review,
 }
 
-impl Default for ZenMode {
-    fn default() -> Self { Self::Compose }
+impl Default for ZenViewMode {
+    fn default() -> Self { Self::Write }
 }
 
 #[derive(Clone)]
@@ -156,8 +156,8 @@ pub struct AppState {
     pub zen_word_count: usize,
     pub zen_current_syntax: ZenSyntax,
     pub zen_theme: ZenTheme,
-    pub zen_mode: crate::state::ZenMode,
     pub zen_view_mode: crate::state::ZenViewMode,
+    pub zen_layout_mode: crate::state::ZenLayoutMode,
     pub zen_draft: DraftState,
     pub zen_summary_mode: crate::state::ZenSummaryMode,
     pub zen_compose_input: String,
@@ -280,8 +280,8 @@ impl Default for AppState {
             zen_word_count: 0,
             zen_current_syntax: ZenSyntax::Markdown,
             zen_theme: ZenTheme::DarkGray,
-            zen_mode: crate::state::ZenMode::default(),
             zen_view_mode: crate::state::ZenViewMode::default(),
+            zen_layout_mode: crate::state::ZenLayoutMode::default(),
             zen_draft: DraftState::default(),
             zen_summary_mode: crate::state::ZenSummaryMode::default(),
             zen_compose_input: String::new(),

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -1,7 +1,7 @@
 use super::core::AppState;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ZenViewMode {
+pub enum ZenLayoutMode {
     Journal,
     Classic,
     Split,
@@ -9,7 +9,7 @@ pub enum ZenViewMode {
     Compose,
 }
 
-impl Default for ZenViewMode {
+impl Default for ZenLayoutMode {
     fn default() -> Self { Self::Journal }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,8 +6,8 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::io::stdout;
-use crate::state::view::ZenViewMode;
-use crate::state::{AppState, SimInput};
+use crate::state::view::ZenLayoutMode;
+use crate::state::{AppState, SimInput, ZenViewMode};
 use crate::render::{
     render_status_bar,
     render_zen,
@@ -440,12 +440,12 @@ pub fn launch_ui() -> std::io::Result<()> {
                     && modifiers.contains(KeyModifiers::SHIFT)
                     && state.mode == "zen"
                 {
-                    state.zen_view_mode = match state.zen_view_mode {
-                        ZenViewMode::Journal => ZenViewMode::Classic,
-                        ZenViewMode::Classic => ZenViewMode::Split,
-                        ZenViewMode::Split => ZenViewMode::Summary,
-                        ZenViewMode::Summary => ZenViewMode::Journal,
-                        ZenViewMode::Compose => ZenViewMode::Journal,
+                    state.zen_layout_mode = match state.zen_layout_mode {
+                        ZenLayoutMode::Journal => ZenLayoutMode::Classic,
+                        ZenLayoutMode::Classic => ZenLayoutMode::Split,
+                        ZenLayoutMode::Split => ZenLayoutMode::Summary,
+                        ZenLayoutMode::Summary => ZenLayoutMode::Journal,
+                        ZenLayoutMode::Compose => ZenLayoutMode::Journal,
                     };
                 } else if code == KeyCode::Char('t')
                     && modifiers == KeyModifiers::CONTROL
@@ -454,7 +454,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.zen_toolbar_open = !state.zen_toolbar_open;
                     state.zen_toolbar_index = 0;
                 } else if code == KeyCode::Tab
-                    && modifiers == KeyModifiers::ALT
+                    && modifiers == KeyModifiers::CONTROL
                     && state.mode == "zen"
                 {
                     input::toggle_zen_view(&mut state);
@@ -497,7 +497,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                 match code {
                     KeyCode::Esc => {
                         if state.mode == "zen"
-                            && state.zen_view_mode == ZenViewMode::Compose
+                            && state.zen_layout_mode == ZenLayoutMode::Compose
+                            && state.zen_view_mode == ZenViewMode::Write
                             && state.zen_draft.editing.is_some()
                         {
                             state.cancel_edit_journal_entry();
@@ -607,7 +608,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                     }
 
                     k @ _ if state.mode == "zen"
-                        && state.zen_view_mode == ZenViewMode::Compose =>
+                        && state.zen_layout_mode == ZenLayoutMode::Compose
+                        && state.zen_view_mode == ZenViewMode::Write =>
                     {
                         crate::zen::editor::handle_key(&mut state, k);
                     }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -30,10 +30,10 @@ pub fn handle_log_keys(state: &mut AppState, code: KeyCode, mods: KeyModifiers) 
     }
 }
 
-/// Toggle Zen compose/scroll view.
+/// Toggle Zen Write/Review view.
 pub fn toggle_zen_view(state: &mut AppState) {
-    state.zen_mode = match state.zen_mode {
-        crate::state::ZenMode::Compose => crate::state::ZenMode::Scroll,
-        crate::state::ZenMode::Scroll => crate::state::ZenMode::Compose,
+    state.zen_view_mode = match state.zen_view_mode {
+        crate::state::ZenViewMode::Write => crate::state::ZenViewMode::Review,
+        crate::state::ZenViewMode::Review => crate::state::ZenViewMode::Write,
     };
 }

--- a/src/zen/editor.rs
+++ b/src/zen/editor.rs
@@ -13,7 +13,10 @@ pub fn handle_key(state: &mut AppState, key: KeyCode) {
         }
         KeyCode::Enter => {
             let text = state.zen_draft.text.trim().to_string();
-            if text.starts_with("/edit ") {
+            if text == "/scroll" {
+                crate::ui::input::toggle_zen_view(state);
+                state.zen_draft.text.clear();
+            } else if text.starts_with("/edit ") {
                 if let Ok(idx) = text[6..].trim().parse::<usize>() {
                     state.start_edit_journal_entry(idx);
                 }

--- a/src/zen/journal.rs
+++ b/src/zen/journal.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use chrono::{Datelike, Local};
 use crate::config::theme::ThemeConfig;
 use crate::state::AppState;
-use crate::state::view::ZenViewMode;
+use crate::state::view::ZenLayoutMode;
 use crate::zen::utils::{highlight_tags_line, extract_tags};
 use crate::beamx::render_full_border;
 
@@ -39,7 +39,7 @@ pub fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
     for (idx, entry) in entries.iter().enumerate().rev() {
         let mut lines: Vec<Line> = Vec::new();
 
-        if matches!(state.zen_view_mode, ZenViewMode::Summary) {
+        if matches!(state.zen_layout_mode, ZenLayoutMode::Summary) {
             let label = match state.zen_summary_mode {
                 crate::state::ZenSummaryMode::Weekly => {
                     format!("Week {}", entry.timestamp.iso_week().week())

--- a/src/zen/state.rs
+++ b/src/zen/state.rs
@@ -198,19 +198,19 @@ impl AppState {
     }
 
     pub fn toggle_summary_view(&mut self) {
-        use crate::state::{ZenSummaryMode, ZenViewMode};
-        match self.zen_view_mode {
-            ZenViewMode::Summary => {
+        use crate::state::{ZenSummaryMode, ZenLayoutMode};
+        match self.zen_layout_mode {
+            ZenLayoutMode::Summary => {
                 self.zen_summary_mode = match self.zen_summary_mode {
                     ZenSummaryMode::Daily => ZenSummaryMode::Weekly,
                     ZenSummaryMode::Weekly => {
-                        self.zen_view_mode = ZenViewMode::Journal;
+                        self.zen_layout_mode = ZenLayoutMode::Journal;
                         ZenSummaryMode::Daily
                     }
                 };
             }
             _ => {
-                self.zen_view_mode = ZenViewMode::Summary;
+                self.zen_layout_mode = ZenLayoutMode::Summary;
                 self.zen_summary_mode = ZenSummaryMode::Daily;
             }
         }


### PR DESCRIPTION
## Summary
- introduce `ZenViewMode` enum with `Write` and `Review`
- rename journal view enum to `ZenLayoutMode`
- toggle Write/Review with `/scroll` command or Ctrl+Tab
- hide input while reviewing journal entries

## Testing
- `cargo check`
- `cargo test` *(fails: hanging tests)*