### PR TITLE
Patch 25.67w - Validate logging

### DIFF
--- a/golden/src.snapshot/bootstrap.rs
+++ b/golden/src.snapshot/bootstrap.rs
@@ -1,5 +1,6 @@
 pub fn start() -> std::io::Result<()> {
     crate::logging::init_logger();
+    tracing::info!("[BOOT] Logger initialized");
     tracing::info!("PrismX logging started");
     tracing::info!("Application bootstrap");
     crate::tui::launch_ui()

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,5 +1,6 @@
 pub fn start() -> std::io::Result<()> {
     crate::logger::init_logger();
+    tracing::info!("[BOOT] Logger initialized");
     tracing::info!("PrismX logging started");
     tracing::info!("Application bootstrap");
     crate::tui::launch_ui()


### PR DESCRIPTION
## Summary
- log when the logger is initialized during bootstrap
- sync golden snapshot

## Testing
- `cargo check`
- `scripts/ci/audit-integrity.sh` *(fails: load_plugins call missing)*