### PR TITLE
Implement node merge and reparent drag-drop

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -203,7 +203,22 @@ pub fn handle_mouse(state: &mut AppState, me: MouseEvent) -> bool {
             if let Some(id) = state.dragging {
                 end_drag(state);
                 let target = state.drag_hover_target.take();
-                logic::reparent(&mut state.nodes, &mut state.root_nodes, id, target);
+                if let Some(tgt) = target {
+                    if me.modifiers.contains(KeyModifiers::CONTROL) {
+                        state.link_map.entry(id).or_default().push(tgt);
+                    } else if logic::node_depth(&state.nodes, id)
+                        == logic::node_depth(&state.nodes, tgt)
+                    {
+                        logic::merge_nodes(
+                            &mut state.nodes,
+                            &mut state.root_nodes,
+                            id,
+                            tgt,
+                        );
+                    } else {
+                        logic::reparent(&mut state.nodes, &mut state.root_nodes, id, Some(tgt));
+                    }
+                }
                 logic::adopt_orphans(&mut state.nodes, &mut state.root_nodes);
                 return true;
             }

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -276,6 +276,9 @@ pub fn render<B: Backend>(
             if highlight && focus_nodes.contains(&node.id) {
                 para = para.style(trail_style(highlight_parent, tick, fade));
             }
+            if state.drag_hover_target == Some(node.id) {
+                para = para.style(trail_style(highlight_sibling, tick, 1.0));
+            }
             if debug && is_problem {
                 para = para.style(Style::default().fg(Color::LightRed));
             }


### PR DESCRIPTION
## Summary
- allow merging or reparenting nodes on drag drop
- highlight target nodes during drag
- support merging logic in gemx logic helpers

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a30c3be30832db9d0f4d82fc5b945