### PR TITLE
Add debug setting for blank node handling

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -16,14 +16,24 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
         }
         // Insert sibling on Enter
         KeyCode::Enter if mods.is_empty() => {
-            state.push_undo();
-            state.handle_enter_key();
+            if state.can_insert_node() {
+                state.push_undo();
+                state.handle_enter_key();
+            } else {
+                state.status_message = "Cannot insert: empty node".into();
+                state.status_message_last_updated = Some(Instant::now());
+            }
             true
         }
         // Insert child on Tab
         KeyCode::Tab if mods.is_empty() => {
-            state.push_undo();
-            state.handle_tab_key();
+            if state.can_insert_node() {
+                state.push_undo();
+                state.handle_tab_key();
+            } else {
+                state.status_message = "Cannot insert: empty node".into();
+                state.status_message_last_updated = Some(Instant::now());
+            }
             true
         }
         // Promote or free on Shift+Tab

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -9,6 +9,7 @@ use std::fs;
 pub struct UserSettings {
     pub auto_arrange: bool,
     pub debug_input_mode: bool,
+    pub debug_allow_empty_nodes: bool,
     pub dock_layout: String,
     pub gemx_beam_color: BeamColor,
     pub zen_beam_color: BeamColor,
@@ -35,6 +36,7 @@ impl Default for UserSettings {
         Self {
             auto_arrange: true,
             debug_input_mode: true,
+            debug_allow_empty_nodes: false,
             dock_layout: "vertical".into(),
             gemx_beam_color: BeamColor::Prism,
             zen_beam_color: BeamColor::Prism,
@@ -72,6 +74,7 @@ pub fn save_user_settings(state: &AppState) {
     let config = UserSettings {
         auto_arrange: state.auto_arrange,
         debug_input_mode: state.debug_input_mode,
+        debug_allow_empty_nodes: state.debug_allow_empty_nodes,
         dock_layout: format!("{:?}", state.favorite_dock_layout).to_lowercase(),
         gemx_beam_color: state.gemx_beam_color,
         zen_beam_color: state.zen_beam_color,

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -64,6 +64,12 @@ impl SettingCategory {
 fn is_debug_mode(s: &AppState) -> bool { s.debug_input_mode }
 fn toggle_debug_mode(s: &mut AppState) { s.debug_input_mode = !s.debug_input_mode; save_user_settings(s); }
 
+fn is_allow_empty_nodes(s: &AppState) -> bool { s.debug_allow_empty_nodes }
+fn toggle_allow_empty_nodes(s: &mut AppState) {
+    s.debug_allow_empty_nodes = !s.debug_allow_empty_nodes;
+    save_user_settings(s);
+}
+
 fn is_auto_arrange(s: &AppState) -> bool { s.auto_arrange }
 fn toggle_auto_arrange(s: &mut AppState) { s.auto_arrange = !s.auto_arrange; save_user_settings(s); }
 
@@ -131,6 +137,7 @@ pub static SETTING_TOGGLES: &[SettingToggle] = &[
     SettingToggle { icon: "✨", label: "Mindmap Lanes", is_enabled: is_mindmap_lanes, toggle: toggle_mindmap_lanes, category: SettingCategory::Modules },
     SettingToggle { icon: "🧠", label: "Hierarchy Icons", is_enabled: is_hierarchy_icons, toggle: toggle_hierarchy_icons, category: SettingCategory::Modules },
     SettingToggle { icon: "🐞", label: "Debug Input Mode", is_enabled: is_debug_mode, toggle: toggle_debug_mode, category: SettingCategory::UX },
+    SettingToggle { icon: "⚠", label: "Allow Empty Nodes", is_enabled: is_allow_empty_nodes, toggle: toggle_allow_empty_nodes, category: SettingCategory::UX },
     SettingToggle { icon: "❤️", label: "Heartbeat", is_enabled: heartbeat_active, toggle: toggle_heartbeat, category: SettingCategory::UX },
 ];
 

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -170,6 +170,7 @@ pub struct AppState {
     pub layout_fail_count: u8,
     pub layout_key: (usize, u64),
     pub debug_input_mode: bool,
+    pub debug_allow_empty_nodes: bool,
     pub debug_border: bool,
     pub debug_overlay: bool,
     pub debug_overlay_sticky: bool,
@@ -332,6 +333,7 @@ impl Default for AppState {
             layout_fail_count: 0,
             layout_key: (0, 0),
             debug_input_mode: true,
+            debug_allow_empty_nodes: false,
             debug_border: std::env::var("PRISMX_DEBUG_BORDER").is_ok(),
             debug_overlay: false,
             debug_overlay_sticky: false,
@@ -406,6 +408,7 @@ impl Default for AppState {
         let config = crate::settings::load_user_settings();
         state.auto_arrange = config.auto_arrange;
         state.debug_input_mode = config.debug_input_mode;
+        state.debug_allow_empty_nodes = config.debug_allow_empty_nodes;
         state.favorite_dock_layout = match config.dock_layout.as_str() {
             "horizontal" => DockLayout::Horizontal,
             _ => DockLayout::Vertical,

--- a/src/state/edit.rs
+++ b/src/state/edit.rs
@@ -8,6 +8,11 @@ impl AppState {
 
     pub fn add_child_node(&mut self) {
         let Some(parent_id) = self.selected else { return };
+        if !self.can_insert_node() {
+            self.status_message = "Cannot insert: empty node".into();
+            self.status_message_last_updated = Some(std::time::Instant::now());
+            return;
+        }
         if !self.nodes.contains_key(&parent_id) {
             return;
         }
@@ -76,6 +81,11 @@ impl AppState {
             Some(id) if self.nodes.contains_key(&id) => id,
             _ => return,
         };
+        if !self.can_insert_node() {
+            self.status_message = "Cannot insert: empty node".into();
+            self.status_message_last_updated = Some(std::time::Instant::now());
+            return;
+        }
         let parent_id = self.nodes.get(&selected_id).and_then(|n| n.parent);
 
         let new_id = self.next_node_id;

--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -14,6 +14,22 @@ impl AppState {
         self.selected.and_then(|id| self.nodes.get_mut(&id))
     }
 
+    pub fn can_insert_node(&self) -> bool {
+        if let Some(id) = self.selected {
+            if let Some(node) = self.nodes.get(&id) {
+                if self.debug_allow_empty_nodes {
+                    true
+                } else {
+                    !node.label.trim().is_empty()
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
     pub fn set_selected(&mut self, id: Option<NodeID>) {
         if let Some(prev) = self.selected {
             if Some(prev) != id {


### PR DESCRIPTION
## Summary
- add `debug_allow_empty_nodes` field in settings and app state
- block node creation if current node is blank unless toggle is enabled
- expose new 'Allow Empty Nodes' toggle in settings panel

## Testing
- `cargo check`
- `cargo test --workspace --all-targets`