### PR TITLE
Fix Zen compose scroll and journal path

### DIFF
--- a/src/zen/state.rs
+++ b/src/zen/state.rs
@@ -125,7 +125,12 @@ impl AppState {
     }
 
     pub fn load_today_journal(&mut self) {
-        let path = format!("journals/{}.prismx", chrono::Local::now().format("%Y-%m-%d"));
+        let dir = dirs::document_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join("prismx")
+            .join("journals");
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join(format!("{}.prismx", chrono::Local::now().format("%Y-%m-%d")));
         if let Ok(content) = fs::read_to_string(&path) {
             self.zen_journal_entries = content
                 .lines()
@@ -146,8 +151,12 @@ impl AppState {
     }
 
     pub fn append_journal_entry(&mut self, entry: &ZenJournalEntry) {
-        let _ = std::fs::create_dir_all("journals");
-        let path = format!("journals/{}.prismx", chrono::Local::now().format("%Y-%m-%d"));
+        let dir = dirs::document_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join("prismx")
+            .join("journals");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join(format!("{}.prismx", chrono::Local::now().format("%Y-%m-%d")));
         if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
             let _ = writeln!(
                 file,

--- a/src/zen/view.rs
+++ b/src/zen/view.rs
@@ -113,11 +113,7 @@ pub fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
     let bg = Block::default().style(Style::default().bg(palette.background));
     f.render_widget(bg, area);
 
-    // Auto-scroll to the latest journal entry when composing
-    unsafe {
-        let ptr = state as *const AppState as *mut AppState;
-        (*ptr).scroll_offset = usize::MAX;
-    }
+    // Preserve manual scroll offset when reviewing history
 
     if state.zen_view_mode == ZenViewMode::Write {
         let chunks = Layout::default()


### PR DESCRIPTION
## Summary
- preserve manual scroll in compose mode
- write zen journal entries under user's documents directory

## Testing
- `cargo check --quiet`
- `cargo test --quiet` *(fails: io error when listing tests)*