### PR TITLE
Add plugin status listing

### DIFF
--- a/src/plugin/panel.rs
+++ b/src/plugin/panel.rs
@@ -5,6 +5,7 @@ use ratatui::style::{Color, Modifier, Style};
 
 use crate::state::{AppState, PluginTagFilter};
 use crate::plugin::registry::registry_filtered;
+use crate::ui::components::plugin_status::render_plugin_status;
 
 pub fn render_plugin_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let style = state.beam_style_for_mode("settings");
@@ -67,6 +68,13 @@ pub fn render_plugin_panel<B: Backend>(f: &mut Frame<B>, area: Rect, state: &App
     }
 
     crate::beamx::render_full_border(f, area, &style, true, false);
+
+    // Display a summary of loaded plugins at the bottom of the panel
+    let height = 3u16;
+    if area.height > height + 2 {
+        let status_area = Rect::new(area.x + 1, area.bottom().saturating_sub(height + 1), area.width - 2, height);
+        render_plugin_status(f, status_area);
+    }
 
     if state.show_plugin_preview {
         if let Some(entry) = entries.get(state.plugin_registry_index) {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod spotlight;
 pub mod feed;
 pub mod plugin;
+pub mod plugin_status;
 pub mod logs;
 pub mod debug;
 pub mod theme;

--- a/src/ui/components/plugin_status.rs
+++ b/src/ui/components/plugin_status.rs
@@ -1,0 +1,32 @@
+use ratatui::{
+    backend::Backend,
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+use crate::ui::layout::Rect;
+use crate::plugin::registry::{registry, PluginStatus};
+
+/// Render a panel listing all loaded plugins.
+pub fn render_plugin_status<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    let entries: Vec<PluginStatus> = registry();
+    let lines: Vec<String> = if entries.is_empty() {
+        vec!["No plugins loaded".to_string()]
+    } else {
+        entries
+            .iter()
+            .map(|p| {
+                if let Some(ref path) = p.path {
+                    format!("{} v{} ({})", p.name, p.version, path)
+                } else {
+                    format!("{} v{}", p.name, p.version)
+                }
+            })
+            .collect()
+    };
+
+    let para = Paragraph::new(lines.join("\n"))
+        .block(Block::default().title("Loaded Plugins").borders(Borders::ALL))
+        .style(Style::default().fg(Color::White));
+    f.render_widget(para, area);
+}

--- a/src/zen/editor.rs
+++ b/src/zen/editor.rs
@@ -63,6 +63,26 @@ pub fn handle_key(state: &mut AppState, key: KeyCode) {
             } else if text == "/cancel" {
                 state.cancel_edit_journal_entry();
                 state.zen_draft.text.clear();
+            } else if text == "/plugins" {
+                use crate::plugin::registry;
+                let list = registry::registry();
+                if list.is_empty() {
+                    state.status_message = "No plugins loaded".into();
+                } else {
+                    let lines: Vec<String> = list
+                        .iter()
+                        .map(|p| {
+                            if let Some(ref path) = p.path {
+                                format!("{} v{} ({})", p.name, p.version, path)
+                            } else {
+                                format!("{} v{}", p.name, p.version)
+                            }
+                        })
+                        .collect();
+                    state.status_message = lines.join(", ");
+                }
+                state.status_message_last_updated = Some(std::time::Instant::now());
+                state.zen_draft.text.clear();
             } else {
                 finalize_entry(state);
             }


### PR DESCRIPTION
## Summary
- track loaded plugins in `plugin::registry`
- show loaded plugin info in plugin panel
- add a `/plugins` command in Zen editor
- expose `render_plugin_status` helper

## Testing
- `cargo test --quiet`