### PR TITLE
patch-25.70i: restore triage navigation and feed ingestion

### DIFF
--- a/src/modules/triage/feed.rs
+++ b/src/modules/triage/feed.rs
@@ -4,6 +4,13 @@ use crate::triage::state::{TriageEntry, TriageSource};
 
 const TRIAGE_TAGS: &[&str] = &["#todo", "#triton", "#priority", "#now"];
 
+fn exists(state: &AppState, source: TriageSource, text: &str) -> bool {
+    state
+        .triage_entries
+        .iter()
+        .any(|e| e.source == source && e.text == text)
+}
+
 fn has_triage_tag(tags: &[String]) -> bool {
     tags.iter().any(|t| TRIAGE_TAGS.contains(&t.as_str()))
 }
@@ -13,10 +20,7 @@ pub fn capture_zen_entry(state: &mut AppState, entry: &ZenJournalEntry) {
     if !has_triage_tag(&entry.tags) {
         return;
     }
-    let exists = state.triage_entries.iter().any(|e| {
-        e.source == TriageSource::Zen && e.created == entry.timestamp && e.text == entry.text
-    });
-    if exists {
+    if exists(state, TriageSource::Zen, &entry.text) {
         return;
     }
     let mut triage_entry = TriageEntry::new(state.triage_entries.len(), &entry.text, TriageSource::Zen);
@@ -40,7 +44,7 @@ pub fn sync_from_plugins(state: &mut AppState) {
         if !TRIAGE_TAGS.iter().any(|t| text_lc.contains(t)) {
             continue;
         }
-        if state.triage_entries.iter().any(|e| e.source == TriageSource::Spotlight && e.text == task) {
+        if exists(state, TriageSource::Spotlight, &task) {
             continue;
         }
         let entry = TriageEntry::new(state.triage_entries.len(), &task, TriageSource::Spotlight);

--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -2,37 +2,51 @@ use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseB
 use crate::state::AppState;
 
 pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
-    if !state.sticky_overlay_visible { return false; }
-    if let Some(idx) = state.sticky_focus {
-        match code {
-            KeyCode::Char(c) if mods.is_empty() || mods == KeyModifiers::SHIFT => {
-                state.sticky_notes_data[idx].body.push(c);
-                return true;
+    if state.sticky_overlay_visible {
+        if let Some(idx) = state.sticky_focus {
+            match code {
+                KeyCode::Char(c) if mods.is_empty() || mods == KeyModifiers::SHIFT => {
+                    state.sticky_notes_data[idx].body.push(c);
+                    return true;
+                }
+                KeyCode::Backspace => {
+                    state.sticky_notes_data[idx].body.pop();
+                    return true;
+                }
+                KeyCode::Left if mods.contains(KeyModifiers::SHIFT) => {
+                    state.sticky_notes_data[idx].translate(-1, 0);
+                    return true;
+                }
+                KeyCode::Right if mods.contains(KeyModifiers::SHIFT) => {
+                    state.sticky_notes_data[idx].translate(1, 0);
+                    return true;
+                }
+                KeyCode::Up if mods.contains(KeyModifiers::SHIFT) => {
+                    state.sticky_notes_data[idx].translate(0, -1);
+                    return true;
+                }
+                KeyCode::Down if mods.contains(KeyModifiers::SHIFT) => {
+                    state.sticky_notes_data[idx].translate(0, 1);
+                    return true;
+                }
+                _ => {}
             }
-            KeyCode::Backspace => {
-                state.sticky_notes_data[idx].body.pop();
-                return true;
-            }
-            KeyCode::Left if mods.contains(KeyModifiers::SHIFT) => {
-                state.sticky_notes_data[idx].translate(-1, 0);
-                return true;
-            }
-            KeyCode::Right if mods.contains(KeyModifiers::SHIFT) => {
-                state.sticky_notes_data[idx].translate(1, 0);
-                return true;
-            }
-            KeyCode::Up if mods.contains(KeyModifiers::SHIFT) => {
-                state.sticky_notes_data[idx].translate(0, -1);
-                return true;
-            }
-            KeyCode::Down if mods.contains(KeyModifiers::SHIFT) => {
-                state.sticky_notes_data[idx].translate(0, 1);
-                return true;
-            }
-            _ => {}
         }
     }
-    false
+
+    match code {
+        KeyCode::Up if mods.is_empty() => {
+            state.triage_focus_prev();
+            state.triage_recalc_counts();
+            true
+        }
+        KeyCode::Down if mods.is_empty() => {
+            state.triage_focus_next();
+            state.triage_recalc_counts();
+            true
+        }
+        _ => false,
+    }
 }
 
 pub fn handle_mouse(state: &mut AppState, me: MouseEvent) -> bool {

--- a/src/modules/triage/mod.rs
+++ b/src/modules/triage/mod.rs
@@ -4,3 +4,5 @@ pub use crate::triage::*;
 pub mod feed;
 pub mod sticky;
 pub mod input;
+
+pub use feed::{capture_zen_entry, sync, sync_from_plugins, sync_from_zen};

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -139,7 +139,9 @@ pub fn render_grouped<B: Backend>(
             for (idx, entry) in entries {
                 let mut entry_style = Style::default();
                 if *idx == state.triage_focus_index {
-                    entry_style = entry_style.add_modifier(Modifier::BOLD);
+                    entry_style = entry_style
+                        .add_modifier(Modifier::BOLD)
+                        .bg(Color::DarkGray);
                 }
                 if entry.resolved {
                     entry_style = entry_style


### PR DESCRIPTION
## Summary
- re-export triage feed helpers
- highlight selected triage entry
- add arrow key navigation for triage entries
- avoid duplicate triage feed imports

## Testing
- `cargo fmt` *(fails: rustfmt component not installed)*
- `cargo test --quiet` *(hangs; aborted)*