### PR TITLE
Fix mindmap layout overflow

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -330,7 +330,6 @@ fn layout_recursive_safe(
 
     let mut col_x = x;
     let mut col_y = child_y;
-    let mut column_width = 0;
     for (index, child_id) in node.children.iter().enumerate() {
         let child_h = subtree_depth(nodes, *child_id) * spacing_y + 1;
         let subtree_w = subtree_span(nodes, *child_id);
@@ -339,13 +338,6 @@ fn layout_recursive_safe(
             .map(|c| label_bounds(&c.label).0)
             .unwrap_or(2);
         let child_w = subtree_w.max(label_w_child + MIN_NODE_GAP);
-        if col_y + child_h > term_height {
-            tracing::debug!("wrap column for node {}", child_id);
-            col_y = child_y;
-            col_x += column_width + SIBLING_SPACING_X;
-            column_width = 0;
-        }
-
         if col_y + child_h > term_height {
             tracing::debug!("overflow node {} beyond height {}", child_id, term_height);
         }
@@ -369,7 +361,7 @@ fn layout_recursive_safe(
         max_x_span = max_x_span.max(ma);
 
         col_y = cy + spacing_y;
-        column_width = column_width.max(child_w);
+        let _ = child_w; // maintain consistent spacing calculations for now
     }
 
     (max_y, min_x_span.min(x), max_x_span.max(x + label_width))

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -15,6 +15,13 @@ pub fn render<B: Backend>(
         layout_vertical(nodes, root);
     }
 
+    // Determine scroll offset if content exceeds available height
+    let max_y = nodes.values().map(|n| n.y).max().unwrap_or(0);
+    let mut scroll = 0i16;
+    if max_y >= area.height as i16 {
+        scroll = max_y - area.height as i16 + 1;
+    }
+
     if debug {
         // Draw connections first
         let mut connections = Vec::new();
@@ -32,14 +39,18 @@ pub fn render<B: Backend>(
         for ((sx, sy), (ex, ey)) in connections {
             let ox = area.x as i16;
             let oy = area.y as i16;
-            draw_line(f, (sx + ox, sy + oy), (ex + ox, ey + oy));
+            draw_line(
+                f,
+                (sx + ox, sy + oy - scroll),
+                (ex + ox, ey + oy - scroll),
+            );
         }
     }
 
     // Draw nodes
     for node in nodes.values() {
         let x = area.x as i16 + node.x;
-        let y = area.y as i16 + node.y;
+        let y = area.y as i16 + node.y - scroll;
         if x >= 0 && y >= 0 && x < area.right() as i16 && y < area.bottom() as i16 {
             let rect = Rect::new(x as u16, y as u16, node.label.len() as u16, 1);
             f.render_widget(Paragraph::new(node.label.clone()), rect);


### PR DESCRIPTION
## Summary
- prevent horizontal wrapping of deep child branches
- add vertical scroll handling for demo mindmap renderer

## Testing
- `cargo test --quiet` *(fails: tests hang)*