### PR TITLE
patch-25.71g: scope sticky note shortcut

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -1,0 +1,26 @@
+use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseButton};
+use crate::state::AppState;
+
+/// Handle GemX (mindmap) specific keyboard shortcuts.
+pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
+    match code {
+        // Create a free node with Ctrl+N only (no Shift)
+        KeyCode::Char('n') if mods == KeyModifiers::CONTROL => {
+            state.push_undo();
+            crate::gemx::interaction::spawn_free_node(state);
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Handle GemX mouse interactions. Currently unused.
+pub fn handle_mouse(_state: &mut AppState, _me: MouseEvent) -> bool {
+    match _me.kind {
+        MouseEventKind::Down(MouseButton::Left)
+        | MouseEventKind::Drag(MouseButton::Left)
+        | MouseEventKind::Up(MouseButton::Left) => {}
+        _ => {}
+    }
+    false
+}

--- a/src/modules/gemx/mod.rs
+++ b/src/modules/gemx/mod.rs
@@ -1,2 +1,3 @@
 pub mod logic;
 pub mod render;
+pub mod input;

--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -2,6 +2,15 @@ use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseB
 use crate::state::AppState;
 
 pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
+    // Toggle sticky notes panel with Ctrl+Shift+N only while in Triage
+    if code == KeyCode::Char('n')
+        && mods.contains(KeyModifiers::CONTROL)
+        && mods.contains(KeyModifiers::SHIFT)
+    {
+        state.toggle_sticky_overlay();
+        return true;
+    }
+
     if state.sticky_overlay_visible {
         if let Some(idx) = state.sticky_focus {
             match code {

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -235,6 +235,13 @@ pub struct AppState {
     pub show_plugin_preview: bool,
 }
 
+impl AppState {
+    /// Helper to check if the application is currently in the Triage module.
+    pub fn is_triage_mode(&self) -> bool {
+        self.mode == "triage"
+    }
+}
+
 pub fn default_beamx_panel_visible() -> bool {
     #[cfg(target_os = "macos")]
     {


### PR DESCRIPTION
## Summary
- add GemX input helper with explicit Ctrl+N handling
- toggle sticky notes from triage input
- add mode helper on `AppState`

## Testing
- `cargo test` *(fails: tests hang >60s)*