### PR TITLE
Patch 25.74b – restore Zen compose input

### DIFF
--- a/src/modules/zen/input.rs
+++ b/src/modules/zen/input.rs
@@ -1,0 +1,183 @@
+use crossterm::event::KeyCode;
+use crate::state::{AppState, ZenJournalEntry};
+use crate::state::view::ZenLayoutMode;
+use crate::state::ZenViewMode;
+use crate::zen::utils::parse_tags;
+
+/// Handle key input for Zen compose mode.
+pub fn handle_key(state: &mut AppState, key: KeyCode) {
+    tracing::info!("[ZEN] handle_key {:?}", key);
+    if state.zen_layout_mode != ZenLayoutMode::Compose
+        || state.zen_view_mode != ZenViewMode::Write
+    {
+        return;
+    }
+
+    match key {
+        KeyCode::Char(c) => {
+            // Spawn a new entry on first character when not editing
+            if state.zen_draft.editing.is_none() && state.zen_draft.text.is_empty() {
+                let entry = ZenJournalEntry {
+                    timestamp: chrono::Local::now(),
+                    text: String::new(),
+                    prev_text: None,
+                    tags: vec![],
+                    frame: 0,
+                };
+                state.zen_journal_entries.push(entry);
+                state.zen_draft.editing = Some(state.zen_journal_entries.len() - 1);
+            }
+            state.zen_draft.text.push(c);
+            if let Some(idx) = state.zen_draft.editing {
+                let text = state.zen_draft.text.clone();
+                state.edit_journal_entry(idx, &text);
+            }
+
+            // Auto-finalize when the user types the /send command
+            if state.zen_draft.text.ends_with("/send") {
+                let len = state.zen_draft.text.len();
+                state.zen_draft.text.truncate(len.saturating_sub(5));
+                if let Some(idx) = state.zen_draft.editing {
+                    let text = state.zen_draft.text.clone();
+                    state.edit_journal_entry(idx, &text);
+                }
+                finalize_entry(state);
+            }
+        }
+        KeyCode::Up => {
+            if state.zen_draft.text.is_empty() && state.zen_draft.editing.is_none() {
+                let len = state.zen_journal_entries.len();
+                if len > 0 {
+                    let idx = state.zen_history_index.unwrap_or(len).saturating_sub(1);
+                    state.zen_history_index = Some(idx);
+                    state.scroll_offset = len.saturating_sub(1) - idx;
+                }
+            }
+        }
+        KeyCode::Down => {
+            if state.zen_draft.text.is_empty() && state.zen_draft.editing.is_none() {
+                if let Some(mut idx) = state.zen_history_index {
+                    let len = state.zen_journal_entries.len();
+                    if idx + 1 < len {
+                        idx += 1;
+                        state.zen_history_index = Some(idx);
+                        state.scroll_offset = len.saturating_sub(1) - idx;
+                    } else {
+                        state.zen_history_index = None;
+                        state.scroll_offset = 0;
+                    }
+                }
+            }
+        }
+        KeyCode::Esc => {
+            state.cancel_edit_journal_entry();
+            state.zen_history_index = None;
+            state.zen_draft.text.clear();
+        }
+        KeyCode::Backspace => {
+            state.zen_draft.text.pop();
+            if let Some(idx) = state.zen_draft.editing {
+                let text = state.zen_draft.text.clone();
+                state.edit_journal_entry(idx, &text);
+            }
+        }
+        KeyCode::Enter => {
+            let text = state.zen_draft.text.trim().to_string();
+            if text.is_empty() && state.zen_draft.editing.is_none() {
+                if let Some(idx) = state.zen_history_index.take() {
+                    state.start_edit_journal_entry(idx);
+                }
+            } else if text == "/scroll" {
+                crate::ui::input::toggle_zen_view(state);
+                state.zen_draft.text.clear();
+            } else if text.starts_with("/edit ") {
+                if let Ok(idx) = text[6..].trim().parse::<usize>() {
+                    state.start_edit_journal_entry(idx);
+                }
+                state.zen_draft.text.clear();
+            } else if text == "/cancel" {
+                state.cancel_edit_journal_entry();
+                state.zen_draft.text.clear();
+            } else if text == "/plugins" {
+                use crate::plugin::registry;
+                let list = registry::registry();
+                if list.is_empty() {
+                    state.status_message = "No plugins loaded".into();
+                } else {
+                    let lines: Vec<String> = list
+                        .iter()
+                        .map(|p| {
+                            if let Some(ref path) = p.path {
+                                format!("{} v{} ({})", p.name, p.version, path)
+                            } else {
+                                format!("{} v{}", p.name, p.version)
+                            }
+                        })
+                        .collect();
+                    state.status_message = lines.join(", ");
+                }
+                state.zen_draft.text.clear();
+            } else if !text.is_empty() {
+                if crate::config::theme::ThemeConfig::load().zen_breathe() {
+                    std::thread::sleep(std::time::Duration::from_millis(150));
+                }
+                let entry = ZenJournalEntry {
+                    timestamp: chrono::Local::now(),
+                    text: text.clone(),
+                    prev_text: None,
+                    frame: 0,
+                    tags: parse_tags(&text),
+                };
+                state.zen_journal_entries.push(entry.clone());
+                state.append_journal_entry(&entry);
+                state.zen_draft.text.clear();
+                state.zen_draft.editing = None;
+            } else {
+                finalize_entry(state);
+            }
+
+            state.status_message_last_updated = Some(std::time::Instant::now());
+        }
+        _ => {}
+    }
+}
+
+fn finalize_entry(state: &mut AppState) {
+    let text = state.zen_draft.text.trim().to_string();
+
+    if text.is_empty() {
+        // Drop empty draft
+        if let Some(idx) = state.zen_draft.editing {
+            if let Some(entry) = state.zen_journal_entries.get(idx) {
+                if entry.text.is_empty() {
+                    state.zen_journal_entries.remove(idx);
+                }
+            }
+        }
+        state.zen_draft.text.clear();
+        state.zen_draft.editing = None;
+        return;
+    }
+
+    if let Some(idx) = state.zen_draft.editing {
+        state.edit_journal_entry(idx, &text);
+        let entry = state.zen_journal_entries[idx].clone();
+        state.append_journal_entry(&entry);
+        crate::modules::triage::feed::capture_zen_entry(state, &entry);
+    } else {
+        let entry = ZenJournalEntry {
+            timestamp: chrono::Local::now(),
+            text: text.clone(),
+            prev_text: None,
+            tags: parse_tags(&text),
+            frame: 0,
+        };
+        state.zen_journal_entries.push(entry.clone());
+        state.append_journal_entry(&entry);
+        crate::modules::triage::feed::capture_zen_entry(state, &entry);
+    }
+
+    state.zen_draft.text.clear();
+    state.zen_draft.editing = None;
+    state.scroll_offset = 0;
+}

