### PR TITLE
Patch 25.72aa - auto-center new node

### DIFF
--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -20,8 +20,9 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
             if state.can_insert_node() {
                 state.push_undo();
                 state.handle_enter_key();
-                let id = state.selected;
-                layout::focus_or_recent(state, id);
+                if let Some(id) = state.selected {
+                    layout::focus_new_node(state, id);
+                }
             } else {
                 state.status_message = "Cannot insert: edit node label first".into();
                 state.status_message_last_updated = Some(Instant::now());
@@ -33,8 +34,9 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
             if state.can_insert_node() {
                 state.push_undo();
                 state.handle_tab_key();
-                let id = state.selected;
-                layout::focus_or_recent(state, id);
+                if let Some(id) = state.selected {
+                    layout::focus_new_node(state, id);
+                }
             } else {
                 state.status_message = "Cannot insert: edit node label first".into();
                 state.status_message_last_updated = Some(Instant::now());

--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -15,7 +15,11 @@ const GRID_EXPANSION_THRESHOLD: usize = 50;
 
 /// Ensure the newly inserted node remains visible by centering on it.
 pub fn focus_new_node(state: &mut AppState, node_id: NodeID) {
-    viewport::ensure_visible(state, node_id);
+    // Auto-arrange jumps immediately to avoid excessive animation when the
+    // entire layout may shift, otherwise scroll smoothly toward the target.
+    let jump = state.auto_arrange;
+    viewport::recenter_on_node(state, node_id, jump);
+
     // After inserting a node we want the immediate layout to remain coherent.
     // Reflow sibling groups around the focused branch so the new node does not
     // cause the entire tree to shift unpredictably.

--- a/src/modules/gemx/viewport.rs
+++ b/src/modules/gemx/viewport.rs
@@ -58,3 +58,24 @@ pub fn follow_focus(state: &mut AppState) {
         ensure_visible(state, id);
     }
 }
+
+/// Center the viewport on the provided node.
+///
+/// When `jump` is true the view jumps immediately. When false, the
+/// centering position is stored in `scroll_target_*` so animation can
+/// interpolate toward it.
+pub fn recenter_on_node(state: &mut AppState, node_id: NodeID, jump: bool) {
+    let prev_x = state.scroll_x;
+    let prev_y = state.scroll_y;
+
+    center_on_node(state, node_id);
+    state.scroll_target_x = state.scroll_x;
+    state.scroll_target_y = state.scroll_y;
+
+    if !jump {
+        state.scroll_x = prev_x;
+        state.scroll_y = prev_y;
+    }
+
+    super::layout::clamp_zoom_scroll(state);
+}


### PR DESCRIPTION
## Summary
- auto-center on inserted nodes in mindmap
- recenter viewport via helper
- smooth-scroll when auto_arrange is false

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683a44a2aac4832da891985d64410e48