### PR TITLE
Add directional arrows for mindmap lines

### DIFF
--- a/src/theme/characters.rs
+++ b/src/theme/characters.rs
@@ -4,3 +4,6 @@ pub const BOTTOM_LEFT: &str = "┗";
 pub const BOTTOM_RIGHT: &str = "┛";
 pub const HORIZONTAL: &str = "━";
 pub const VERTICAL: &str = "┃";
+pub const DOWN_ARROW: &str = "↓";
+pub const RIGHT_ARROW: &str = "→";
+pub const DIAGONAL_ARROW: &str = "↘";

--- a/src/ui/lines.rs
+++ b/src/ui/lines.rs
@@ -1,5 +1,5 @@
 use ratatui::{prelude::*, widgets::Paragraph};
-use ratatui::style::Color;
+use ratatui::style::{Color, Style};
 use crate::ui::animate::{shimmer, scale_color};
 
 /// Draw a straight line between two points using simple box-drawing glyphs.
@@ -48,6 +48,28 @@ pub fn draw_line_with_arrow<B: Backend>(
         let rect = Rect::new(ex as u16, ey as u16, 1, 1);
         f.render_widget(Paragraph::new(arrow), rect);
     }
+}
+
+/// Render an arrow glyph at the provided point using optional shimmer style.
+pub fn draw_arrow<B: Backend>(
+    f: &mut Frame<B>,
+    pos: (i16, i16),
+    tick: u64,
+    color: Color,
+    arrow: &str,
+    shimmer_enabled: bool,
+) {
+    let (x, y) = pos;
+    if x < 0 || y < 0 {
+        return;
+    }
+    let style = if shimmer_enabled {
+        shimmer(color, tick)
+    } else {
+        Style::default().fg(color)
+    };
+    let rect = Rect::new(x as u16, y as u16, 1, 1);
+    f.render_widget(Paragraph::new(arrow).style(style), rect);
 }
 
 /// Draw a vertical line that fades from `color` using a shimmer effect.


### PR DESCRIPTION
## Summary
- implement draw_arrow helper and add arrow constants
- render vertical and horizontal connectors with arrows in `gemx` module
- support optional shimmer or plain ASCII lines

## Testing
- `cargo check -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_6839f9f5a6dc832d8766b913aa3ff038