### PR TITLE
Implement triage tag toggling hotkeys

### DIFF
--- a/src/state/triage.rs
+++ b/src/state/triage.rs
@@ -53,6 +53,29 @@ impl AppState {
         self.triage_focus_next();
     }
 
+    /// Toggle a tag on the currently focused entry.
+    pub fn triage_toggle_tag(&mut self, tag: &str) {
+        if let Some(entry) = self.triage_entries.get_mut(self.triage_focus_index) {
+            let has_tag = entry.tags.iter().any(|t| t.eq_ignore_ascii_case(tag));
+            if has_tag {
+                entry.tags.retain(|t| !t.eq_ignore_ascii_case(tag));
+                let words: Vec<String> = entry
+                    .text
+                    .split_whitespace()
+                    .filter(|w| !w.eq_ignore_ascii_case(tag))
+                    .map(|w| w.to_string())
+                    .collect();
+                entry.text = words.join(" ");
+            } else {
+                if !entry.text.is_empty() && !entry.text.ends_with(' ') {
+                    entry.text.push(' ');
+                }
+                entry.text.push_str(tag);
+                entry.tags.push(tag.to_lowercase());
+            }
+        }
+    }
+
     /// Update cached tag counts used in status views.
     pub fn triage_recalc_counts(&mut self) {
         let (n, t, d) = crate::triage::state::tag_counts(self);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -585,6 +585,18 @@ pub fn launch_ui() -> std::io::Result<()> {
                         state.triage_delete_current();
                         state.triage_recalc_counts();
                     }
+                    KeyCode::Char('1') if state.mode == "triage" && modifiers == KeyModifiers::CONTROL => {
+                        state.triage_toggle_tag("#now");
+                        state.triage_recalc_counts();
+                    }
+                    KeyCode::Char('2') if state.mode == "triage" && modifiers == KeyModifiers::CONTROL => {
+                        state.triage_toggle_tag("#triton");
+                        state.triage_recalc_counts();
+                    }
+                    KeyCode::Char('3') if state.mode == "triage" && modifiers == KeyModifiers::CONTROL => {
+                        state.triage_toggle_tag("#done");
+                        state.triage_recalc_counts();
+                    }
 
                     KeyCode::Up if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {
                         state.dock_focus_prev();

--- a/tests/triage_toggle.rs
+++ b/tests/triage_toggle.rs
@@ -1,0 +1,17 @@
+use prismx::state::AppState;
+use prismx::triage::state::{TriageEntry, TriageSource};
+
+#[test]
+fn triage_toggle_tag_adds_and_removes() {
+    let mut state = AppState::default();
+    state.triage_entries.push(TriageEntry::new(0, "fix bug", TriageSource::Zen));
+    state.triage_focus_index = 0;
+
+    state.triage_toggle_tag("#now");
+    assert!(state.triage_entries[0].tags.contains(&"#now".to_string()));
+    assert!(state.triage_entries[0].text.contains("#now"));
+
+    state.triage_toggle_tag("#now");
+    assert!(!state.triage_entries[0].tags.contains(&"#now".to_string()));
+    assert!(!state.triage_entries[0].text.contains("#now"));
+}


### PR DESCRIPTION
## Summary
- allow toggling tags on the focused triage entry
- wire Ctrl+1/2/3 keys to toggle #now/#triton/#done
- add regression test for triage_toggle_tag

## Testing
- `cargo test --quiet` *(fails: render_gemx_snapshot::gemx_renders_correctly)*
- `cargo test --quiet --test triage_toggle`