### PR TITLE
Implement patch 25.67t

### DIFF
--- a/src/zen/view.rs
+++ b/src/zen/view.rs
@@ -113,6 +113,12 @@ pub fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
     let bg = Block::default().style(Style::default().bg(palette.background));
     f.render_widget(bg, area);
 
+    // Auto-scroll to the latest journal entry when composing
+    unsafe {
+        let ptr = state as *const AppState as *mut AppState;
+        (*ptr).scroll_offset = usize::MAX;
+    }
+
     if state.zen_view_mode == ZenViewMode::Write {
         let chunks = Layout::default()
             .direction(Direction::Vertical)


### PR DESCRIPTION
## Summary
- auto-scroll Zen Compose history to newest entry

## Testing
- `cargo check`
- `cargo test` *(fails: render_gemx_snapshot::gemx_renders_correctly)*