### PR TITLE
Patch 25.67v – Fix journal tag filtering

### DIFF
--- a/src/zen/state.rs
+++ b/src/zen/state.rs
@@ -166,11 +166,20 @@ impl AppState {
     }
 
     pub fn filtered_journal_entries(&self) -> Vec<&ZenJournalEntry> {
-        self.zen_journal_entries
+        let filter = self
+            .zen_tag_filter
+            .as_ref()
+            .map(|t| t.trim_start_matches('#').to_lowercase());
+
+        self
+            .zen_journal_entries
             .iter()
-            .filter(|e| {
-                if let Some(tag) = &self.zen_tag_filter {
-                    e.tags.iter().any(|t| t.eq_ignore_ascii_case(tag))
+            .filter(|entry| {
+                if let Some(tag) = &filter {
+                    entry
+                        .tags
+                        .iter()
+                        .any(|t| t.trim_start_matches('#').eq_ignore_ascii_case(tag))
                 } else {
                     true
                 }


### PR DESCRIPTION
## Summary
- fix tag filter logic in `filtered_journal_entries`

## Testing
- `cargo test --quiet` *(fails: render_gemx_snapshot::gemx_renders_correctly)*