### PR TITLE
patch-25.70k: fix module switcher navigation

### DIFF
--- a/src/hotkeys/actions.rs
+++ b/src/hotkeys/actions.rs
@@ -30,7 +30,7 @@ pub fn redo(state: &mut AppState) {
 
 pub fn open_module_switcher(state: &mut AppState) {
     state.module_switcher_open = true;
-    state.module_switcher_index = 0;
+    state.module_switcher_index = crate::modules::switcher::index_for_mode(&state.mode);
 }
 
 pub fn start_drag(state: &mut AppState) {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,4 @@
 pub mod gemx;
 pub mod triage;
 pub mod zen;
+pub mod switcher;

--- a/src/modules/switcher.rs
+++ b/src/modules/switcher.rs
@@ -1,0 +1,29 @@
+pub const MODULES: [(&str, &str); 5] = [
+    ("\u{1F4AD}", "Mindmap"),    // 💭
+    ("\u{1F9D8}", "Zen"),        // 🧘
+    ("\u{1F3E5}", "Triage"),     // 🏥
+    ("\u{2699}\u{FE0F}", "Settings"), // ⚙️
+    ("\u{1F50C}", "Plugins"),    // 🔌
+];
+
+pub fn mode_for_index(index: usize) -> &'static str {
+    match index % MODULES.len() {
+        0 => "gemx",
+        1 => "zen",
+        2 => "triage",
+        3 => "settings",
+        4 => "plugin",
+        _ => "gemx",
+    }
+}
+
+pub fn index_for_mode(mode: &str) -> usize {
+    match mode {
+        "gemx" => 0,
+        "zen" => 1,
+        "triage" => 2,
+        "settings" => 3,
+        "plugin" => 4,
+        _ => 0,
+    }
+}

--- a/src/render/module_switcher.rs
+++ b/src/render/module_switcher.rs
@@ -6,15 +6,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
+use crate::modules::switcher;
 
 pub fn render_module_switcher<B: Backend>(f: &mut Frame<B>, area: Rect, index: usize) {
-    let modules = [
-        ("💭", "Mindmap"),
-        ("🧘", "Zen"),
-        ("🏥", "Triage"),
-        ("⚙️", "Settings"),
-        ("🔌", "Plugins"),
-    ];
+    let modules = switcher::MODULES;
 
     let lines: Vec<Line> = modules
         .iter()

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -407,13 +407,7 @@ impl AppState {
     }
 
     pub fn get_module_by_index(&self) -> &str {
-        match self.module_switcher_index % 4 {
-            0 => "gemx",
-            1 => "zen",
-            2 => "triage",
-            3 => "settings",
-            _ => "gemx",
-        }
+        crate::modules::switcher::mode_for_index(self.module_switcher_index)
     }
 
     pub fn favorite_entries(&self) -> Vec<FavoriteEntry> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -30,6 +30,7 @@ use crate::ui::components::plugin::render_plugin;
 use crate::ui::components::logs::render_logs;
 use crate::ui::input;
 use crate::modules::triage::input as triage_input;
+use crate::modules::switcher;
 
 use crate::hotkeys::match_hotkey;
 use crate::shortcuts::{match_shortcut, Shortcut};
@@ -337,9 +338,14 @@ pub fn launch_ui() -> std::io::Result<()> {
 
                 // 🧭 Module switcher
                 if state.module_switcher_open {
+                    let count = switcher::MODULES.len();
                     match code {
                         KeyCode::Tab => {
-                            state.module_switcher_index = (state.module_switcher_index + 1) % 4;
+                            state.module_switcher_index = (state.module_switcher_index + 1) % count;
+                            tracing::debug!("[INPUT] module switcher index {}", state.module_switcher_index);
+                        }
+                        KeyCode::BackTab => {
+                            state.module_switcher_index = (state.module_switcher_index + count - 1) % count;
                             tracing::debug!("[INPUT] module switcher index {}", state.module_switcher_index);
                         }
                         KeyCode::Enter => {
@@ -395,7 +401,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                     state.redo();
                 } else if match_hotkey("open_module_switcher", code, modifiers, &state) {
                     state.module_switcher_open = true;
-                    state.module_switcher_index = 0;
+                    state.module_switcher_index = switcher::index_for_mode(&state.mode);
                     tracing::info!("[INPUT] module switcher opened");
                 } else if match_hotkey("start_drag", code, modifiers, &state) {
                     if state.selected_drag_source.is_some() {

--- a/src/ui/components/module.rs
+++ b/src/ui/components/module.rs
@@ -10,19 +10,14 @@ use crate::state::AppState;
 use crate::ui::animate;
 use crate::config::theme::ThemeConfig;
 use crate::render::traits::{Renderable, RenderFrame};
+use crate::modules::switcher;
 
 pub fn render_module_switcher(
     f: &mut RenderFrame<'_>,
     area: Rect,
     state: &AppState,
 ) {
-    let modules = [
-        ("💭", "Mindmap"),
-        ("🧘", "Zen"),
-        ("🏥", "Triage"),
-        ("⚙️", "Settings"),
-        ("🔌", "Plugins"),
-    ];
+    let modules = switcher::MODULES;
 
     let count = modules.len();
     let index = state.module_switcher_index % count;

--- a/tests/module_switcher.rs
+++ b/tests/module_switcher.rs
@@ -11,4 +11,6 @@ fn module_switcher_displays_correct_labels() {
     assert_eq!(state.get_module_by_index(), "triage");
     state.module_switcher_index = 3;
     assert_eq!(state.get_module_by_index(), "settings");
+    state.module_switcher_index = 4;
+    assert_eq!(state.get_module_by_index(), "plugin");
 }


### PR DESCRIPTION
## Summary
- centralize module list in new `modules::switcher`
- open switcher highlighting current module
- support Tab and Shift+Tab navigation
- expose plugin module in helper
- update tests

## Testing
- `cargo test module_switcher_displays_correct_labels -- --nocapture`