### PR TITLE
Add settings preview with live font samples

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,6 +1,7 @@
 // src/settings.rs
 use crate::beam_color::BeamColor;
 use crate::state::AppState;
+use crate::theme::fonts::FontStyle;
 use serde::{Deserialize, Serialize};
 use std::fs;
 
@@ -18,6 +19,8 @@ pub struct UserSettings {
     pub beamx_panel_theme: BeamColor,
     pub beamx_panel_visible: bool,
     pub mindmap_lanes: bool,
+    pub font_style: FontStyle,
+    pub beam_animation: bool,
 }
 
 impl Default for UserSettings {
@@ -35,6 +38,8 @@ impl Default for UserSettings {
             beamx_panel_theme: BeamColor::Prism,
             beamx_panel_visible: crate::state::default_beamx_panel_visible(),
             mindmap_lanes: true,
+            font_style: FontStyle::Regular,
+            beam_animation: true,
         }
     }
 }
@@ -63,6 +68,8 @@ pub fn save_user_settings(state: &AppState) {
         beamx_panel_theme: state.beamx_panel_theme,
         beamx_panel_visible: state.beamx_panel_visible,
         mindmap_lanes: state.mindmap_lanes,
+        font_style: state.font_style,
+        beam_animation: state.beam_animation,
     };
 
     if let Ok(serialized) = toml::to_string(&config) {

--- a/src/settings/render.rs
+++ b/src/settings/render.rs
@@ -10,15 +10,31 @@ use ratatui::{
 use crate::state::AppState;
 use crate::config::theme::ThemeConfig;
 use super::{layout::settings_area, toggle::SETTING_TOGGLES};
+use crate::theme::previews::preview_line;
 
 pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
     let theme = ThemeConfig::load();
     let mut lines: Vec<Line> = Vec::new();
+    let header_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
 
     for (i, t) in SETTING_TOGGLES.iter().enumerate() {
+        // section headers
+        if i == 0 {
+            lines.push(Line::from(Span::styled("Font", header_style)));
+        } else if i == 1 {
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled("UI", header_style)));
+        } else if i == 5 {
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled("Layout", header_style)));
+        }
+
         let enabled = (t.is_enabled)(state);
         let selected = i == state.settings_focus_index % SETTING_TOGGLES.len();
-        let label = t.label;
+        let mut label = t.label.to_string();
+        if t.label == "Font Style" {
+            label = format!("Font Style: {}", state.font_style.name());
+        }
 
         let check = if enabled { "[x]" } else { "[ ]" };
         let prefix = if selected { "> " } else { "  " };
@@ -38,11 +54,10 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppStat
             Span::styled(prefix.to_string(), style),
             Span::styled(format!("{} {} {}", check, t.icon, label), style),
         ]));
-
-        if i == 2 || i == 3 {
-            lines.push(Line::default());
-        }
     }
+
+    lines.push(Line::default());
+    lines.push(preview_line(state.font_style, state.settings_beam_color));
 
     let rect = settings_area(area, &lines);
 

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -1,5 +1,6 @@
 use crate::beam_color::BeamColor;
 use crate::state::AppState;
+use crate::theme::fonts::FontStyle;
 use super::save_user_settings;
 use std::sync::atomic::{AtomicU8, Ordering};
 
