### PR TITLE
Patch 25.73e – Enable Nerd Font Rendering & Symbol Mapping

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -8,15 +8,16 @@ use ratatui::{
 use crate::ui::animate::breath_style;
 use std::time::{SystemTime, UNIX_EPOCH};
 use crate::beamx;
+use crate::theme::icons;
 use unicode_width::UnicodeWidthStr;
 
 pub fn module_icon(mode: &str) -> &'static str {
     match mode {
-        "gemx" => "💭",
-        "zen" => "🧘",
-        "triage" => "🏥",
-        "spotlight" => "🔍",
-        "settings" => "⚙️",
+        "gemx" => icons::ICON_GEMX,
+        "zen" => icons::ICON_ZEN,
+        "triage" => icons::ICON_TRIAGE,
+        "spotlight" => icons::ICON_SPOTLIGHT,
+        "settings" => icons::ICON_SETTINGS,
         "plugin" => "🔌",
         _ => "❓",
     }

--- a/src/render/shortcuts_overlay.rs
+++ b/src/render/shortcuts_overlay.rs
@@ -81,7 +81,8 @@ pub fn render_shortcuts_overlay<B: Backend>(f: &mut Frame<B>, area: Rect, state:
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;
 
-    let block = Block::default().title("Shortcuts").borders(Borders::ALL);
+    let title = format!("{} Shortcuts", crate::theme::icons::ICON_TERMINAL);
+    let block = Block::default().title(title).borders(Borders::ALL);
     let content = Paragraph::new(lines).block(block);
 
     let rect = Rect::new(x, y, width, height);

--- a/src/theme/icons.rs
+++ b/src/theme/icons.rs
@@ -1,4 +1,25 @@
+// Node glyphs used throughout the UI
 pub const ROOT_NODE: &str = "\u{1F9E0}"; // 🧠
 pub const CHILD_NODE: &str = "└▶";
 pub const SIBLING_NODE: &str = "↔";
+
+// ───── Module Icons ─────
+pub const ICON_GEMX: &str = "🧠";
+pub const ICON_ZEN: &str = "🧘";
+pub const ICON_TRIAGE: &str = "🏷️";
+pub const ICON_SETTINGS: &str = "⚙️";
+pub const ICON_SPOTLIGHT: &str = "🔍";
+
+// ───── Status Icons ─────
+pub const ICON_SYNC: &str = "";    // nf-fa-wifi
+pub const ICON_SHELL: &str = "";   // nf-fa-terminal
+pub const ICON_SUCCESS: &str = ""; // nf-fa-check
+pub const ICON_LOG: &str = "";     // nf-fa-rss
+pub const ICON_CLOCK: &str = "";   // nf-fa-history
+
+// ───── Overlay Icons ─────
+pub const ICON_NODE: &str = "";    // nf-fa-sticky_note_o
+pub const ICON_TERMINAL: &str = ""; // nf-oct-terminal
+pub const ICON_DATE: &str = "";    // nf-oct-calendar
+pub const ICON_LINK: &str = "";    // nf-fa-link
 

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -78,6 +78,9 @@ pub fn render_status<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState)
         status_line(state)
     };
 
+    // Prefix the active module icon for quick visual context
+    text = format!("{} {}", module_icon(&state.mode), text);
+
     let content_style = Style::default().fg(beam.status_color);
     let width = area.width.saturating_sub(2);
     if text.len() as u16 > width {

--- a/tests/module_icon.rs
+++ b/tests/module_icon.rs
@@ -2,9 +2,9 @@ use prismx::render::module_icon::module_icon;
 
 #[test]
 fn module_icon_matches_mode() {
-    assert_eq!(module_icon("gemx"), "💭");
+    assert_eq!(module_icon("gemx"), "🧠");
     assert_eq!(module_icon("zen"), "🧘");
-    assert_eq!(module_icon("triage"), "🏥");
+    assert_eq!(module_icon("triage"), "🏷️");
     assert_eq!(module_icon("spotlight"), "🔍");
     assert_eq!(module_icon("settings"), "⚙️");
 }


### PR DESCRIPTION
## Summary
- extend `icons.rs` with Nerd Font symbols for modules, status items, and overlays
- prefix the active module icon in the status bar
- decorate the shortcuts overlay title with a terminal icon
- update module icon function and tests to use new glyphs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a23633d38832d802d7ef3e1d12b40