### PR TITLE
Implement size-aware layout

### DIFF
--- a/src/gemx/layout.rs
+++ b/src/gemx/layout.rs
@@ -61,13 +61,33 @@ pub fn arrange_horizontally(nodes: &mut NodeMap, ids: &[NodeID], y: i16) {
 fn clamp_overlaps(nodes: &mut NodeMap) {
     let mut used = HashSet::new();
     for node in nodes.values_mut() {
+        let (bw, bh) = crate::layout::label_bounds(&node.label);
         let mut pos = (node.x, node.y);
-        while used.contains(&pos) {
+        loop {
+            let mut collision = false;
+            for dx in 0..bw {
+                for dy in 0..bh {
+                    if used.contains(&(pos.0 + dx, pos.1 + dy)) {
+                        collision = true;
+                        break;
+                    }
+                }
+                if collision {
+                    break;
+                }
+            }
+            if !collision {
+                for dx in 0..bw {
+                    for dy in 0..bh {
+                        used.insert((pos.0 + dx, pos.1 + dy));
+                    }
+                }
+                break;
+            }
             pos.0 += crate::layout::SIBLING_SPACING_X;
         }
         node.x = pos.0;
         node.y = pos.1;
-        used.insert(pos);
     }
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -28,6 +28,23 @@ pub const SNAP_GRID_Y: i16 = 2;
 pub const RESERVED_ZONE_W: i16 = 6;
 pub const RESERVED_ZONE_H: i16 = 6;
 
+/// Estimate the width and height of a label in grid units.
+///
+/// Returns `(width, height)` where width is the longest line length plus a
+/// padding of 2 characters and height is the number of lines.
+pub fn label_bounds(label: &str) -> (i16, i16) {
+    let mut width = 0i16;
+    let mut height = 0i16;
+    for line in label.lines() {
+        height += 1;
+        width = width.max(line.chars().count() as i16);
+    }
+    if height == 0 {
+        height = 1;
+    }
+    (width + 2, height)
+}
+
 pub fn spacing_for_zoom(zoom: f32) -> (i16, i16) {
     if zoom < 0.7 {
         (4, 2)
@@ -42,7 +59,7 @@ pub fn subtree_span(nodes: &NodeMap, id: NodeID) -> i16 {
             return 0;
         }
         if let Some(node) = nodes.get(&nid) {
-            let label_w = node.label.len() as i16 + 2;
+            let (label_w, _) = label_bounds(&node.label);
             if node.collapsed || node.children.is_empty() {
                 return label_w;
             }
@@ -203,7 +220,11 @@ pub fn layout_nodes(
     if auto_arrange {
         use std::collections::HashSet;
         let mut used: HashSet<(i16, i16)> = HashSet::new();
-        for pos in coords.values_mut() {
+        for (id, pos) in coords.iter_mut() {
+            let (bw, bh) = nodes
+                .get(id)
+                .map(|n| label_bounds(&n.label))
+                .unwrap_or((2, 1));
             loop {
                 if pos.x == 0 {
                     pos.x += SNAP_GRID_X;
@@ -211,8 +232,24 @@ pub fn layout_nodes(
                 if pos.y == 0 {
                     pos.y += SNAP_GRID_Y;
                 }
-                let key = (pos.x, pos.y);
-                if used.insert(key) {
+                let mut collision = false;
+                for dx in 0..bw {
+                    for dy in 0..bh {
+                        if used.contains(&(pos.x + dx, pos.y + dy)) {
+                            collision = true;
+                            break;
+                        }
+                    }
+                    if collision {
+                        break;
+                    }
+                }
+                if !collision {
+                    for dx in 0..bw {
+                        for dy in 0..bh {
+                            used.insert((pos.x + dx, pos.y + dy));
+                        }
+                    }
                     break;
                 }
                 pos.x += SNAP_GRID_X;
@@ -273,14 +310,14 @@ fn layout_recursive_safe(
     };
     roles.insert(node_id, role);
 
-    let label_width = node.label.len() as i16 + 2;
+    let (label_width, label_height) = label_bounds(&node.label);
     out.insert(node_id, Coords { x, y });
 
     if node.collapsed || node.children.is_empty() {
-        return (y, x, x + label_width);
+        return (y + label_height - 1, x, x + label_width);
     }
 
-    let child_y = y + CHILD_SPACING_Y;
+    let child_y = y + label_height + (CHILD_SPACING_Y - 1);
 
     let mut max_y = y;
     let mut min_x_span = x;
@@ -294,7 +331,7 @@ fn layout_recursive_safe(
         let subtree_w = subtree_span(nodes, *child_id);
         let label_w_child = nodes
             .get(child_id)
-            .map(|c| c.label.len() as i16 + 2)
+            .map(|c| label_bounds(&c.label).0)
             .unwrap_or(2);
         let child_w = subtree_w.max(label_w_child + MIN_NODE_GAP);
         if col_y + child_h > term_height {


### PR DESCRIPTION
## Summary
- implement patch 25.67m notes
- estimate node label bounding boxes
- use bounding boxes when laying out nodes
- prevent overlap in GemX layout modes

## Testing
- `cargo test --lib`