### PR TITLE
Implement triage entry grouping

### DIFF
--- a/src/modules/triage/mod.rs
+++ b/src/modules/triage/mod.rs
@@ -1,5 +1,6 @@
 pub mod render;
 pub use crate::triage::*;
+pub use render::render_grouped;
 
 pub mod feed;
 pub mod sticky;

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -82,11 +82,13 @@ pub fn progress_bar(now: usize, triton: usize, done: usize) -> String {
 
 /// Render triage entries grouped by primary tags (#now, #triton, #done).
 /// When `show_icons` is true, tag headers include emoji icons.
+
 pub fn render_grouped<B: Backend>(
     f: &mut Frame<B>,
     area: Rect,
     state: &mut AppState,
     show_icons: bool,
+    collapsed: Option<&HashSet<&str>>,
 ) {
     let style = state.beam_style_for_mode("triage");
     let block_style = Style::default().fg(style.border_color);
@@ -124,17 +126,23 @@ pub fn render_grouped<B: Backend>(
             if entries.is_empty() {
                 continue;
             }
-            let header = match *tag {
-                "#now" => if show_icons { "🔥 NOW" } else { "#NOW" },
-                "#triton" => if show_icons { "🧠 TRITON" } else { "#TRITON" },
-                "#done" => if show_icons { "✅ DONE" } else { "#DONE" },
-                _ => "OTHER",
-            };
-            lines.push(Line::from(Span::styled(
-                header,
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
-            )));
+            let collapsed = collapsed
+                .map(|c| c.contains(tag))
+                .unwrap_or(false);
+           let header = match *tag {
+               "#now" => if show_icons { "🔥 NOW" } else { "#NOW" },
+               "#triton" => if show_icons { "🧠 TRITON" } else { "#TRITON" },
+               "#done" => if show_icons { "✅ DONE" } else { "#DONE" },
+               _ => "OTHER",
+           };
+           lines.push(Line::from(Span::styled(
+               header,
+               Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+           )));
             lines.push(Line::from(""));
+            if collapsed {
+                continue;
+            }
 
             for (idx, entry) in entries {
                 let mut entry_style = Style::default();


### PR DESCRIPTION
## Summary
- add grouping render with optional collapsed tags in triage module
- re-export `render_grouped`

## Testing
- `cargo check -q`
- `cargo test --quiet --lib`
