### PR TITLE
patch-25.74d: triage ui fixes

### DIFF
--- a/src/modules/triage/feed.rs
+++ b/src/modules/triage/feed.rs
@@ -27,6 +27,8 @@ pub fn capture_zen_entry(state: &mut AppState, entry: &ZenJournalEntry) {
     triage_entry.created = entry.timestamp;
     triage_entry.tags = entry.tags.clone();
     state.triage_entries.push(triage_entry);
+    state.triage_entries
+        .sort_by(|a, b| b.created.cmp(&a.created));
 }
 
 /// Pull all tagged Zen entries into triage.
@@ -49,6 +51,8 @@ pub fn sync_from_plugins(state: &mut AppState) {
         }
         let entry = TriageEntry::new(state.triage_entries.len(), &task, TriageSource::Spotlight);
         state.triage_entries.push(entry);
+        state.triage_entries
+            .sort_by(|a, b| b.created.cmp(&a.created));
     }
 }
 


### PR DESCRIPTION
## Summary
- refresh triage feed on render
- show filter label and pad feed
- sort triage entries by timestamp
- reserve space for dock icons in status bar

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683a68f548a8832dba631ccd04eaeb17