### PR TITLE
Add mindmap beam lines and arrow correction

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -71,3 +71,13 @@ pub fn compute_depths(nodes: &NodeMap) -> HashMap<NodeID, usize> {
 pub fn spacing_for_zoom(zoom: f32) -> (i16, i16) {
     spacing_scale(zoom)
 }
+
+/// Calculate the horizontal center position of a node's label.
+pub fn center_x(nodes: &NodeMap, id: NodeID) -> i16 {
+    if let Some(n) = nodes.get(&id) {
+        let (w, _) = label_bounds(&n.label);
+        n.x + w / 2
+    } else {
+        0
+    }
+}

--- a/src/ui/lines.rs
+++ b/src/ui/lines.rs
@@ -32,3 +32,18 @@ pub fn draw_line<B: Backend>(f: &mut Frame<B>, start: (i16, i16), end: (i16, i16
         draw_line(f, (sx, ey), end);
     }
 }
+
+/// Draw a line and place an arrow glyph at the end position.
+pub fn draw_line_with_arrow<B: Backend>(
+    f: &mut Frame<B>,
+    start: (i16, i16),
+    end: (i16, i16),
+    arrow: &str,
+) {
+    draw_line(f, start, end);
+    let (ex, ey) = end;
+    if ex >= 0 && ey >= 0 {
+        let rect = Rect::new(ex as u16, ey as u16, 1, 1);
+        f.render_widget(Paragraph::new(arrow), rect);
+    }
+}


### PR DESCRIPTION
## Summary
- add `center_x` helper to layout engine
- add `draw_line_with_arrow` helper
- draw vertical beam lines and horizontal sibling lines in GemX debug view
- fix arrow direction for child and sibling connectors

## Testing
- `cargo check`
- `cargo test` *(fails to complete due to hanging tests)*