### PR TITLE
Add sticky note base structs

### DIFF
--- a/src/modules/triage/mod.rs
+++ b/src/modules/triage/mod.rs
@@ -1,1 +1,3 @@
 pub use crate::triage::*;
+
+pub mod sticky;

--- a/src/modules/triage/sticky.rs
+++ b/src/modules/triage/sticky.rs
@@ -1,0 +1,76 @@
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+/// Draggable sticky note widget used in the Triage panel.
+#[derive(Clone, Debug)]
+pub struct StickyNote {
+    /// Short heading displayed at the top of the note.
+    pub title: String,
+    /// Multi-line text body for the note.
+    pub body: String,
+    /// Background color of the note.
+    pub color: Color,
+    /// Top-left X position in terminal cells.
+    pub x: u16,
+    /// Top-left Y position in terminal cells.
+    pub y: u16,
+    /// Whether this note is currently focused.
+    pub focused: bool,
+}
+
+impl StickyNote {
+    /// Create a new sticky note at the given coordinates.
+    pub fn new<T: Into<String>, B: Into<String>>(title: T, body: B, color: Color, x: u16, y: u16) -> Self {
+        Self {
+            title: title.into(),
+            body: body.into(),
+            color,
+            x,
+            y,
+            focused: false,
+        }
+    }
+
+    /// Area occupied by this note.
+    pub fn area(&self) -> Rect {
+        Rect::new(self.x, self.y, 20, 8)
+    }
+
+    /// Move the note by the specified delta.
+    pub fn translate(&mut self, dx: i16, dy: i16) {
+        self.x = adjust(self.x, dx);
+        self.y = adjust(self.y, dy);
+    }
+
+    /// Check if the provided coordinates are inside this note.
+    pub fn contains(&self, x: u16, y: u16) -> bool {
+        let area = self.area();
+        x >= area.x && x < area.right() && y >= area.y && y < area.bottom()
+    }
+
+    /// Render the sticky note widget.
+    pub fn render<B: Backend>(&self, f: &mut Frame<B>) {
+        let area = self.area();
+        let mut style = Style::default().bg(self.color);
+        if self.focused {
+            style = style.add_modifier(Modifier::BOLD);
+        }
+        let block = Block::default().borders(Borders::ALL).style(style);
+        f.render_widget(block, area);
+
+        let title = Paragraph::new(self.title.clone())
+            .style(Style::default().add_modifier(Modifier::BOLD));
+        f.render_widget(title, Rect::new(area.x + 1, area.y + 1, area.width - 2, 1));
+
+        let body = Paragraph::new(self.body.clone()).wrap(Wrap { trim: true });
+        f.render_widget(body, Rect::new(area.x + 1, area.y + 2, area.width - 2, area.height - 3));
+    }
+}
+
+fn adjust(val: u16, delta: i16) -> u16 {
+    if delta.is_negative() {
+        val.saturating_sub(delta.wrapping_abs() as u16)
+    } else {
+        val.saturating_add(delta as u16)
+    }
+}

--- a/src/theme/colors.rs
+++ b/src/theme/colors.rs
@@ -23,3 +23,11 @@ impl SpotlightPalette {
         }
     }
 }
+
+/// Default background colors for sticky notes in the Triage panel.
+pub const STICKY_COLORS: [Color; 4] = [
+    Color::Rgb(252, 234, 170), // yellow
+    Color::Rgb(250, 210, 180), // peach
+    Color::Rgb(210, 240, 180), // green
+    Color::Rgb(200, 220, 250), // blue
+];

--- a/src/ui/drag.rs
+++ b/src/ui/drag.rs
@@ -1,0 +1,30 @@
+/// Generic drag helper for movable UI elements.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct DragState {
+    pub active: bool,
+    pub last_x: u16,
+    pub last_y: u16,
+}
+
+impl DragState {
+    /// Begin a drag operation from the given coordinates.
+    pub fn start(&mut self, x: u16, y: u16) {
+        self.active = true;
+        self.last_x = x;
+        self.last_y = y;
+    }
+
+    /// End the current drag operation.
+    pub fn stop(&mut self) {
+        self.active = false;
+    }
+
+    /// Calculate the delta from the previous coordinates and update the stored position.
+    pub fn delta(&mut self, x: u16, y: u16) -> (i16, i16) {
+        let dx = x as i16 - self.last_x as i16;
+        let dy = y as i16 - self.last_y as i16;
+        self.last_x = x;
+        self.last_y = y;
+        (dx, dy)
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,3 +10,4 @@ pub mod lines;
 pub mod borders;
 pub mod status;
 pub mod dock;
+pub mod drag;


### PR DESCRIPTION
## Summary
- add `StickyNote` type for draggable post-it cards
- expose sticky note module under triage
- provide default sticky colors in theme
- add reusable `DragState` helper

## Testing
- `cargo check -q`
- `cargo test -q` *(fails: render_gemx_snapshot::gemx_renders_correctly)*