### PR TITLE
patch-25.73d: Enable dock icon module switching

### DIFF
--- a/src/state/helpers.rs
+++ b/src/state/helpers.rs
@@ -458,8 +458,11 @@ impl AppState {
     pub fn trigger_favorite(&mut self, index: usize) {
         let entries = self.favorite_entries();
         if let Some(entry) = entries.get(index) {
-            self.spotlight_input = entry.command.to_string();
-            self.show_spotlight = true;
+            let cmd = entry.command.trim().trim_start_matches('/');
+            if !self.handle_spotlight_command(cmd) {
+                self.spotlight_input = entry.command.to_string();
+                self.show_spotlight = true;
+            }
             self.favorite_focus_index = Some(index);
             self.dock_pulse_frames = 6;
             self.status_message = entry.command.to_string();

--- a/src/ui/dock.rs
+++ b/src/ui/dock.rs
@@ -1,9 +1,18 @@
-use ratatui::{backend::Backend, style::{Modifier, Style}, widgets::Paragraph, Frame};
+use ratatui::{
+    backend::Backend,
+    style::{Color, Modifier, Style},
+    widgets::{Clear, Paragraph},
+    Frame,
+};
 use crate::ui::layout::Rect;
 use crate::state::AppState;
 use crate::config::theme::ThemeConfig;
 use crate::modules::switcher::MODULES;
 use crate::plugin::registry;
+use crate::ui::borders::draw_rounded_border;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+use crate::ui::animate;
 
 pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     if !state.favorite_dock_enabled {
@@ -40,5 +49,39 @@ pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
 
     if state.dock_pulse_frames > 0 && std::env::var("PRISMX_TEST").is_err() {
         state.dock_pulse_frames -= 1;
+    }
+
+    render_dock_preview(f, area, state, &entries, true);
+}
+
+fn render_dock_preview<B: Backend>(
+    f: &mut Frame<B>,
+    area: Rect,
+    state: &mut AppState,
+    entries: &[(String, String)],
+    horizontal: bool,
+) {
+    if let Some(idx) = state.dock_hover_index {
+        if let Some((rect, _)) = state.dock_entry_bounds.get(idx) {
+            if let Some((icon, cmd)) = entries.get(idx) {
+                let text = format!("{} {}", icon, cmd);
+                let width = text.len() as u16 + 2;
+                let (x, y) = if horizontal {
+                    (rect.x.saturating_sub(1), rect.y.saturating_sub(3))
+                } else {
+                    (rect.right() + 1, rect.y)
+                };
+                let w = width.min(area.width.saturating_sub(x));
+                let h = 3u16;
+                let rect = Rect::new(x.min(area.right().saturating_sub(w)), y.max(area.top()), w, h);
+                let block_style = Style::default().bg(Color::Black).fg(Color::White);
+                f.render_widget(Clear, rect);
+                draw_rounded_border(f, rect, block_style);
+                f.render_widget(
+                    Paragraph::new(text).style(block_style),
+                    Rect::new(rect.x + 1, rect.y + 1, rect.width.saturating_sub(2), 1),
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make dock hover show preview like favorites
- switch modules when dock icon command matches a module

## Testing
- `cargo test`