### PR TITLE
patch-25.72j: implement fluid reflow

### DIFF
--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -6,11 +6,23 @@ pub use crate::layout::engine::sibling_offset;
 /// Ensure the newly inserted node remains visible by centering on it.
 pub fn focus_new_node(state: &mut AppState, node_id: NodeID) {
     viewport::ensure_visible(state, node_id);
+    // After inserting a node we want the immediate layout to remain coherent.
+    // Reflow sibling groups around the focused branch so the new node does not
+    // cause the entire tree to shift unpredictably.
+    reflow_around_focus(state);
 }
 
 /// Follow the currently selected node each frame.
 pub fn follow_focus_node(state: &mut AppState) {
     viewport::follow_focus(state);
+}
+
+/// Reposition root branches so the currently focused branch remains stationary
+/// while its siblings shift outward if necessary. This keeps horizontal
+/// alignment stable when inserting or expanding nodes.
+pub fn reflow_around_focus(state: &mut AppState) {
+    let focus = focused_root(state);
+    preserve_focused_branch(&mut state.nodes, &state.root_nodes, focus);
 }
 
 /// Clamp scroll offsets relative to zoom level to avoid jumpiness.


### PR DESCRIPTION
## Summary
- add `reflow_siblings` to layout engine
- center new nodes and reflow siblings around current focus

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6839f1f2e8d8832d8cc0d3c4d5e0b084