### PR TITLE
Implement smart navigation and reparent actions

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -1,4 +1,5 @@
 use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseButton};
+use std::time::Instant;
 use crate::state::AppState;
 
 /// Handle GemX (mindmap) specific keyboard shortcuts.
@@ -26,6 +27,50 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
         KeyCode::BackTab if mods.is_empty() => {
             state.push_undo();
             state.handle_shift_tab_key();
+            true
+        }
+        // Alt+Left: previous sibling
+        KeyCode::Left if mods == KeyModifiers::ALT => {
+            state.focus_prev_sibling();
+            true
+        }
+        // Alt+Right: next sibling
+        KeyCode::Right if mods == KeyModifiers::ALT => {
+            state.focus_next_sibling();
+            true
+        }
+        // Alt+Up: move to parent
+        KeyCode::Up if mods == KeyModifiers::ALT => {
+            state.move_focus_left();
+            true
+        }
+        // Alt+Down: move to first child
+        KeyCode::Down if mods == KeyModifiers::ALT => {
+            state.move_focus_right();
+            true
+        }
+        // Ctrl+Shift+Up: promote selected node
+        KeyCode::Up if mods.contains(KeyModifiers::CONTROL) && mods.contains(KeyModifiers::SHIFT) => {
+            if let Some(id) = state.selected {
+                state.push_undo();
+                crate::modules::gemx::logic::promote(&mut state.nodes, &mut state.root_nodes, id);
+                state.selection_trail.push_back((id, Instant::now()));
+                if state.selection_trail.len() > 8 { state.selection_trail.pop_front(); }
+                state.status_message = "Node promoted".into();
+                state.status_message_last_updated = Some(Instant::now());
+            }
+            true
+        }
+        // Ctrl+Shift+Down: demote selected node under previous sibling
+        KeyCode::Down if mods.contains(KeyModifiers::CONTROL) && mods.contains(KeyModifiers::SHIFT) => {
+            if let Some(id) = state.selected {
+                state.push_undo();
+                crate::modules::gemx::logic::demote_prev_sibling(&mut state.nodes, &mut state.root_nodes, id);
+                state.selection_trail.push_back((id, Instant::now()));
+                if state.selection_trail.len() > 8 { state.selection_trail.pop_front(); }
+                state.status_message = "Node demoted".into();
+                state.status_message_last_updated = Some(Instant::now());
+            }
             true
         }
         _ => false,

--- a/src/modules/gemx/logic.rs
+++ b/src/modules/gemx/logic.rs
@@ -39,3 +39,29 @@ pub fn adopt_orphans(nodes: &mut NodeMap, roots: &mut Vec<NodeID>) {
     roots.sort_unstable();
     roots.dedup();
 }
+
+/// Promote `node_id` one level up in the hierarchy.
+pub fn promote(nodes: &mut NodeMap, roots: &mut Vec<NodeID>, node_id: NodeID) {
+    if let Some(parent_id) = nodes.get(&node_id).and_then(|n| n.parent) {
+        let grand = nodes.get(&parent_id).and_then(|p| p.parent);
+        reparent(nodes, roots, node_id, grand);
+    }
+}
+
+/// Demote `node_id` under its previous sibling if possible.
+pub fn demote_prev_sibling(
+    nodes: &mut NodeMap,
+    roots: &mut Vec<NodeID>,
+    node_id: NodeID,
+) {
+    if let Some(parent_id) = nodes.get(&node_id).and_then(|n| n.parent) {
+        if let Some(parent) = nodes.get(&parent_id) {
+            if let Some(pos) = parent.children.iter().position(|&c| c == node_id) {
+                if pos > 0 {
+                    let prev = parent.children[pos - 1];
+                    reparent(nodes, roots, node_id, Some(prev));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add functions for promoting/demoting nodes in GemX logic
- support Alt-based sibling/parent/child navigation in GemX input
- allow Ctrl+Shift+Arrow reparent actions with visual feedback

## Testing
- `cargo test --quiet`