### PR TITLE
patch-25.70a: lock spotlight width

### DIFF
--- a/src/theme/layout.rs
+++ b/src/theme/layout.rs
@@ -4,3 +4,14 @@ pub fn spacing_scale(zoom: f32) -> (i16, i16) {
     (x, y)
 }
 
+/// Fixed width for the Spotlight overlay in columns.
+pub const SPOTLIGHT_WIDTH: u16 = 60;
+
+/// Determine the width of Spotlight based on the available area.
+///
+/// The width never exceeds [`SPOTLIGHT_WIDTH`] and is independent of user input
+/// length so the panel remains stable as commands are typed.
+pub fn spotlight_width(area_width: u16) -> u16 {
+    area_width.min(SPOTLIGHT_WIDTH)
+}
+

--- a/src/ui/components/spotlight.rs
+++ b/src/ui/components/spotlight.rs
@@ -9,6 +9,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::ui::animate::cursor_blink;
 use std::time::{SystemTime, UNIX_EPOCH};
 use crate::ui::layout::Rect;
+use crate::theme::layout::spotlight_width;
 
 use crate::state::AppState;
 use crate::spotlight::{command_preview, command_suggestions_scored};
@@ -26,9 +27,9 @@ pub fn render_spotlight<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut Ap
     let display_input = format!("{}{}", raw_input, caret);
     let cfg = ThemeConfig::load();
     let palette = cfg.spotlight_palette();
-    let base_width = area.width.min(60);
-    let min_width = UnicodeWidthStr::width(display_input.as_str()) as u16 + 3; // "> " prefix
-    let width = base_width.min(min_width.max(3));
+
+    // Use a fixed width so the Spotlight panel doesn't resize with input length.
+    let width = spotlight_width(area.width);
     let x_offset = area.x + (area.width.saturating_sub(width)) / 2;
     let y_offset = area.y + area.height / 3;
 


### PR DESCRIPTION
## Summary
- lock Spotlight width to prevent horizontal resizing while typing
- expose `spotlight_width` helper in layout module

## Testing
- `cargo check`
- `cargo test` *(fails: tests hang after 60s)*