### PR TITLE
Implement Zen entry deletion

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -32,11 +32,18 @@ pub fn handle_log_keys(state: &mut AppState, code: KeyCode, mods: KeyModifiers) 
 }
 
 /// Route keystrokes while in Zen mode to the editor handler.
-pub fn route_zen_keys(state: &mut AppState, code: KeyCode, _mods: KeyModifiers) -> bool {
+pub fn route_zen_keys(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
     if state.mode == "zen"
         && state.zen_layout_mode == ZenLayoutMode::Compose
         && state.zen_view_mode == ZenViewMode::Write
     {
+        if code == KeyCode::Char('d') && mods.contains(KeyModifiers::CONTROL) {
+            if let Some(idx) = state.zen_history_index.take() {
+                state.delete_journal_entry(idx);
+            }
+            return true;
+        }
+
         crate::zen::editor::handle_key(state, code);
         return true;
     }

--- a/src/zen/state.rs
+++ b/src/zen/state.rs
@@ -222,6 +222,31 @@ impl AppState {
         }
     }
 
+    /// Delete the specified journal entry.
+    pub fn delete_journal_entry(&mut self, index: usize) {
+        if index >= self.zen_journal_entries.len() {
+            return;
+        }
+        self.zen_journal_entries.remove(index);
+
+        if let Some(edit) = self.zen_draft.editing {
+            if edit == index {
+                self.zen_draft.editing = None;
+                self.zen_draft.text.clear();
+            } else if edit > index {
+                self.zen_draft.editing = Some(edit - 1);
+            }
+        }
+
+        if let Some(hist) = self.zen_history_index {
+            if hist == index {
+                self.zen_history_index = None;
+            } else if hist > index {
+                self.zen_history_index = Some(hist - 1);
+            }
+        }
+    }
+
     pub fn set_tag_filter(&mut self, tag: Option<&str>) {
         self.zen_tag_filter = tag.map(|t| t.to_string());
     }


### PR DESCRIPTION
## Summary
- add delete_journal_entry to Zen state
- allow Ctrl+D in compose mode to delete highlighted journal entry

## Testing
- `cargo check -q`
- `cargo test --workspace --quiet`