@@ -51,12 +52,20 @@ fn toggle_beamx_panel_visibility(s: &mut AppState) { s.beamx_panel_visible = !s.
 fn is_mindmap_lanes(s: &AppState) -> bool { s.mindmap_lanes }
 fn toggle_mindmap_lanes(s: &mut AppState) { s.mindmap_lanes = !s.mindmap_lanes; save_user_settings(s); }
 
+fn toggle_font_style(s: &mut AppState) { s.font_style = s.font_style.next(); save_user_settings(s); }
+fn font_style_enabled(_: &AppState) -> bool { true }
+
+fn is_beam_animation(s: &AppState) -> bool { s.beam_animation }
+fn toggle_beam_animation(s: &mut AppState) { s.beam_animation = !s.beam_animation; save_user_settings(s); }
+
 pub static SETTING_TOGGLES: &[SettingToggle] = &[
+    SettingToggle { icon: "🔠", label: "Font Style", is_enabled: font_style_enabled, toggle: toggle_font_style },
     SettingToggle { icon: "🐞", label: "Debug Input Mode", is_enabled: is_debug_mode, toggle: toggle_debug_mode },
-    SettingToggle { icon: "🤖", label: "Auto-Arrange", is_enabled: is_auto_arrange, toggle: toggle_auto_arrange },
-    SettingToggle { icon: "🔒", label: "Lock Zoom Scale", is_enabled: is_zoom_locked, toggle: toggle_zoom_lock },
+    SettingToggle { icon: "⚡", label: "Beam Animations", is_enabled: is_beam_animation, toggle: toggle_beam_animation },
     SettingToggle { icon: "🎨", label: "Theme Preset", is_enabled: |_| true, toggle: toggle_theme },
     SettingToggle { icon: "💠", label: "BeamX Panel", is_enabled: is_beamx_panel_visible, toggle: toggle_beamx_panel_visibility },
+    SettingToggle { icon: "🤖", label: "Auto-Arrange", is_enabled: is_auto_arrange, toggle: toggle_auto_arrange },
+    SettingToggle { icon: "🔒", label: "Lock Zoom Scale", is_enabled: is_zoom_locked, toggle: toggle_zoom_lock },
     SettingToggle { icon: "✨", label: "Mindmap Lanes", is_enabled: is_mindmap_lanes, toggle: toggle_mindmap_lanes },
 ];
 

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -184,6 +184,8 @@ pub struct AppState {
     pub zen_icon_glyph: Option<String>,
     pub beamx_panel_theme: crate::beam_color::BeamColor,
     pub beamx_panel_visible: bool,
+    pub font_style: crate::theme::fonts::FontStyle,
+    pub beam_animation: bool,
     pub triage_view_mode: crate::state::TriageViewMode,
     pub plugin_view_mode: crate::state::PluginViewMode,
     pub plugin_tag_filter: crate::state::PluginTagFilter,
@@ -316,6 +318,8 @@ impl Default for AppState {
             zen_icon_glyph: None,
             beamx_panel_theme: crate::beam_color::BeamColor::Prism,
             beamx_panel_visible: default_beamx_panel_visible(),
+            font_style: crate::theme::fonts::FontStyle::Regular,
+            beam_animation: true,
             triage_view_mode: crate::state::TriageViewMode::default(),
             plugin_view_mode: crate::state::PluginViewMode::default(),
             plugin_tag_filter: crate::state::PluginTagFilter::default(),
@@ -339,6 +343,8 @@ impl Default for AppState {
         state.beamx_panel_theme = config.beamx_panel_theme;
         state.beamx_panel_visible = config.beamx_panel_visible;
         state.mindmap_lanes = config.mindmap_lanes;
+        state.font_style = config.font_style;
+        state.beam_animation = config.beam_animation;
 
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,6 +5,8 @@ use std::sync::Mutex;
 
 pub mod zen;
 pub mod colors;
+pub mod fonts;
+pub mod previews;
 
 static CURRENT_THEME: Mutex<&str> = Mutex::new("dark");
 

--- a/src/theme/fonts.rs
+++ b/src/theme/fonts.rs
@@ -1,0 +1,39 @@
+use ratatui::style::{Style, Modifier};
+use serde::{Serialize, Deserialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum FontStyle {
+    Regular,
+    Bold,
+    Italic,
+}
+
+impl Default for FontStyle {
+    fn default() -> Self { FontStyle::Regular }
+}
+
+impl FontStyle {
+    pub fn next(self) -> Self {
+        match self {
+            FontStyle::Regular => FontStyle::Bold,
+            FontStyle::Bold => FontStyle::Italic,
+            FontStyle::Italic => FontStyle::Regular,
+        }
+    }
+
+    pub fn style(self) -> Style {
+        match self {
+            FontStyle::Regular => Style::default(),
+            FontStyle::Bold => Style::default().add_modifier(Modifier::BOLD),
+            FontStyle::Italic => Style::default().add_modifier(Modifier::ITALIC),
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            FontStyle::Regular => "Regular",
+            FontStyle::Bold => "Bold",
+            FontStyle::Italic => "Italic",
+        }
+    }
+}

--- a/src/theme/previews.rs
+++ b/src/theme/previews.rs
@@ -1,0 +1,29 @@
+use ratatui::{
+    backend::Backend,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::beam_color::BeamColor;
+use super::fonts::FontStyle;
+
+pub fn preview_line(font: FontStyle, color: BeamColor) -> Line<'static> {
+    let (fg, _, _) = color.palette();
+    Line::from(Span::styled(
+        "Sample: The quick brown fox jumps over the lazy dog",
+        font.style().fg(fg),
+    ))
+}
+
+pub fn render_preview<B: Backend>(
+    f: &mut Frame<B>,
+    area: Rect,
+    font: FontStyle,
+    color: BeamColor,
+) {
+    let line = preview_line(font, color);
+    let para = Paragraph::new(line);
+    f.render_widget(para, area);
+}


### PR DESCRIPTION
## Summary
- expand settings to include font style and animation toggles
- group settings by category with headers
- render one-line preview showing the active font and beam color
- add helper modules for font styles and preview rendering

## Testing
- `cargo check -q`
- `cargo test -q` *(fails: render_gemx_snapshot::gemx_renders_correctly)*