--- a/src/modules/zen/mod.rs
+++ b/src/modules/zen/mod.rs
@@ -1,3 +1,5 @@
 pub use crate::zen::*;
 
 pub mod output;
+pub mod input;
+pub mod render;

--- a/src/modules/zen/render.rs
+++ b/src/modules/zen/render.rs
@@ -1,0 +1,172 @@
+use ratatui::prelude::*;
+use crate::canvas::prism::render_prism;
+use crate::state::AppState;
+use crate::state::view::ZenLayoutMode;
+use crate::state::ZenViewMode;
+use crate::zen::journal::{render_zen_journal, render_history};
+use crate::beamx::render_full_border;
+use crate::render::traits::{Renderable, RenderFrame};
+use crate::theme::zen::zen_theme;
+
+/// Dispatches the correct Zen view mode renderer
+pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    match state.zen_layout_mode {
+        ZenLayoutMode::Journal => {
+            render_zen_journal(f, area, state);
+        }
+        ZenLayoutMode::Classic => {
+            render_classic(f, area, state);
+        }
+        ZenLayoutMode::Summary => {
+            render_zen_journal(f, area, state);
+        }
+        ZenLayoutMode::Split => {
+            let mid = area.width / 2;
+            let left = Rect {
+                x: area.x,
+                y: area.y,
+                width: mid,
+                height: area.height,
+            };
+            let right = Rect {
+                x: area.x + mid,
+                y: area.y,
+                width: area.width - mid,
+                height: area.height,
+            };
+            render_classic(f, left, state);
+            render_zen_journal(f, right, state);
+        }
+        ZenLayoutMode::Dual => {
+            use ratatui::widgets::Block;
+            use ratatui::style::Style;
+
+            let palette = zen_theme();
+            let tick = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                / 300) as u64;
+
+            let mid = area.width / 2;
+            let left = Rect {
+                x: area.x,
+                y: area.y,
+                width: mid,
+                height: area.height,
+            };
+            let right = Rect {
+                x: area.x + mid,
+                y: area.y,
+                width: area.width - mid,
+                height: area.height,
+            };
+
+            let bg = Block::default().style(Style::default().bg(palette.background));
+            f.render_widget(bg, area);
+
+            render_input(f, left, state, tick);
+            render_history(f, right, state);
+        }
+        ZenLayoutMode::Compose => {
+            let tick = (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                / 300) as u64;
+            render_compose(f, area, state, tick);
+        }
+    }
+
+    render_prism(f, area);
+}
+
+/// Classic buffer-based Zen text editor
+pub fn render_classic<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    use ratatui::{
+        text::Line,
+        widgets::{Block, Borders, Paragraph},
+        style::Style,
+    };
+    let palette = zen_theme();
+
+    let lines: Vec<Line> = state
+        .zen_buffer
+        .iter()
+        .map(|line| Line::from(line.as_str()))
+        .collect();
+
+    let para = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::NONE).style(Style::default().bg(palette.background)))
+        .style(Style::default().fg(palette.text).bg(palette.background));
+
+    f.render_widget(para, area);
+    render_prism(f, area);
+}
+
+/// Compose mode includes input and scrollable journal view
+pub fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::widgets::Block;
+    use ratatui::style::Style;
+    let palette = zen_theme();
+    let bg = Block::default().style(Style::default().bg(palette.background));
+    f.render_widget(bg, area);
+
+    // Preserve manual scroll offset when reviewing history
+
+    if state.zen_view_mode == ZenViewMode::Write {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(75), Constraint::Percentage(25)].as_ref())
+            .split(area);
+
+        render_history(f, chunks[0], state);
+        render_input(f, chunks[1], state, tick);
+    } else {
+        render_history(f, area, state);
+    }
+}
+
+/// One-line entry field at bottom of Compose mode
+pub fn render_input<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, tick: u64) {
+    use ratatui::widgets::{Paragraph, Block, Borders};
+    use ratatui::style::Style;
+    use crate::ui::animate::cursor_blink;
+    use chrono::Local;
+    let palette = zen_theme();
+
+    let padding = area.width / 4;
+    let usable_width = area.width - padding * 2;
+
+    let caret = cursor_blink(tick);
+    let timestamp = Local::now().format("%H:%M").to_string();
+    let input = format!("{} {}{}", timestamp, state.zen_draft.text, caret);
+
+    let input_rect = Rect::new(area.x + padding, area.bottom().saturating_sub(2), usable_width, 1);
+    let mut block = Block::default().borders(Borders::NONE).style(Style::default().bg(palette.background));
+
+    if state.zen_draft.editing.is_some() {
+        block = block.borders(Borders::ALL).border_style(Style::default().fg(Color::DarkGray));
+    }
+
+    let widget = Paragraph::new(input).style(Style::default().fg(palette.text).bg(palette.background)).block(block);
+    f.render_widget(widget, input_rect);
+}
+
+/// Wrapper implementing [`Renderable`] for the Zen view.
+pub struct ZenView<'a> {
+    pub state: &'a AppState,
+}
+
+impl<'a> ZenView<'a> {
+    pub fn new(state: &'a AppState) -> Self {
+        Self { state }
+    }
+}
+
+impl<'a> Renderable for ZenView<'a> {
+    fn render(&mut self, f: &mut RenderFrame<'_>, area: Rect) {
+        render_zen(f, area, self.state);
+    }
+}

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -370,7 +370,7 @@ impl Default for AppState {
             zen_current_syntax: ZenSyntax::Markdown,
             zen_theme: ZenTheme::DarkGray,
             zen_view_mode: crate::state::ZenViewMode::default(),
-            zen_layout_mode: crate::state::ZenLayoutMode::default(),
+            zen_layout_mode: crate::state::view::ZenLayoutMode::Compose,
             zen_draft: DraftState::default(),
             zen_summary_mode: crate::state::ZenSummaryMode::default(),
             zen_compose_input: String::new(),


### PR DESCRIPTION
## Summary
- add zen input/render modules
- default Zen to Compose mode

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a5341cc88832d94fa542a6f3f04fe