### PR TITLE
Patch 25.74a heartbeat + dock alignment

### DIFF
--- a/src/ui/beamx.rs
+++ b/src/ui/beamx.rs
@@ -184,3 +184,9 @@ pub fn render_insert_cursor<B: Backend>(
     render_glyph(f, pos.0, pos.1, glyph, s);
 }
 
+/// Simple two-frame heartbeat glyph used by the status bar.
+pub fn heartbeat_glyph(tick: u64) -> &'static str {
+    const HEART: [&str; 2] = ["💓", "❤"];
+    crate::ui::animate::pulse(&HEART, tick)
+}
+

--- a/src/ui/dock.rs
+++ b/src/ui/dock.rs
@@ -10,6 +10,9 @@ use crate::config::theme::ThemeConfig;
 use crate::modules::switcher::MODULES;
 use crate::plugin::registry;
 use crate::ui::borders::draw_rounded_border;
+use crate::render::module_icon::{module_icon, module_label};
+use crate::layout::RESERVED_ZONE_W;
+use unicode_width::UnicodeWidthStr;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 use crate::ui::animate;
@@ -33,8 +36,17 @@ pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     let beam = state.beam_style_for_mode(&state.mode);
     let accent = ThemeConfig::load().accent_color();
 
+    let dock_width = entries.len() as u16 * 3;
+
+    let zoom_text = format!("Zoom: {:.1}x", state.zoom_scale);
+    let zoom_w = zoom_text.len() as u16 + 2;
+    let icon_content = format!("{} {}", module_icon(&state.mode), module_label(&state.mode));
+    let icon_w = UnicodeWidthStr::width(icon_content.as_str()) as u16 + 2;
+    let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 1;
+
     let y = area.y + area.height.saturating_sub(2);
-    let mut x = area.x + 1;
+    let mut x = area.right().saturating_sub(dock_width + offset);
+    if x <= area.x { x = area.x + 1; }
 
     for (i, (icon, command)) in entries.iter().enumerate() {
         let rect = Rect::new(x, y, 2, 1);

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -78,8 +78,21 @@ pub fn render_status<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState)
         status_line(state)
     };
 
-    // Prefix the active module icon for quick visual context
-    text = format!("{} {}", module_icon(&state.mode), text);
+    // Prefix heartbeat and active module icon for quick visual context
+    if matches!(state.mode.as_str(), "zen" | "gemx") && state.heartbeat_mode != crate::state::HeartbeatMode::Silent {
+        let tick = if std::env::var("PRISMX_TEST").is_ok() {
+            0
+        } else {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() / 600
+        } as u64;
+        let heart = crate::ui::beamx::heartbeat_glyph(tick / 2);
+        text = format!("{heart} {} {}", module_icon(&state.mode), text);
+    } else {
+        text = format!("{} {}", module_icon(&state.mode), text);
+    }
 
     let content_style = Style::default().fg(beam.status_color);
     let width = area.width.saturating_sub(2);


### PR DESCRIPTION
## Summary
- restore heartbeat pulse rendering for zen/idle modes
- add heartbeat glyph helper
- right-align dock icons in status bar
- prefix heartbeat to textual status

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_683a4a06ed80832d95f5eb5a615297a1