### PR TITLE
25.67k: center viewport on selected node

### DIFF
--- a/patches/patch-25.67k-mindmap-focus-center/FILES_CHANGED.txt
+++ b/patches/patch-25.67k-mindmap-focus-center/FILES_CHANGED.txt
@@ -1,2 +1,8 @@
-~ src/ui/viewport.rs
-~ src/ui/components/mindmap.rs
+~ src/state/core.rs
+~ src/state/helpers.rs
+~ src/state/edit.rs
+~ src/state/history.rs
+~ src/state/serialize.rs
+~ src/gemx/interaction.rs
+~ src/screen/gemx.rs
+~ src/tui/mod.rs

--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -75,9 +75,6 @@ pub fn spawn_free_node(state: &mut AppState) {
     state.root_nodes.push(new_id);
     state.set_selected(Some(new_id));
 
-    // Viewport centering for visibility
-    crate::layout::center_on_node(state, new_id);
-
     // Graph integrity + layout role refresh
     crate::layout::roles::recalculate_roles(state);
     state.ensure_valid_roots();

--- a/src/screen/gemx.rs
+++ b/src/screen/gemx.rs
@@ -52,7 +52,7 @@ pub fn render_gemx<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
     if let Some(sel) = state.selected {
         if !state.nodes.contains_key(&sel) {
-            state.selected = None;
+            state.set_selected(None);
         }
     }
     if state.selected.is_none() {

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -117,6 +117,8 @@ pub struct AppState {
     pub zoom_locked_by_user: bool,
     pub scroll_x: i16,
     pub scroll_y: i16,
+    pub scroll_target_x: i16,
+    pub scroll_target_y: i16,
     pub snap_to_grid: bool,
     pub drawing_root: Option<NodeID>,
     pub dragging: Option<NodeID>,
@@ -241,6 +243,8 @@ impl Default for AppState {
             zoom_locked_by_user: false,
             scroll_x: 0,
             scroll_y: 0,
+            scroll_target_x: 0,
+            scroll_target_y: 0,
             snap_to_grid: false,
             drawing_root: None,
             dragging: None,
@@ -338,6 +342,9 @@ impl Default for AppState {
         }
 
         state.loaded_plugins = loader::discover_plugins(std::path::Path::new("plugins"));
+
+        state.scroll_target_x = state.scroll_x;
+        state.scroll_target_y = state.scroll_y;
 
         state
     }

--- a/src/state/edit.rs
+++ b/src/state/edit.rs
@@ -52,12 +52,11 @@ impl AppState {
             self.root_nodes.dedup();
         }
 
-        self.selected = Some(new_id);
+        self.set_selected(Some(new_id));
         if !self.auto_arrange {
             self.ensure_grid_positions();
             crate::layout::roles::recalculate_roles(self);
         }
-        crate::layout::center_on_node(self, new_id);
         if self.nodes.get(&new_id).and_then(|n| n.parent).is_none() {
             if let Some(n) = self.nodes.get_mut(&new_id) {
                 n.parent = Some(parent_id);
@@ -102,14 +101,13 @@ impl AppState {
 
         self.nodes.insert(new_id, sibling);
         crate::log_debug!(self, "Inserted node {} → parent {:?}", new_id, parent_id);
-        self.selected = Some(new_id);
+        self.set_selected(Some(new_id));
 
         if !self.auto_arrange {
             self.ensure_grid_positions();
             crate::layout::roles::recalculate_roles(self);
         }
         self.ensure_valid_roots();
-        crate::layout::center_on_node(self, new_id);
         self.audit_node_graph();
         self.audit_ancestry();
     }
@@ -159,7 +157,6 @@ impl AppState {
 
         crate::layout::roles::recalculate_roles(self);
         self.ensure_valid_roots();
-        crate::layout::center_on_node(self, new_id);
         self.audit_node_graph();
         self.audit_ancestry();
     }

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -17,6 +17,16 @@ impl AppState {
     pub fn set_selected(&mut self, id: Option<NodeID>) {
         self.selected = id;
         self.last_promoted_root = None;
+
+        if let Some(node_id) = id {
+            let prev_x = self.scroll_x;
+            let prev_y = self.scroll_y;
+            crate::layout::center_on_node(self, node_id);
+            self.scroll_target_x = self.scroll_x;
+            self.scroll_target_y = self.scroll_y;
+            self.scroll_x = prev_x;
+            self.scroll_y = prev_y;
+        }
     }
 
     pub fn dock_focus_prev(&mut self) {
@@ -329,6 +339,25 @@ impl AppState {
         if let Some(id) = self.selected {
             crate::layout::zoom_to_anchor(self, id);
         }
+    }
+
+    /// Animate scroll offsets toward the target values for smooth centering.
+    pub fn animate_scroll(&mut self) {
+        let dx = self.scroll_target_x - self.scroll_x;
+        if dx.abs() > 0 {
+            self.scroll_x += dx / 2;
+            if (self.scroll_x - self.scroll_target_x).abs() <= 1 {
+                self.scroll_x = self.scroll_target_x;
+            }
+        }
+        let dy = self.scroll_target_y - self.scroll_y;
+        if dy.abs() > 0 {
+            self.scroll_y += dy / 2;
+            if (self.scroll_y - self.scroll_target_y).abs() <= 1 {
+                self.scroll_y = self.scroll_target_y;
+            }
+        }
+        crate::layout::clamp_scroll(self);
     }
 
     pub fn clear_fallback_promotions(&mut self) {

--- a/src/state/history.rs
+++ b/src/state/history.rs
@@ -31,7 +31,7 @@ impl AppState {
             self.redo_stack.push(current);
             self.nodes = prev.nodes;
             self.root_nodes = prev.root_nodes;
-            self.selected = prev.selected;
+            self.set_selected(prev.selected);
             crate::layout::roles::recalculate_roles(self);
             self.ensure_valid_roots();
         }
@@ -48,7 +48,7 @@ impl AppState {
             self.undo_stack.push(current);
             self.nodes = next.nodes;
             self.root_nodes = next.root_nodes;
-            self.selected = next.selected;
+            self.set_selected(next.selected);
             crate::layout::roles::recalculate_roles(self);
             self.ensure_valid_roots();
         }

--- a/src/state/serialize.rs
+++ b/src/state/serialize.rs
@@ -72,9 +72,11 @@ pub fn apply(state: &mut AppState, snap: PersistedLayout) {
         .map(|n| (n.id, Node::from(n)))
         .collect::<HashMap<_, _>>();
     state.root_nodes = snap.root_nodes;
-    state.selected = snap.selected;
+    state.set_selected(snap.selected);
     state.zoom_scale = snap.zoom;
     state.scroll_x = snap.scroll_x;
     state.scroll_y = snap.scroll_y;
+    state.scroll_target_x = snap.scroll_x;
+    state.scroll_target_y = snap.scroll_y;
     state.drawing_root = snap.drawing_root;
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -46,6 +46,8 @@ pub fn draw(
         state.ensure_grid_positions();
     }
 
+    state.animate_scroll();
+
     if state.show_spotlight && !state.prev_show_spotlight {
         state.spotlight_just_opened = true;
         state.spotlight_animation_frame = 0;


### PR DESCRIPTION
## Summary
- implement automatic viewport centering when selection changes
- add simple animated scrolling toward the target node
- update undo/redo and serialization to preserve centering
- refresh patch docs for 25.67k

## Testing
- `cargo test --lib --tests -- --skip render_gemx_snapshot`