### PR TITLE
Implement diagonal tilt for deep branches

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -10,9 +10,15 @@ use crate::layout::{
 use crate::theme::layout::spacing_scale;
 
 /// Depth at which additional horizontal spacing is applied for long branches.
-pub const DEEP_BRANCH_THRESHOLD: usize = 12;
+/// Depth at which long vertical branches begin tilting horizontally.
+///
+/// When a branch grows deeper than this value we slowly stagger child nodes
+/// to the right so the stack fans out diagonally rather than forming a
+/// perfectly vertical line. This helps avoid collisions with nearby branches
+/// while still keeping nodes tightly grouped.
+pub const DEEP_BRANCH_THRESHOLD: usize = 6;
 /// Horizontal offset step applied for each level beyond the threshold.
-pub const DEEP_BRANCH_STEP_X: i16 = 2;
+pub const DEEP_BRANCH_STEP_X: i16 = 1;
 use std::collections::HashMap;
 
 /// Recursively position nodes so siblings are laid out horizontally

--- a/src/modules/gemx/layout.rs
+++ b/src/modules/gemx/layout.rs
@@ -193,6 +193,11 @@ fn shift_subtree(nodes: &mut crate::node::NodeMap, id: NodeID, dx: i16) {
 }
 
 /// Calculate dynamic spacing between root clusters based on available width.
+///
+/// When a tree contains extremely deep branches the layout engine begins to
+/// stagger child nodes horizontally (see [`DEEP_BRANCH_THRESHOLD`]). Each root
+/// cluster therefore requires additional horizontal padding to account for this
+/// diagonal fan-out so connectors remain clean and nodes don't collide.
 fn root_spacing(nodes: &crate::node::NodeMap, roots: &[NodeID]) -> i16 {
     use crate::layout::{subtree_span, subtree_depth, SIBLING_SPACING_X, MIN_SIBLING_SPACING_X, RESERVED_ZONE_W};
     use crate::layout::engine::{DEEP_BRANCH_THRESHOLD, DEEP_BRANCH_STEP_X};


### PR DESCRIPTION
## Summary
- stagger deep branches diagonally by default
- document extra root spacing used when branches tilt

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_683a5be09e40832db6c009a3b89ae054