### PR TITLE
Implement context-aware shortcut overlay

### DIFF
--- a/src/render/shortcuts_overlay.rs
+++ b/src/render/shortcuts_overlay.rs
@@ -24,10 +24,46 @@ pub fn render_shortcuts_overlay<B: Backend>(f: &mut Frame<B>, area: Rect, state:
         groups.entry("Plugins").or_default().push((k, v));
     }
 
+    let active_group = match state.mode.as_str() {
+        "zen" => "Zen",
+        "triage" => "Triage",
+        "plugin" => "Plugins",
+        "settings" => "Settings",
+        _ => "GemX",
+    };
+
     let mut lines: Vec<Line> = Vec::new();
-    for (group, items) in groups {
-        lines.push(Line::from(Span::styled(group, Style::default().add_modifier(Modifier::BOLD))));
-        for (k, v) in items {
+
+    if let Some(mut items) = groups.remove(active_group) {
+        lines.push(Line::from(Span::styled(
+            active_group,
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for (k, v) in items.drain(..) {
+            lines.push(Line::from(format!("{} = {}", k, v)));
+        }
+        lines.push(Line::from(""));
+    }
+
+    if let Some(mut items) = groups.remove("Debug") {
+        if state.debug_overlay || state.debug_overlay_sticky {
+            lines.push(Line::from(Span::styled(
+                "Debug",
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+            for (k, v) in items.drain(..) {
+                lines.push(Line::from(format!("{} = {}", k, v)));
+            }
+            lines.push(Line::from(""));
+        }
+    }
+
+    if let Some(mut items) = groups.remove("Global") {
+        lines.push(Line::from(Span::styled(
+            "Global",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for (k, v) in items.drain(..) {
             lines.push(Line::from(format!("{} = {}", k, v)));
         }
         lines.push(Line::from(""));

--- a/src/ui/shortcuts.rs
+++ b/src/ui/shortcuts.rs
@@ -1,5 +1,18 @@
 pub fn action_group(action: &str) -> &'static str {
-    if action.starts_with("zen_") || matches!(action, "mode_zen" | "save") {
+    if matches!(
+        action,
+        "quit"
+            | "switch_module"
+            | "open_module_switcher"
+            | "help"
+            | "toggle_keymap"
+            | "toggle_triage"
+            | "toggle_plugin"
+            | "toggle_settings"
+            | "mode_zen"
+    ) {
+        "Global"
+    } else if action.starts_with("zen_") || matches!(action, "save") {
         "Zen"
     } else if action.contains("triage") {
         "Triage"


### PR DESCRIPTION
## Summary
- categorize global hotkeys in `action_group`
- filter overlay to show active module plus global keys

## Testing
- `cargo test` *(fails: long-running tests exceed timeout)*