### PR TITLE
Implement auto-numbered node labels

### DIFF
--- a/src/gemx/interaction.rs
+++ b/src/gemx/interaction.rs
@@ -24,7 +24,8 @@ pub fn spawn_free_node(state: &mut AppState) {
         .unwrap_or(100)
         + 1;
 
-    let mut node = Node::new(new_id, "Free Node", None);
+    let label = state.next_label();
+    let mut node = Node::new(new_id, &label, None);
 
     if !state.auto_arrange {
         use std::collections::HashSet;

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -110,7 +110,7 @@ pub fn render<B: Backend>(
                 if let Some(child) = nodes.get(cid) {
                     let start = (cx, beam_y);
                     let end = (cx, scale_y(child.y));
-                    let is_ghost = child.label == "New Child" || child.label == "New Sibling";
+                    let is_ghost = child.label.starts_with("node ");
                     if is_ghost {
                         draw_ghost_line(f, start, end, tick, p_color);
                     } else {
@@ -158,12 +158,8 @@ pub fn render<B: Backend>(
             let rect = Rect::new(x as u16, y as u16, width, 1);
             f.render_widget(Paragraph::new(display.clone()), rect);
 
-            if node.label == "New Child" || node.label == "New Sibling" {
-                let kind = if node.label == "New Child" {
-                    InsertCursorKind::Child
-                } else {
-                    InsertCursorKind::Sibling
-                };
+            if node.label.starts_with("node ") {
+                let kind = InsertCursorKind::Sibling;
                 let cx = rect.x + rect.width;
                 let cy = rect.y;
                 render_insert_cursor(f, (cx, cy), tick, kind, &cursor_style);

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -112,6 +112,8 @@ pub struct AppState {
     pub root_nodes: Vec<NodeID>,
     /// ID to assign to the next created node for fast insertion
     pub next_node_id: NodeID,
+    /// Sequence number for auto-generated node labels
+    pub next_node_label: u32,
     pub last_promoted_root: Option<NodeID>,
     pub selected: Option<NodeID>,
     pub selection_trail: VecDeque<(NodeID, Instant)>,
@@ -273,6 +275,7 @@ impl Default for AppState {
             nodes,
             root_nodes: vec![node_a, node_b],
             next_node_id: 3,
+            next_node_label: 1,
             last_promoted_root: None,
             selected: Some(node_a),
             selection_trail: VecDeque::new(),

--- a/src/state/edit.rs
+++ b/src/state/edit.rs
@@ -27,7 +27,8 @@ impl AppState {
             }
         }
 
-        let mut child = Node::new(new_id, "New Child", Some(parent_id));
+        let label = self.next_label();
+        let mut child = Node::new(new_id, &label, Some(parent_id));
         if self.auto_arrange {
             if let Some(parent) = self.nodes.get(&parent_id) {
                 child.x = parent.x;
@@ -79,7 +80,8 @@ impl AppState {
 
         let new_id = self.next_node_id;
         self.next_node_id += 1;
-        let mut sibling = Node::new(new_id, "New Sibling", parent_id);
+        let label = self.next_label();
+        let mut sibling = Node::new(new_id, &label, parent_id);
 
         if let Some(selected) = self.nodes.get(&selected_id) {
             sibling.x = selected.x + SIBLING_SPACING_X;
@@ -147,7 +149,8 @@ impl AppState {
     pub fn add_free_node(&mut self) {
         let new_id = self.next_node_id;
         self.next_node_id += 1;
-        let mut node = Node::new(new_id, "Free Node", None);
+        let label = self.next_label();
+        let mut node = Node::new(new_id, &label, None);
 
         if !self.auto_arrange {
             node.x = (self.nodes.len() as i16 % 5) * SIBLING_SPACING_X;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -33,4 +33,11 @@ impl AppState {
     pub fn handle_shift_tab_key(&mut self) {
         self.promote_selected_node();
     }
+
+    /// Generate the next automatic node label.
+    pub fn next_label(&mut self) -> String {
+        let label = format!("node {:03}", self.next_node_label);
+        self.next_node_label += 1;
+        label
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -633,8 +633,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                         let allowed = modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT;
                         if allowed && (c.is_ascii_graphic() || c == ' ') {
                             if let Some(node) = state.get_selected_node_mut() {
-                                if node.label == "New Child"
-                                    || node.label == "New Sibling"
+                                if node.label.starts_with("node ")
                                     || node.label == "Node A"
                                     || node.label == "Node B"
                                 {


### PR DESCRIPTION
## Summary
- give `AppState` a `next_node_label` counter
- generate numeric labels when adding nodes
- clear numeric labels on first character typed
- treat numeric labels as placeholders when rendering

## Testing
- `cargo test --quiet`