### PR TITLE
patch-25.70b: update Triage icon

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -14,7 +14,7 @@ pub fn module_icon(mode: &str) -> &'static str {
     match mode {
         "gemx" => "💭",
         "zen" => "🧘",
-        "triage" => "🧭",
+        "triage" => "🏥",
         "spotlight" => "🔍",
         "settings" => "⚙️",
         "plugin" => "🔌",

--- a/src/render/module_switcher.rs
+++ b/src/render/module_switcher.rs
@@ -11,7 +11,7 @@ pub fn render_module_switcher<B: Backend>(f: &mut Frame<B>, area: Rect, index: u
     let modules = [
         ("💭", "Mindmap"),
         ("🧘", "Zen"),
-        ("🧭", "Triage"),
+        ("🏥", "Triage"),
         ("⚙️", "Settings"),
         ("🔌", "Plugins"),
     ];

--- a/src/spotlight/result.rs
+++ b/src/spotlight/result.rs
@@ -3,7 +3,7 @@ pub fn command_icon(cmd: &str) -> &'static str {
     match cmd {
         "zen" => "\u{1F4C4}",  // 📄
         "settings" => "\u{2699}\u{FE0F}", // ⚙️
-        "triage" => "\u{1F9ED}", // 🧭
+        "triage" => "\u{1F3E5}", // 🏥
         "gemx" => "\u{1F4AD}", // 💭
         "plugin" => "\u{1F50C}", // 🔌
         "search" => "\u{1F50D}", // 🔍

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -419,7 +419,7 @@ impl AppState {
     pub fn favorite_entries(&self) -> Vec<FavoriteEntry> {
         let default_favorites = [
             ("⚙️", "/settings"),
-            ("📬", "/triage"),
+            ("🏥", "/triage"),
             ("💭", "/gemx"),
             ("🧘", "/zen"),
             ("🔍", "/spotlight"),
@@ -440,7 +440,7 @@ impl AppState {
             all[2].icon = "💬";
         }
         if (self.mode == "triage" || self.show_triage) && all.len() >= 2 {
-            all[1].icon = "📫";
+            all[1].icon = "🏥";
         }
         all
     }

--- a/src/ui/components/module.rs
+++ b/src/ui/components/module.rs
@@ -19,7 +19,7 @@ pub fn render_module_switcher(
     let modules = [
         ("💭", "Mindmap"),
         ("🧘", "Zen"),
-        ("🧭", "Triage"),
+        ("🏥", "Triage"),
         ("⚙️", "Settings"),
         ("🔌", "Plugins"),
     ];

--- a/tests/module_icon.rs
+++ b/tests/module_icon.rs
@@ -4,7 +4,7 @@ use prismx::render::module_icon::module_icon;
 fn module_icon_matches_mode() {
     assert_eq!(module_icon("gemx"), "💭");
     assert_eq!(module_icon("zen"), "🧘");
-    assert_eq!(module_icon("triage"), "🧭");
+    assert_eq!(module_icon("triage"), "🏥");
     assert_eq!(module_icon("spotlight"), "🔍");
     assert_eq!(module_icon("settings"), "⚙️");
 }


### PR DESCRIPTION
## Summary
- use hospital emoji for Triage module icon
- update spotlight command icon
- refresh favorites dock icon
- adjust module switcher and tests

## Testing
- `PRISMX_TEST=1 cargo test --quiet`