### PR TITLE
patch-25.72q-viewport-containment

### DIFF
--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -1,8 +1,10 @@
 use crate::state::AppState;
-use crate::node::NodeID;
+use crate::node::{NodeID, NodeMap};
 use super::viewport;
 pub use crate::layout::engine::sibling_offset;
 use crossterm::terminal;
+use ratatui::prelude::Rect;
+use crate::layout::GEMX_HEADER_HEIGHT;
 
 /// Ensure the newly inserted node remains visible by centering on it.
 pub fn focus_new_node(state: &mut AppState, node_id: NodeID) {
@@ -52,6 +54,18 @@ pub fn clamp_zoom_scroll(state: &mut AppState) {
     state.scroll_y = state.scroll_y.clamp(0, limit + pad_vert);
     state.scroll_target_x = state.scroll_target_x.clamp(0, limit + pad_right);
     state.scroll_target_y = state.scroll_target_y.clamp(0, limit + pad_vert);
+}
+
+/// Ensure all nodes remain within the visible viewport area.
+pub fn enforce_viewport_bounds(nodes: &mut NodeMap, area: Rect) {
+    let min_x = area.x as i16 + 1;
+    let max_x = area.right() as i16 - 2;
+    let min_y = GEMX_HEADER_HEIGHT.max(area.y as i16 + 1);
+    let max_y = area.bottom() as i16 - 2;
+    for node in nodes.values_mut() {
+        node.x = node.x.clamp(min_x, max_x);
+        node.y = node.y.clamp(min_y, max_y);
+    }
 }
 
 /// Determine dynamic child spacing based on total depth.

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -2,7 +2,7 @@ use ratatui::{prelude::*, widgets::Paragraph};
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
 use crate::layout::engine::{center_x, layout_vertical};
-use super::layout::clamp_child_spacing;
+use super::layout::{clamp_child_spacing, enforce_viewport_bounds};
 use crate::ui::lines::{
     draw_vertical_fade,
     draw_horizontal_shimmer,
@@ -46,6 +46,7 @@ pub fn render<B: Backend>(
     for &root in roots {
         layout_vertical(nodes, root, spacing_y);
     }
+    enforce_viewport_bounds(nodes, area);
 
     let zoom = state.zoom_scale as f32;
 


### PR DESCRIPTION
## Summary
- add enforce_viewport_bounds() to clamp node coordinates
- call enforce_viewport_bounds from GemX renderer to keep nodes inside the viewport

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a04760e94832d8380ef67bf273f5d