### PR TITLE
patch-25.68c: BeamX emblem cleanup

### DIFF
--- a/src/beamx.rs
+++ b/src/beamx.rs
@@ -153,15 +153,14 @@ pub fn render_full_border<B: Backend>(
     let beam_x = area.right() - 1;
     let arrow_top_y = area.top();
     let arrow_bottom_y = area.top() + 4;
-    let skip_y_range = (arrow_top_y + 1)..arrow_bottom_y;
+    let skip_y_range = (arrow_top_y + 1)..=arrow_bottom_y;
     for y in area.y + 1..bottom {
         let p = Paragraph::new("┃").style(fg);
         f.render_widget(p, Rect::new(area.x, y, 1, 1));
-        if trim_right {
-            if beamx_enabled && skip_y_range.contains(&y) {
-                continue;
-            }
-        } else if beamx_enabled && right == beam_x && (y == arrow_top_y + 1 || y == arrow_bottom_y) {
+        if beamx_enabled && right == beam_x && skip_y_range.contains(&y) {
+            continue;
+        }
+        if trim_right && skip_y_range.contains(&y) {
             continue;
         }
         let p2 = Paragraph::new("┃").style(fg);

--- a/src/theme/characters.rs
+++ b/src/theme/characters.rs
@@ -1,6 +1,6 @@
-pub const TOP_LEFT: &str = "╭";
-pub const TOP_RIGHT: &str = "╮";
-pub const BOTTOM_LEFT: &str = "╰";
-pub const BOTTOM_RIGHT: &str = "╯";
-pub const HORIZONTAL: &str = "─";
-pub const VERTICAL: &str = "│";
+pub const TOP_LEFT: &str = "┏";
+pub const TOP_RIGHT: &str = "┓";
+pub const BOTTOM_LEFT: &str = "┗";
+pub const BOTTOM_RIGHT: &str = "┛";
+pub const HORIZONTAL: &str = "━";
+pub const VERTICAL: &str = "┃";

--- a/src/ui/beamx.rs
+++ b/src/ui/beamx.rs
@@ -130,8 +130,8 @@ impl From<BeamXMode> for BeamXStyle {
                 bottom_left: "⬈",
                 left: "⥤",
                 right: "⥢",
-                top_right: "⬋",
-                bottom_right: "⬉",
+                top_right: "↙",
+                bottom_right: "↖",
                 pulse: &DEFAULT_PULSE,
             },
             BeamXMode::Default => Self {
@@ -142,8 +142,8 @@ impl From<BeamXMode> for BeamXStyle {
                 bottom_left: "⬈",
                 left: "⥤",
                 right: "⥢",
-                top_right: "⬋",
-                bottom_right: "⬉",
+                top_right: "↙",
+                bottom_right: "↖",
                 pulse: &DEFAULT_PULSE,
             },
         }


### PR DESCRIPTION
## Summary
- clear heavy corner artifacts in theme characters
- skip border rendering through BeamX arrow channel
- use diagonal arrows to avoid residual vertical bar

## Testing
- `cargo test` *(fails: render_gemx_snapshot::gemx_renders_correctly)*