### PR TITLE
Implement smart focus after node insertion

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -20,6 +20,8 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
             if state.can_insert_node() {
                 state.push_undo();
                 state.handle_enter_key();
+                let id = state.selected;
+                layout::focus_or_recent(state, id);
             } else {
                 state.status_message = "Cannot insert: edit node label first".into();
                 state.status_message_last_updated = Some(Instant::now());
@@ -31,6 +33,8 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
             if state.can_insert_node() {
                 state.push_undo();
                 state.handle_tab_key();
+                let id = state.selected;
+                layout::focus_or_recent(state, id);
             } else {
                 state.status_message = "Cannot insert: edit node label first".into();
                 state.status_message_last_updated = Some(Instant::now());

--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -22,6 +22,27 @@ pub fn focus_new_node(state: &mut AppState, node_id: NodeID) {
     reflow_around_focus(state);
 }
 
+/// Attempt to focus the most recently visible node if `node_id` is missing.
+pub fn focus_or_recent(state: &mut AppState, node_id: Option<NodeID>) {
+    if let Some(id) = node_id {
+        state.set_selected(Some(id));
+        focus_new_node(state, id);
+        return;
+    }
+
+    let mut target = None;
+    for (nid, _) in state.selection_trail.iter().rev() {
+        if state.nodes.contains_key(nid) && viewport::node_visible(state, *nid) {
+            target = Some(*nid);
+            break;
+        }
+    }
+    if let Some(id) = target {
+        state.set_selected(Some(id));
+        focus_new_node(state, id);
+    }
+}
+
 /// Follow the currently selected node each frame.
 pub fn follow_focus_node(state: &mut AppState) {
     viewport::follow_focus(state);


### PR DESCRIPTION
## Summary
- add `focus_or_recent` helper to select newly inserted node or fall back to the latest visible
- use the new helper after Enter/Tab inserts in GemX

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683a261f1c58832db649bc33a39bc821