### PR TITLE
Implement grid padding for low zoom

### DIFF
--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -16,10 +16,16 @@ pub fn follow_focus_node(state: &mut AppState) {
 /// Clamp scroll offsets relative to zoom level to avoid jumpiness.
 pub fn clamp_zoom_scroll(state: &mut AppState) {
     let limit = (1000.0 * state.zoom_scale) as i16;
-    state.scroll_x = state.scroll_x.clamp(0, limit);
-    state.scroll_y = state.scroll_y.clamp(0, limit);
-    state.scroll_target_x = state.scroll_target_x.clamp(0, limit);
-    state.scroll_target_y = state.scroll_target_y.clamp(0, limit);
+
+    // Give the user some buffer space when fully zoomed out so nodes aren't
+    // forced against the viewport edges. Padding increases as zoom decreases.
+    let pad_right = if state.zoom_scale <= 0.5 { 40 } else { 20 };
+    let pad_vert = if state.zoom_scale <= 0.5 { 20 } else { 10 };
+
+    state.scroll_x = state.scroll_x.clamp(0, limit + pad_right);
+    state.scroll_y = state.scroll_y.clamp(0, limit + pad_vert);
+    state.scroll_target_x = state.scroll_target_x.clamp(0, limit + pad_right);
+    state.scroll_target_y = state.scroll_target_y.clamp(0, limit + pad_vert);
 }
 
 /// Determine dynamic child spacing based on total depth.

--- a/src/modules/gemx/viewport.rs
+++ b/src/modules/gemx/viewport.rs
@@ -8,10 +8,22 @@ pub fn node_visible(state: &AppState, node_id: NodeID) -> bool {
     let (tw, th) = terminal::size().unwrap_or((80, 20));
     let zoom = state.zoom_scale as f32;
     let (sx, sy) = spacing_for_zoom(state.zoom_scale);
+
+    // When zoomed out it's easy for nodes to hug the terminal edges. Apply a
+    // small visibility margin so centering leaves room on the right and bottom
+    // of the screen. The top margin keeps the focused node from touching the
+    // header.
+    let right_pad = if zoom <= 0.5 { 4.0 } else { 2.0 };
+    let bottom_pad = if zoom <= 0.5 { 2.0 } else { 1.0 };
+    let top_pad = if zoom <= 0.5 { 1.0 } else { 0.0 };
+
     if let Some(node) = state.nodes.get(&node_id) {
         let dx = ((node.x - state.scroll_x) as f32 * sx as f32 * zoom).round();
         let dy = ((node.y - state.scroll_y) as f32 * sy as f32 * zoom).round();
-        return dx >= 0.0 && dx < tw as f32 && dy >= 0.0 && dy < th as f32;
+        return dx >= 0.0
+            && dx < tw as f32 - right_pad
+            && dy >= top_pad
+            && dy < th as f32 - bottom_pad;
     }
     false
 }


### PR DESCRIPTION
## Summary
- keep right/top/bottom margins when checking node visibility
- clamp scroll with dynamic padding based on zoom level

## Testing
- `cargo test`