### PR TITLE
patch-25.70n: Match layout between Spotlight and Module Switcher

### DIFF
--- a/src/modules/switcher.rs
+++ b/src/modules/switcher.rs
@@ -1,3 +1,7 @@
+use crate::theme::layout::OVERLAY_WIDTH;
+
+pub const SWITCHER_WIDTH: u16 = OVERLAY_WIDTH;
+
 pub const MODULES: [(&str, &str); 5] = [
     ("\u{1F4AD}", "Mindmap"),    // 💭
     ("\u{1F9D8}", "Zen"),        // 🧘

--- a/src/theme/layout.rs
+++ b/src/theme/layout.rs
@@ -4,14 +4,25 @@ pub fn spacing_scale(zoom: f32) -> (i16, i16) {
     (x, y)
 }
 
+/// Standard width for small overlay panels like Spotlight and the module
+/// switcher.
+pub const OVERLAY_WIDTH: u16 = 60;
+
+/// Determine the width of an overlay panel based on the available area. The
+/// width never exceeds [`OVERLAY_WIDTH`].
+pub fn overlay_width(area_width: u16) -> u16 {
+    area_width.min(OVERLAY_WIDTH)
+}
+
 /// Fixed width for the Spotlight overlay in columns.
-pub const SPOTLIGHT_WIDTH: u16 = 60;
+///
+/// This constant is an alias for [`OVERLAY_WIDTH`] and retained for backwards
+/// compatibility with existing callers.
+pub const SPOTLIGHT_WIDTH: u16 = OVERLAY_WIDTH;
 
 /// Determine the width of Spotlight based on the available area.
-///
-/// The width never exceeds [`SPOTLIGHT_WIDTH`] and is independent of user input
-/// length so the panel remains stable as commands are typed.
+/// This simply forwards to [`overlay_width`].
 pub fn spotlight_width(area_width: u16) -> u16 {
-    area_width.min(SPOTLIGHT_WIDTH)
+    overlay_width(area_width)
 }
 

--- a/src/ui/components/module.rs
+++ b/src/ui/components/module.rs
@@ -6,6 +6,8 @@ use ratatui::{
 };
 use crate::ui::layout::Rect;
 
+use crate::theme::layout::overlay_width;
+
 use crate::state::AppState;
 use crate::ui::animate;
 use crate::config::theme::ThemeConfig;
@@ -62,14 +64,9 @@ pub fn render_module_switcher(
         })
         .collect();
 
-    let content_width = lines
-        .iter()
-        .map(|l| l.width() as u16)
-        .max()
-        .unwrap_or(0)
-        .saturating_add(4);
-
-    let base_width = content_width.min(area.width);
+    // Use a fixed width shared with Spotlight so the panel does not resize based
+    // on its content.
+    let base_width = overlay_width(area.width);
     let mut height = lines.len() as u16 + 2;
     height = height.min(area.height.saturating_sub(1));
 


### PR DESCRIPTION
## Summary
- share overlay width constant for Spotlight and Module Switcher
- keep Spotlight width stable via helper function
- resize Module Switcher using shared width
- expose `SWITCHER_WIDTH` constant

## Testing
- `cargo check --quiet`
- `cargo test --quiet -- --test-threads=1` *(fails: took too long / aborted)*