### PR TITLE
patch-25.72s: dynamic grid expansion

### DIFF
--- a/src/modules/gemx/viewport.rs
+++ b/src/modules/gemx/viewport.rs
@@ -47,6 +47,7 @@ pub fn ensure_visible(state: &mut AppState, node_id: NodeID) {
         state.scroll_target_x = state.scroll_x;
         state.scroll_target_y = state.scroll_y;
     }
+    super::layout::clamp_zoom_scroll(state);
 }
 
 /// Keep the currently focused node in view.


### PR DESCRIPTION
## Summary
- expand scroll limits based on farthest node
- dynamically grow viewport bounds when nodes exceed visible area
- keep scroll positions clamped after centering on a node

## Testing
- `cargo check -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_683a0f714724832d81d23b7c080cc286