### PR TITLE
Add hashtag parsing for Zen journal

### DIFF
--- a/golden/src.snapshot/state/core.rs
+++ b/golden/src.snapshot/state/core.rs
@@ -69,6 +69,7 @@ pub struct ZenJournalEntry {
     pub timestamp: chrono::DateTime<chrono::Local>,
     pub text: String,
     pub prev_text: Option<String>,
+    pub tags: Vec<String>,
 }
 
 #[derive(Clone, Default)]

--- a/golden/src.snapshot/state/zen.rs
+++ b/golden/src.snapshot/state/zen.rs
@@ -137,6 +137,7 @@ impl AppState {
                             timestamp: dt.with_timezone(&chrono::Local),
                             text: text.to_string(),
                             prev_text: None,
+                            tags: crate::zen::utils::parse_tags(text),
                         })
                 })
                 .collect();
@@ -176,16 +177,16 @@ impl AppState {
         if let Some(entry) = self.zen_journal_entries.get_mut(index) {
             entry.prev_text = Some(entry.text.clone());
             entry.text = text.to_string();
+            entry.tags = crate::zen::utils::parse_tags(text);
         }
     }
 
     pub fn filtered_journal_entries(&self) -> Vec<&ZenJournalEntry> {
-        use crate::zen::utils::extract_tags;
         self.zen_journal_entries
             .iter()
             .filter(|e| {
                 if let Some(tag) = &self.zen_tag_filter {
-                    extract_tags(&e.text).iter().any(|t| t.eq_ignore_ascii_case(tag))
+                    e.tags.iter().any(|t| t.eq_ignore_ascii_case(tag))
                 } else {
                     true
                 }

--- a/golden/src.snapshot/ui/components/feed.rs
+++ b/golden/src.snapshot/ui/components/feed.rs
@@ -10,7 +10,7 @@ use ratatui::{
 use crate::state::ZenJournalEntry;
 use crate::ui::animate::fade_line;
 use crate::config::theme::ThemeConfig;
-use crate::zen::utils::extract_tags;
+
 use chrono::Datelike;
 
 
@@ -29,10 +29,7 @@ pub fn render_feed<B: Backend>(
     for (idx, entry) in entries.iter().enumerate().rev() {
         // Filter by tag if present
         if let Some(tag) = tag_filter {
-            if !extract_tags(&entry.text)
-                .iter()
-                .any(|t| t.eq_ignore_ascii_case(tag))
-            {
+            if !entry.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
                 continue;
             }
         }

--- a/golden/src.snapshot/zen/journal.rs
+++ b/golden/src.snapshot/zen/journal.rs
@@ -10,7 +10,7 @@ use chrono::{Datelike, Local};
 use crate::config::theme::ThemeConfig;
 use crate::state::AppState;
 use crate::state::view::ZenViewMode;
-use crate::zen::utils::{highlight_tags_line, extract_tags};
+use crate::zen::utils::highlight_tags_line;
 use crate::beamx::render_full_border;
 
 /// Public render entry point for Journal view
@@ -70,9 +70,8 @@ pub fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
             Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
         )));
 
-        let tags = extract_tags(&entry.text);
-        if !tags.is_empty() {
-            lines.push(highlight_tags_line(&tags.join(" ")));
+        if !entry.tags.is_empty() {
+            lines.push(highlight_tags_line(&entry.tags.join(" ")));
         }
 
         for l in entry.text.lines() {

--- a/golden/src.snapshot/zen/utils.rs
+++ b/golden/src.snapshot/zen/utils.rs
@@ -24,6 +24,14 @@ pub fn extract_tags(text: &str) -> Vec<String> {
     tags
 }
 
+/// Extract tags and normalize to lowercase for classification
+pub fn parse_tags(text: &str) -> Vec<String> {
+    extract_tags(text)
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
 pub fn highlight_tags_line(input: &str) -> Line<'static> {
     use ratatui::text::{Span, Line};
     let mut spans = Vec::new();

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -69,6 +69,7 @@ pub struct ZenJournalEntry {
     pub timestamp: chrono::DateTime<chrono::Local>,
     pub text: String,
     pub prev_text: Option<String>,
+    pub tags: Vec<String>,
 }
 
 #[derive(Clone, Default)]

--- a/src/triage/helpers.rs
+++ b/src/triage/helpers.rs
@@ -6,7 +6,7 @@ use super::state::TriageEntry;
 pub fn extract_tags(text: &str) -> Vec<String> {
     let re = Regex::new(r"#\w+").unwrap();
     re.find_iter(text)
-        .map(|m| m.as_str().to_string())
+        .map(|m| m.as_str().to_lowercase())
         .collect()
 }
 
@@ -14,11 +14,11 @@ pub fn extract_tags(text: &str) -> Vec<String> {
 /// `#NOW` > `#TRITON` > `#TODO`/`#PRIORITY` > others.
 pub fn sort_by_priority(entries: &mut [TriageEntry]) {
     fn priority(entry: &TriageEntry) -> u8 {
-        if entry.tags.iter().any(|t| t == "#NOW") {
+        if entry.tags.iter().any(|t| t == "#now") {
             0
-        } else if entry.tags.iter().any(|t| t == "#TRITON") {
+        } else if entry.tags.iter().any(|t| t == "#triton") {
             1
-        } else if entry.tags.iter().any(|t| t == "#TODO" || t == "#PRIORITY") {
+        } else if entry.tags.iter().any(|t| t == "#todo" || t == "#priority") {
             2
         } else {
             3

--- a/src/triage/state.rs
+++ b/src/triage/state.rs
@@ -3,7 +3,7 @@ use crate::state::{AppState, ZenJournalEntry};
 use crate::triage::helpers::extract_tags;
 
 /// Tags that mark an entry for triage.
-const TRIAGE_TAGS: &[&str] = &["#TODO", "#TRITON", "#PRIORITY", "#NOW"];
+const TRIAGE_TAGS: &[&str] = &["#todo", "#triton", "#priority", "#now"];
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum TriageSource {
@@ -42,10 +42,7 @@ impl TriageEntry {
 pub fn collect(entries: &[ZenJournalEntry]) -> Vec<ZenJournalEntry> {
     let mut filtered: Vec<ZenJournalEntry> = entries
         .iter()
-        .filter(|e| {
-            let tags = extract_tags(&e.text);
-            tags.iter().any(|tag| TRIAGE_TAGS.contains(&tag.as_str()))
-        })
+        .filter(|e| e.tags.iter().any(|tag| TRIAGE_TAGS.contains(&tag.as_str())))
         .cloned()
         .collect();
 
@@ -55,7 +52,8 @@ pub fn collect(entries: &[ZenJournalEntry]) -> Vec<ZenJournalEntry> {
 }
 
 pub fn capture_entry(state: &mut AppState, source: TriageSource, text: &str) {
-    if text.contains("#TODO") || text.contains("#NOW") || text.contains("#TRITON") {
+    let text_lc = text.to_lowercase();
+    if TRIAGE_TAGS.iter().any(|tg| text_lc.contains(tg)) {
         let id = state.triage_entries.len();
         let entry = TriageEntry::new(id, text, source);
         state.triage_entries.push(entry);
@@ -91,12 +89,12 @@ pub fn handle_inline_command(state: &mut AppState, text: &str) -> bool {
 pub fn resolve(state: &mut AppState, id: usize) {
     if let Some(entry) = state.triage_entries.get_mut(id) {
         entry.resolved = true;
-        if entry.tags.contains(&"#TRITON".to_string()) {
-            entry.tags.retain(|t| t != "#TRITON");
-            entry.tags.push("#DONE".into());
-        } else if entry.tags.contains(&"#NOW".to_string()) {
-            entry.tags.retain(|t| t != "#NOW");
-            entry.tags.push("#TRITON".into());
+        if entry.tags.contains(&"#triton".to_string()) {
+            entry.tags.retain(|t| t != "#triton");
+            entry.tags.push("#done".into());
+        } else if entry.tags.contains(&"#now".to_string()) {
+            entry.tags.retain(|t| t != "#now");
+            entry.tags.push("#triton".into());
         }
     }
 }
@@ -118,9 +116,9 @@ pub fn archive(state: &mut AppState, id: usize) {
 pub fn update_pipeline(state: &mut AppState) {
     for entry in &mut state.triage_entries {
         // Promote resolved #TRITON entries to #DONE
-        if entry.resolved && entry.tags.contains(&"#TRITON".to_string()) {
-            entry.tags.retain(|t| t != "#TRITON");
-            entry.tags.push("#DONE".into());
+        if entry.resolved && entry.tags.contains(&"#triton".to_string()) {
+            entry.tags.retain(|t| t != "#triton");
+            entry.tags.push("#done".into());
             continue;
         }
 
@@ -129,11 +127,11 @@ pub fn update_pipeline(state: &mut AppState) {
         }
 
         // Auto-promote #NOW to #TRITON after ~60s
-        if entry.tags.contains(&"#NOW".to_string()) {
+        if entry.tags.contains(&"#now".to_string()) {
             let since = Local::now().signed_duration_since(entry.created).num_seconds();
             if since > 60 {
-                entry.tags.retain(|t| t != "#NOW");
-                entry.tags.push("#TRITON".into());
+                entry.tags.retain(|t| t != "#now");
+                entry.tags.push("#triton".into());
             }
         }
     }
@@ -148,13 +146,13 @@ pub fn tag_counts(state: &AppState) -> (usize, usize, usize) {
         if entry.archived {
             continue;
         }
-        if entry.tags.iter().any(|t| t.eq("#NOW")) {
+        if entry.tags.iter().any(|t| t.eq("#now")) {
             now += 1;
         }
-        if entry.tags.iter().any(|t| t.eq("#TRITON")) {
+        if entry.tags.iter().any(|t| t.eq("#triton")) {
             triton += 1;
         }
-        if entry.tags.iter().any(|t| t.eq("#DONE")) {
+        if entry.tags.iter().any(|t| t.eq("#done")) {
             done += 1;
         }
     }

--- a/src/ui/components/feed.rs
+++ b/src/ui/components/feed.rs
@@ -10,7 +10,7 @@ use crate::ui::layout::Rect;
 use crate::state::ZenJournalEntry;
 use crate::ui::animate::fade_line;
 use crate::config::theme::ThemeConfig;
-use crate::zen::utils::extract_tags;
+
 use chrono::Datelike;
 
 
@@ -29,10 +29,7 @@ pub fn render_feed<B: Backend>(
     for (_idx, entry) in entries.iter().enumerate().rev() {
         // Filter by tag if present
         if let Some(tag) = tag_filter {
-            if !extract_tags(&entry.text)
-                .iter()
-                .any(|t| t.eq_ignore_ascii_case(tag))
-            {
+            if !entry.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
                 continue;
             }
         }

--- a/src/zen/editor.rs
+++ b/src/zen/editor.rs
@@ -34,6 +34,7 @@ pub fn handle_key(state: &mut AppState, key: KeyCode) {
                         timestamp: chrono::Local::now(),
                         text: text.clone(),
                         prev_text: None,
+                        tags: crate::zen::utils::parse_tags(&text),
                     };
                     state.zen_journal_entries.push(entry.clone());
                     state.append_journal_entry(&entry);

--- a/src/zen/journal.rs
+++ b/src/zen/journal.rs
@@ -10,7 +10,7 @@ use chrono::{Datelike, Local};
 use crate::config::theme::ThemeConfig;
 use crate::state::AppState;
 use crate::state::view::ZenViewMode;
-use crate::zen::utils::{highlight_tags_line, extract_tags};
+use crate::zen::utils::highlight_tags_line;
 use crate::beamx::render_full_border;
 
 /// Public render entry point for Journal view
@@ -70,9 +70,8 @@ pub fn render_history<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
             Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM),
         )));
 
-        let tags = extract_tags(&entry.text);
-        if !tags.is_empty() {
-            lines.push(highlight_tags_line(&tags.join(" ")));
+        if !entry.tags.is_empty() {
+            lines.push(highlight_tags_line(&entry.tags.join(" ")));
         }
 
         for l in entry.text.lines() {

--- a/src/zen/state.rs
+++ b/src/zen/state.rs
@@ -137,6 +137,7 @@ impl AppState {
                             timestamp: dt.with_timezone(&chrono::Local),
                             text: text.to_string(),
                             prev_text: None,
+                            tags: crate::zen::utils::parse_tags(text),
                         })
                 })
                 .collect();
@@ -176,16 +177,16 @@ impl AppState {
         if let Some(entry) = self.zen_journal_entries.get_mut(index) {
             entry.prev_text = Some(entry.text.clone());
             entry.text = text.to_string();
+            entry.tags = crate::zen::utils::parse_tags(text);
         }
     }
 
     pub fn filtered_journal_entries(&self) -> Vec<&ZenJournalEntry> {
-        use crate::zen::utils::extract_tags;
         self.zen_journal_entries
             .iter()
             .filter(|e| {
                 if let Some(tag) = &self.zen_tag_filter {
-                    extract_tags(&e.text).iter().any(|t| t.eq_ignore_ascii_case(tag))
+                    e.tags.iter().any(|t| t.eq_ignore_ascii_case(tag))
                 } else {
                     true
                 }

--- a/src/zen/utils.rs
+++ b/src/zen/utils.rs
@@ -24,6 +24,14 @@ pub fn extract_tags(text: &str) -> Vec<String> {
     tags
 }
 
+/// Extract tags and normalize to lowercase for classification
+pub fn parse_tags(text: &str) -> Vec<String> {
+    extract_tags(text)
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
 pub fn highlight_tags_line(input: &str) -> Line<'static> {
     let mut spans = Vec::new();
     for token in input.split_whitespace() {

--- a/tests/tag_parser.rs
+++ b/tests/tag_parser.rs
@@ -1,0 +1,7 @@
+use prismx::zen::utils::parse_tags;
+
+#[test]
+fn parses_hashtags_lowercase() {
+    let tags = parse_tags("Working on #FOCUS and #triton items #COIN");
+    assert_eq!(tags, vec!["#focus", "#triton", "#coin"]);
+}


### PR DESCRIPTION
## Summary
- track lowercase `tags` for each `ZenJournalEntry`
- parse tags via new `parse_tags` helper
- update zen editing, state filtering and UI to use stored tags
- normalize triage tag handling to lowercase
- add basic unit test for tag parsing

## Testing
- `cargo test --test tag_parser --quiet`