### PR TITLE
Implement dynamic spacing clamp for GemX mindmap

### DIFF
--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -20,3 +20,20 @@ pub fn clamp_zoom_scroll(state: &mut AppState) {
     state.scroll_target_x = state.scroll_target_x.clamp(0, limit);
     state.scroll_target_y = state.scroll_target_y.clamp(0, limit);
 }
+
+/// Determine dynamic child spacing based on total depth.
+pub fn clamp_child_spacing(state: &AppState, roots: &[NodeID], max_h: i16) -> i16 {
+    use crate::layout::{CHILD_SPACING_Y, MIN_CHILD_SPACING_Y, subtree_depth};
+
+    let mut depth = 1i16;
+    for r in roots {
+        depth = depth.max(subtree_depth(&state.nodes, *r));
+    }
+    let required = depth * CHILD_SPACING_Y;
+    if max_h > 0 && required > max_h {
+        let ratio = max_h as f32 / required as f32;
+        ((CHILD_SPACING_Y as f32 * ratio).floor() as i16).max(MIN_CHILD_SPACING_Y)
+    } else {
+        CHILD_SPACING_Y
+    }
+}

--- a/src/modules/gemx/mod.rs
+++ b/src/modules/gemx/mod.rs
@@ -1,3 +1,5 @@
 pub mod logic;
 pub mod render;
 pub mod input;
+pub mod layout;
+pub mod viewport;

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -1,8 +1,8 @@
 use ratatui::{prelude::*, widgets::Paragraph};
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
-use crate::layout::{CHILD_SPACING_Y};
-use crate::layout::engine::{layout_vertical, center_x};
+use crate::layout::engine::{center_x, layout_vertical};
+use super::layout::clamp_child_spacing;
 use crate::ui::lines::{
     draw_vertical_fade,
     draw_horizontal_shimmer,
@@ -22,8 +22,9 @@ pub fn render<B: Backend>(
     state: &AppState,
     debug: bool,
 ) {
+    let spacing_y = clamp_child_spacing(state, roots, area.height as i16);
     for &root in roots {
-        layout_vertical(nodes, root);
+        layout_vertical(nodes, root, spacing_y);
     }
 
     let tick = (std::time::SystemTime::now()
@@ -55,7 +56,7 @@ pub fn render<B: Backend>(
             }
 
             let px = center_x(nodes, node.id);
-            let beam_y = node.y + (CHILD_SPACING_Y - 1).max(1);
+            let beam_y = node.y + (spacing_y - 1).max(1);
 
             // vertical beam from parent to sibling bar
             draw_vertical_fade(


### PR DESCRIPTION
## Summary
- compute variable child spacing based on tree depth
- expose `viewport` and `layout` modules in `modules::gemx`
- prevent node overlap and space sibling chains
- use spacing clamp when laying out and rendering GemX mindmaps

## Testing
- `cargo test`