### PR TITLE
Add Zen dual view and markdown styling

### DIFF
--- a/golden/src.snapshot/state/view.rs
+++ b/golden/src.snapshot/state/view.rs
@@ -7,6 +7,7 @@ pub enum ZenLayoutMode {
     Split,
     Summary,
     Compose,
+    Dual,
 }
 
 impl Default for ZenLayoutMode {

--- a/golden/src.snapshot/tui/mod.rs
+++ b/golden/src.snapshot/tui/mod.rs
@@ -447,7 +447,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                         ZenLayoutMode::Journal => ZenLayoutMode::Classic,
                         ZenLayoutMode::Classic => ZenLayoutMode::Split,
                         ZenLayoutMode::Split => ZenLayoutMode::Summary,
-                        ZenLayoutMode::Summary => ZenLayoutMode::Journal,
+                        ZenLayoutMode::Summary => ZenLayoutMode::Dual,
+                        ZenLayoutMode::Dual => ZenLayoutMode::Journal,
                         ZenLayoutMode::Compose => ZenLayoutMode::Journal,
                     };
                 } else if code == KeyCode::Char('t')

--- a/golden/src.snapshot/zen/render.rs
+++ b/golden/src.snapshot/zen/render.rs
@@ -5,6 +5,7 @@ use crate::state::{AppState};
 use crate::state::view::ZenLayoutMode;
 use crate::zen::journal::{render_zen_journal, render_history};
 use crate::beamx::render_full_border;
+use crate::theme::zen::zen_theme;
 
 /// Dispatches the correct Zen view mode renderer
 pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -34,6 +35,37 @@ pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             };
             render_classic(f, left, state);
             render_zen_journal(f, right, state);
