### PR TITLE
Implement smart node insertion shortcuts

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -10,6 +10,24 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
             crate::gemx::interaction::spawn_free_node(state);
             true
         }
+        // Insert sibling on Enter
+        KeyCode::Enter if mods.is_empty() => {
+            state.push_undo();
+            state.handle_enter_key();
+            true
+        }
+        // Insert child on Tab
+        KeyCode::Tab if mods.is_empty() => {
+            state.push_undo();
+            state.handle_tab_key();
+            true
+        }
+        // Promote or free on Shift+Tab
+        KeyCode::BackTab if mods.is_empty() => {
+            state.push_undo();
+            state.handle_shift_tab_key();
+            true
+        }
         _ => false,
     }
 }

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -110,6 +110,8 @@ pub struct AppState {
     pub zen_buffer: Vec<String>,
     pub nodes: NodeMap,
     pub root_nodes: Vec<NodeID>,
+    /// ID to assign to the next created node for fast insertion
+    pub next_node_id: NodeID,
     pub last_promoted_root: Option<NodeID>,
     pub selected: Option<NodeID>,
     pub selection_trail: VecDeque<(NodeID, Instant)>,
@@ -268,6 +270,7 @@ impl Default for AppState {
             zen_buffer: vec![String::from(" ")],
             nodes,
             root_nodes: vec![node_a, node_b],
+            next_node_id: 3,
             last_promoted_root: None,
             selected: Some(node_a),
             selection_trail: VecDeque::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -28,4 +28,9 @@ impl AppState {
     pub fn handle_tab_key(&mut self) {
         self.add_child_node();
     }
+
+    /// Handle Shift+Tab by promoting the current node one level up.
+    pub fn handle_shift_tab_key(&mut self) {
+        self.promote_selected_node();
+    }
 }

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -43,6 +43,44 @@ impl AppState {
         }
     }
 
+    /// Move focus to the previous sibling if available.
+    pub fn focus_prev_sibling(&mut self) {
+        if let Some(current) = self.selected {
+            if let Some(parent_id) = self.nodes.get(&current).and_then(|n| n.parent) {
+                if let Some(parent) = self.nodes.get(&parent_id) {
+                    if let Some(pos) = parent.children.iter().position(|&c| c == current) {
+                        if pos > 0 {
+                            self.set_selected(Some(parent.children[pos - 1]));
+                        }
+                    }
+                }
+            } else if let Some(pos) = self.root_nodes.iter().position(|&r| r == current) {
+                if pos > 0 {
+                    self.set_selected(Some(self.root_nodes[pos - 1]));
+                }
+            }
+        }
+    }
+
+    /// Move focus to the next sibling if available.
+    pub fn focus_next_sibling(&mut self) {
+        if let Some(current) = self.selected {
+            if let Some(parent_id) = self.nodes.get(&current).and_then(|n| n.parent) {
+                if let Some(parent) = self.nodes.get(&parent_id) {
+                    if let Some(pos) = parent.children.iter().position(|&c| c == current) {
+                        if pos + 1 < parent.children.len() {
+                            self.set_selected(Some(parent.children[pos + 1]));
+                        }
+                    }
+                }
+            } else if let Some(pos) = self.root_nodes.iter().position(|&r| r == current) {
+                if pos + 1 < self.root_nodes.len() {
+                    self.set_selected(Some(self.root_nodes[pos + 1]));
+                }
+            }
+        }
+    }
+
     pub fn drill_down(&mut self) {
         if let Some(current) = self.get_selected_node() {
             if !current.children.is_empty() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -624,10 +624,10 @@ pub fn launch_ui() -> std::io::Result<()> {
 
                     KeyCode::Up if state.mode == "gemx" => state.move_focus_up(),
                     KeyCode::Down if state.mode == "gemx" => state.move_focus_down(),
-                    KeyCode::Left if state.mode == "gemx" => state.move_focus_left(),
-                    KeyCode::Right if state.mode == "gemx" => state.move_focus_right(),
-                    KeyCode::Tab if state.mode == "gemx" => state.move_focus_right(),
-                    KeyCode::BackTab if state.mode == "gemx" => state.move_focus_left(),
+                    KeyCode::Left if state.mode == "gemx" => state.focus_prev_sibling(),
+                    KeyCode::Right if state.mode == "gemx" => state.focus_next_sibling(),
+                    KeyCode::Tab if state.mode == "gemx" => state.focus_next_sibling(),
+                    KeyCode::BackTab if state.mode == "gemx" => state.handle_shift_tab_key(),
 
                     KeyCode::Char(c) if state.mode == "gemx" => {
                         let allowed = modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT;


### PR DESCRIPTION
## Summary
- add smart key handling for GemX node insertion
- support sibling/child insert and promotion on Shift+Tab
- navigate between siblings with arrow keys
- track next node ID for quick inserts

## Testing
- `cargo check`
- `cargo test` *(fails: hanging tests; interrupted after >60s)*