### PR TITLE
patch-25.70h: enable sticky notes panel

### DIFF
--- a/src/hotkeys/actions.rs
+++ b/src/hotkeys/actions.rs
@@ -123,3 +123,7 @@ pub fn toggle_settings(state: &mut AppState) {
     state.mode = "settings".into();
 }
 
+pub fn toggle_sticky_notes(state: &mut AppState) {
+    state.toggle_sticky_overlay();
+}
+

--- a/src/hotkeys/bindings.rs
+++ b/src/hotkeys/bindings.rs
@@ -37,6 +37,7 @@ pub fn load_default_hotkeys() -> HashMap<String, String> {
     map.insert("debug_overlay".into(), "alt-d".into());
     map.insert("debug_overlay_sticky".into(), "alt-shift-d".into());
     map.insert("reload_plugins".into(), "alt-r".into());
+    map.insert("toggle_sticky_notes".into(), "ctrl-shift-n".into());
 
 
     map

--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -1,0 +1,69 @@
+use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseButton};
+use crate::state::AppState;
+
+pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
+    if !state.sticky_overlay_visible { return false; }
+    if let Some(idx) = state.sticky_focus {
+        match code {
+            KeyCode::Char(c) if mods.is_empty() || mods == KeyModifiers::SHIFT => {
+                state.sticky_notes_data[idx].body.push(c);
+                return true;
+            }
+            KeyCode::Backspace => {
+                state.sticky_notes_data[idx].body.pop();
+                return true;
+            }
+            KeyCode::Left if mods.contains(KeyModifiers::SHIFT) => {
+                state.sticky_notes_data[idx].translate(-1, 0);
+                return true;
+            }
+            KeyCode::Right if mods.contains(KeyModifiers::SHIFT) => {
+                state.sticky_notes_data[idx].translate(1, 0);
+                return true;
+            }
+            KeyCode::Up if mods.contains(KeyModifiers::SHIFT) => {
+                state.sticky_notes_data[idx].translate(0, -1);
+                return true;
+            }
+            KeyCode::Down if mods.contains(KeyModifiers::SHIFT) => {
+                state.sticky_notes_data[idx].translate(0, 1);
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+pub fn handle_mouse(state: &mut AppState, me: MouseEvent) -> bool {
+    if !state.sticky_overlay_visible { return false; }
+    match me.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            if let Some(idx) = state.sticky_note_at(me.column, me.row) {
+                state.sticky_focus = Some(idx);
+                for (i, note) in state.sticky_notes_data.iter_mut().enumerate() {
+                    note.focused = i == idx;
+                }
+                state.sticky_drag.start(me.column, me.row);
+                return true;
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if state.sticky_drag.active {
+                let (dx, dy) = state.sticky_drag.delta(me.column, me.row);
+                if let Some(idx) = state.sticky_focus {
+                    state.sticky_notes_data[idx].translate(dx, dy);
+                }
+                return true;
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            if state.sticky_drag.active {
+                state.sticky_drag.stop();
+                return true;
+            }
+        }
+        _ => {}
+    }
+    false
+}

--- a/src/modules/triage/mod.rs
+++ b/src/modules/triage/mod.rs
@@ -3,3 +3,4 @@ pub use crate::triage::*;
 
 pub mod feed;
 pub mod sticky;
+pub mod input;

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -182,5 +182,11 @@ pub fn render_grouped<B: Backend>(
         .block(Block::default().borders(Borders::NONE).style(block_style));
     f.render_widget(feed, body);
 
+    if state.sticky_overlay_visible {
+        for note in &state.sticky_notes_data {
+            note.render(f);
+        }
+    }
+
     render_full_border(f, area, &style, true, false);
 }

--- a/src/modules/triage/sticky.rs
+++ b/src/modules/triage/sticky.rs
@@ -1,5 +1,6 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use crate::ui::drag::DragState;
 
 /// Draggable sticky note widget used in the Triage panel.
 #[derive(Clone, Debug)]
@@ -64,6 +65,27 @@ impl StickyNote {
 
         let body = Paragraph::new(self.body.clone()).wrap(Wrap { trim: true });
         f.render_widget(body, Rect::new(area.x + 1, area.y + 2, area.width - 2, area.height - 3));
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct StickyPanel {
+    pub notes: Vec<StickyNote>,
+    pub visible: bool,
+    pub drag: DragState,
+    pub focus: Option<usize>,
+}
+
+impl StickyPanel {
+    pub fn note_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.notes.iter().position(|n| n.contains(x, y))
+    }
+
+    pub fn render<B: Backend>(&self, f: &mut Frame<B>) {
+        if !self.visible { return; }
+        for note in &self.notes {
+            note.render(f);
+        }
     }
 }
 

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -5,6 +5,8 @@ use crate::layout::{GEMX_HEADER_HEIGHT, LayoutRole};
 use crate::plugin::{loader, PluginHost};
 use crate::zen::image::JournalEntry;
 pub use crate::zen::state::*;
+use crate::modules::triage::sticky::StickyNote;
+use crate::ui::drag::DragState;
 
 use crate::hotkeys::load_hotkeys;
 use serde::{Serialize, Deserialize};
@@ -220,6 +222,10 @@ pub struct AppState {
     pub beam_shimmer: bool,
     pub zoom_grid: bool,
     pub sticky_notes: bool,
+    pub sticky_overlay_visible: bool,
+    pub sticky_notes_data: Vec<StickyNote>,
+    pub sticky_focus: Option<usize>,
+    pub sticky_drag: DragState,
     pub shortcut_overlay: ShortcutOverlayMode,
     pub heartbeat_mode: HeartbeatMode,
     pub triage_view_mode: crate::state::TriageViewMode,
@@ -367,6 +373,10 @@ impl Default for AppState {
             beam_shimmer: true,
             zoom_grid: false,
             sticky_notes: false,
+            sticky_overlay_visible: false,
+            sticky_notes_data: Vec::new(),
+            sticky_focus: None,
+            sticky_drag: DragState::default(),
             shortcut_overlay: ShortcutOverlayMode::Full,
             heartbeat_mode: HeartbeatMode::Pulse,
             triage_view_mode: crate::state::TriageViewMode::default(),

--- a/src/state/triage.rs
+++ b/src/state/triage.rs
@@ -102,4 +102,25 @@ impl AppState {
         self.triage_summary.triton = t;
         self.triage_summary.done = d;
     }
+
+    pub fn toggle_sticky_overlay(&mut self) {
+        self.sticky_overlay_visible = !self.sticky_overlay_visible;
+        if self.sticky_overlay_visible && self.sticky_notes_data.is_empty() {
+            self.sticky_notes_data.push(crate::modules::triage::sticky::StickyNote::new(
+                "Note",
+                "",
+                ratatui::style::Color::Yellow,
+                2,
+                2,
+            ));
+            self.sticky_focus = Some(0);
+            if let Some(n) = self.sticky_notes_data.get_mut(0) {
+                n.focused = true;
+            }
+        }
+    }
+
+    pub fn sticky_note_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.sticky_notes_data.iter().position(|n| n.contains(x, y))
+    }
 }

--- a/src/ui/shortcuts.rs
+++ b/src/ui/shortcuts.rs
@@ -14,7 +14,7 @@ pub fn action_group(action: &str) -> &'static str {
         "Global"
     } else if action.starts_with("zen_") || matches!(action, "save") {
         "Zen"
-    } else if action.contains("triage") {
+    } else if action.contains("triage") || action.contains("sticky_notes") {
         "Triage"
     } else if action.contains("plugin") {
         "Plugins"
@@ -43,6 +43,7 @@ pub fn shortcuts_for(module: &str) -> &'static [(&'static str, &'static str)] {
             ("Enter", "Edit Tag"),
             ("Ctrl+D", "Delete Entry"),
             ("Ctrl+T", "Toggle Priority"),
+            ("Ctrl+Shift+N", "Sticky Notes"),
         ],
         "GemX" => &[
             ("Ctrl+N", "New Node"),


### PR DESCRIPTION
## Summary
- hook up sticky notes module in triage
- add Ctrl+Shift+N hotkey for sticky notes overlay
- render sticky notes in Triage
- implement note input and dragging logic
- store sticky overlay state in AppState

## Testing
- `cargo check`
- `cargo test` *(fails: tests hang / network issues)*