### PR TITLE
Patch 25.73a – Relocate Dock to Bottom-Left Status Bar

### DIFF
--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -9,6 +9,7 @@ use ratatui::{
 use crate::state::AppState;
 use crate::ui::status::status_line;
 use crate::ui::animate::breath_style;
+use crate::render::favorites::render_favorites_dock;
 
 pub fn render_status_bar<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -46,4 +47,5 @@ pub fn render_status_bar<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut A
     f.render_widget(block, area);
     let inner_width = area.width.saturating_sub(2);
     f.render_widget(content, Rect::new(area.x + 1, area.y + 1, inner_width, 1));
+    render_favorites_dock(f, area, state);
 }

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -347,7 +347,7 @@ impl Default for AppState {
             loaded_plugins: Vec::new(),
             plugin_favorites: Vec::new(),
             favorite_dock_limit: 3,
-            favorite_dock_layout: DockLayout::Vertical,
+            favorite_dock_layout: DockLayout::Horizontal,
             favorite_dock_enabled: true,
             dock_focus_index: None,
             dock_hover_index: None,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,6 @@ use crate::render::{
     render_spotlight,
     render_triage,
     render_module_icon,
-    render_favorites_dock,
     Renderable,
     ZenView,
     ModuleSwitcher,
@@ -114,7 +113,6 @@ pub fn draw(
 
         // status bar is rendered separately based on AppState
         render_module_icon(f, full, &state.mode);
-        render_favorites_dock(f, full, state);
         if state.show_logs {
             render_logs(f, full, state);
         }
@@ -613,14 +611,7 @@ pub fn launch_ui() -> std::io::Result<()> {
                         state.triage_set_filter(Some("#done"));
                     }
 
-                    KeyCode::Up if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {
-                        state.dock_focus_prev();
-                        if state.mode == "gemx" { state.move_focus_up(); }
-                    }
-                    KeyCode::Down if state.favorite_dock_enabled && modifiers == KeyModifiers::NONE => {
-                        state.dock_focus_next();
-                        if state.mode == "gemx" { state.move_focus_down(); }
-                    }
+
 
                     KeyCode::Up if state.mode == "gemx" => state.move_focus_up(),
                     KeyCode::Down if state.mode == "gemx" => state.move_focus_down(),

--- a/src/ui/dock.rs
+++ b/src/ui/dock.rs
@@ -14,56 +14,20 @@ pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     state.dock_entry_bounds.clear();
 
     let beam = state.beam_style_for_mode(&state.mode);
-    let base_style = Style::default().fg(beam.border_color);
     let accent = ThemeConfig::load().accent_color();
-    let horizontal = state.favorite_dock_layout == DockLayout::Horizontal;
-    let height = if horizontal { 3 } else { favorites.len() as u16 + 2 };
-    let width = if horizontal {
-        favorites.len() as u16 * 3 + 2
-    } else {
-        6
-    };
 
-    if horizontal {
-        let x = area.x + 1;
-        // align closely with status bar
-        let y = area.height.saturating_sub(height + 3);
-        draw_rounded_border(f, Rect::new(x - 1, y - 1, width, height), base_style);
-        for (i, entry) in favorites.iter().enumerate() {
-            let gx = x + i as u16 * 3;
-            let rect = Rect::new(gx, y, 2, 1);
-            let mut style = base_style;
-            if state.favorite_focus_index == Some(i) {
-                style = Style::default().fg(accent).add_modifier(Modifier::REVERSED);
-            }
-            f.render_widget(Paragraph::new(entry.icon).style(style), rect);
-            state.dock_entry_bounds.push((rect, entry.command.to_string()));
+    let y = area.y + area.height.saturating_sub(2);
+    let mut x = area.x + 1;
+
+    for (i, entry) in favorites.iter().enumerate() {
+        let rect = Rect::new(x, y, 2, 1);
+        let mut style = Style::default().fg(beam.status_color);
+        if state.favorite_focus_index == Some(i) || state.dock_hover_index == Some(i) {
+            style = Style::default().fg(accent).add_modifier(Modifier::REVERSED);
         }
-    } else {
-        if favorites.is_empty() {
-            return;
-        }
-        let base_y = area.height.saturating_sub(favorites.len() as u16 + 3);
-        f.render_widget(Paragraph::new(format!("{}{}", VERTICAL, HORIZONTAL)).style(base_style), Rect::new(0, base_y - 1, 2, 1));
-        for (i, entry) in favorites.iter().enumerate() {
-            let gy = base_y + i as u16;
-            let mut style = if Some(i) == state.dock_focus_index {
-                Style::default().fg(Color::LightCyan).add_modifier(Modifier::REVERSED)
-            } else {
-                base_style
-            };
-            if state.favorite_focus_index == Some(i) {
-                style = Style::default().fg(accent).add_modifier(Modifier::REVERSED);
-            }
-            let line = format!("{} {}", entry.icon, VERTICAL);
-            let rect = Rect::new(0, gy, 4, 1);
-            f.render_widget(Paragraph::new(line).style(style), rect);
-            state.dock_entry_bounds.push((rect, entry.command.to_string()));
-        }
-        let bottom_y = base_y + favorites.len() as u16;
-        let underscore_len = area.width.saturating_sub(3) as usize;
-        let bottom_line = format!("{}{}{}", VERTICAL, HORIZONTAL.repeat(underscore_len), VERTICAL);
-        f.render_widget(Paragraph::new(bottom_line).style(base_style), Rect::new(0, bottom_y, area.width, 1));
+        f.render_widget(Paragraph::new(entry.icon).style(style), rect);
+        state.dock_entry_bounds.push((rect, entry.command.to_string()));
+        x += 3;
     }
 
     if state.dock_pulse_frames > 0 && std::env::var("PRISMX_TEST").is_err() {


### PR DESCRIPTION
## Summary
- render dock directly inside the status bar
- default dock layout to horizontal
- drop arrow-based dock navigation
- integrate dock drawing inside status bar renderer

## Testing
- `cargo test --quiet`