+        }
+        ZenLayoutMode::Dual => {
+            use ratatui::widgets::Block;
+            use ratatui::style::Style;
+
+            let palette = zen_theme();
+            let tick = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                / 300) as u64;
+
+            let mid = area.width / 2;
+            let left = Rect {
+                x: area.x,
+                y: area.y,
+                width: mid,
+                height: area.height,
+            };
+            let right = Rect {
+                x: area.x + mid,
+                y: area.y,
+                width: area.width - mid,
+                height: area.height,
+            };
+
+            let bg = Block::default().style(Style::default().bg(palette.background));
+            f.render_widget(bg, area);
+
+            render_input(f, left, state, tick);
+            render_history(f, right, state);
         }
         ZenLayoutMode::Compose => {
             let tick = (std::time::SystemTime::now()

--- a/golden/src.snapshot/zen/utils.rs
+++ b/golden/src.snapshot/zen/utils.rs
@@ -1,5 +1,5 @@
 use ratatui::text::{Line, Span};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Style, Modifier};
 
 /// Extract all hashtags from a line of text (e.g., "#tag")
 pub fn extract_tags(text: &str) -> Vec<String> {
@@ -36,11 +36,27 @@ pub fn highlight_tags_line(input: &str) -> Line<'static> {
     use ratatui::text::{Span, Line};
     let mut spans = Vec::new();
     for token in input.split_whitespace() {
-        if token.starts_with('#') {
-            spans.push(Span::styled(token.to_string(), Style::default().fg(Color::Blue)));
+        let span = if token.starts_with("**") && token.ends_with("**") && token.len() > 4 {
+            Span::styled(
+                token[2..token.len() - 2].to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            )
+        } else if token.starts_with('*') && token.ends_with('*') && token.len() > 2 {
+            Span::styled(
+                token[1..token.len() - 1].to_string(),
+                Style::default().add_modifier(Modifier::DIM),
+            )
+        } else if token.starts_with('`') && token.ends_with('`') && token.len() > 2 {
+            Span::styled(
+                token[1..token.len() - 1].to_string(),
+                Style::default().fg(Color::Yellow),
+            )
+        } else if token.starts_with('#') {
+            Span::styled(token.to_string(), Style::default().fg(Color::Blue))
         } else {
-            spans.push(Span::raw(token.to_string()));
-        }
+            Span::raw(token.to_string())
+        };
+        spans.push(span);
         spans.push(Span::raw(" "));
     }
     Line::from(spans)

--- a/src/state/view.rs
+++ b/src/state/view.rs
@@ -7,6 +7,7 @@ pub enum ZenLayoutMode {
     Split,
     Summary,
     Compose,
+    Dual,
 }
 
 impl Default for ZenLayoutMode {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -444,7 +444,8 @@ pub fn launch_ui() -> std::io::Result<()> {
                         ZenLayoutMode::Journal => ZenLayoutMode::Classic,
                         ZenLayoutMode::Classic => ZenLayoutMode::Split,
                         ZenLayoutMode::Split => ZenLayoutMode::Summary,
-                        ZenLayoutMode::Summary => ZenLayoutMode::Journal,
+                        ZenLayoutMode::Summary => ZenLayoutMode::Dual,
+                        ZenLayoutMode::Dual => ZenLayoutMode::Journal,
                         ZenLayoutMode::Compose => ZenLayoutMode::Journal,
                     };
                 } else if code == KeyCode::Char('t')

--- a/src/zen/utils.rs
+++ b/src/zen/utils.rs
@@ -1,5 +1,5 @@
 use ratatui::text::{Line, Span};
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Style, Modifier};
 
 /// Extract all hashtags from a line of text (e.g., "#tag")
 pub fn extract_tags(text: &str) -> Vec<String> {
@@ -35,11 +35,27 @@ pub fn parse_tags(text: &str) -> Vec<String> {
 pub fn highlight_tags_line(input: &str) -> Line<'static> {
     let mut spans = Vec::new();
     for token in input.split_whitespace() {
-        if token.starts_with('#') {
-            spans.push(Span::styled(token.to_string(), Style::default().fg(Color::Blue)));
+        let span = if token.starts_with("**") && token.ends_with("**") && token.len() > 4 {
+            Span::styled(
+                token[2..token.len() - 2].to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            )
+        } else if token.starts_with('*') && token.ends_with('*') && token.len() > 2 {
+            Span::styled(
+                token[1..token.len() - 1].to_string(),
+                Style::default().add_modifier(Modifier::DIM),
+            )
+        } else if token.starts_with('`') && token.ends_with('`') && token.len() > 2 {
+            Span::styled(
+                token[1..token.len() - 1].to_string(),
+                Style::default().fg(Color::Yellow),
+            )
+        } else if token.starts_with('#') {
+            Span::styled(token.to_string(), Style::default().fg(Color::Blue))
         } else {
-            spans.push(Span::raw(token.to_string()));
-        }
+            Span::raw(token.to_string())
+        };
+        spans.push(span);
         spans.push(Span::raw(" "));
     }
     Line::from(spans)

--- a/src/zen/view.rs
+++ b/src/zen/view.rs
@@ -35,6 +35,37 @@ pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
             render_classic(f, left, state);
             render_zen_journal(f, right, state);
         }
+        ZenLayoutMode::Dual => {
+            use ratatui::widgets::Block;
+            use ratatui::style::Style;
+
+            let palette = zen_theme();
+            let tick = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                / 300) as u64;
+
+            let mid = area.width / 2;
+            let left = Rect {
+                x: area.x,
+                y: area.y,
+                width: mid,
+                height: area.height,
+            };
+            let right = Rect {
+                x: area.x + mid,
+                y: area.y,
+                width: area.width - mid,
+                height: area.height,
+            };
+
+            let bg = Block::default().style(Style::default().bg(palette.background));
+            f.render_widget(bg, area);
+
+            render_input(f, left, state, tick);
+            render_history(f, right, state);
+        }
         ZenLayoutMode::Compose => {
             let tick = (std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
## Summary
- introduce `ZenLayoutMode::Dual`
- show input on the left and history on the right in dual layout
- cycle dual layout with other views
- support bold, italic and code styling in markdown tag highlighter
- update golden snapshots

## Testing
- `cargo test`