### PR TITLE
patch-25.74e: restore heartbeat pulse

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -12,12 +12,13 @@ use crate::theme::icons;
 use unicode_width::UnicodeWidthStr;
 
 pub fn module_icon(mode: &str) -> &'static str {
+    let nerd = icons::nerd_font_enabled();
     match mode {
-        "gemx" => icons::ICON_GEMX,
-        "zen" => icons::ICON_ZEN,
-        "triage" => icons::ICON_TRIAGE,
-        "spotlight" => icons::ICON_SPOTLIGHT,
-        "settings" => icons::ICON_SETTINGS,
+        "gemx" => if nerd { icons::ICON_GEMX } else { icons::FALLBACK_ICON_GEMX },
+        "zen" => if nerd { icons::ICON_ZEN } else { icons::FALLBACK_ICON_ZEN },
+        "triage" => if nerd { icons::ICON_TRIAGE } else { icons::FALLBACK_ICON_TRIAGE },
+        "spotlight" => if nerd { icons::ICON_SPOTLIGHT } else { icons::FALLBACK_ICON_SPOTLIGHT },
+        "settings" => if nerd { icons::ICON_SETTINGS } else { icons::FALLBACK_ICON_SETTINGS },
         "plugin" => "🔌",
         _ => "❓",
     }

--- a/src/render/shortcuts_overlay.rs
+++ b/src/render/shortcuts_overlay.rs
@@ -81,7 +81,7 @@ pub fn render_shortcuts_overlay<B: Backend>(f: &mut Frame<B>, area: Rect, state:
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;
 
-    let title = format!("{} Shortcuts", crate::theme::icons::ICON_TERMINAL);
+    let title = format!("{} Shortcuts", crate::theme::icons::terminal_icon());
     let block = Block::default().title(title).borders(Borders::ALL);
     let content = Paragraph::new(lines).block(block);
 

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 use crate::state::AppState;
 use crate::ui::status::status_line;
-use crate::ui::animate::{breath_style, shimmer};
+use crate::ui::animate::breath_style;
 use crate::render::favorites::render_favorites_dock;
 use crate::ui::beamx::heartbeat_glyph;
 use crate::state::HeartbeatMode;
@@ -44,7 +44,7 @@ pub fn render_status_bar<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut A
         && !matches!(state.heartbeat_mode, HeartbeatMode::Silent);
 
     let spans = if show_heart {
-        let heart_style = shimmer(Color::White, tick);
+        let heart_style = breath_style(Color::White, tick);
         let heart = heartbeat_glyph(tick / 2);
         Spans::from(vec![
             Span::styled(heart, heart_style),

--- a/src/theme/icons.rs
+++ b/src/theme/icons.rs
@@ -10,6 +10,13 @@ pub const ICON_TRIAGE: &str = "🏷️";
 pub const ICON_SETTINGS: &str = "⚙️";
 pub const ICON_SPOTLIGHT: &str = "🔍";
 
+// Simple ASCII fallbacks when Nerd Font icons aren't available
+pub const FALLBACK_ICON_GEMX: &str = "[G]";
+pub const FALLBACK_ICON_ZEN: &str = "[Z]";
+pub const FALLBACK_ICON_TRIAGE: &str = "[T]";
+pub const FALLBACK_ICON_SETTINGS: &str = "[S]";
+pub const FALLBACK_ICON_SPOTLIGHT: &str = "[?]";
+
 // ───── Status Icons ─────
 pub const ICON_SYNC: &str = "";    // nf-fa-wifi
 pub const ICON_SHELL: &str = "";   // nf-fa-terminal
@@ -22,4 +29,18 @@ pub const ICON_NODE: &str = "";    // nf-fa-sticky_note_o
 pub const ICON_TERMINAL: &str = ""; // nf-oct-terminal
 pub const ICON_DATE: &str = "";    // nf-oct-calendar
 pub const ICON_LINK: &str = "";    // nf-fa-link
+
+pub const FALLBACK_ICON_NODE: &str = "[N]";
+pub const FALLBACK_ICON_TERMINAL: &str = "[T]";
+pub const FALLBACK_ICON_DATE: &str = "[D]";
+pub const FALLBACK_ICON_LINK: &str = "[L]";
+
+/// Determine if Nerd Font icons should be used.
+pub fn nerd_font_enabled() -> bool {
+    std::env::var("PRISMX_NO_NERD_FONT").is_err()
+}
+
+pub fn terminal_icon() -> &'static str {
+    if nerd_font_enabled() { ICON_TERMINAL } else { FALLBACK_ICON_TERMINAL }
+}
 

--- a/src/ui/beamx.rs
+++ b/src/ui/beamx.rs
@@ -187,6 +187,11 @@ pub fn render_insert_cursor<B: Backend>(
 /// Simple two-frame heartbeat glyph used by the status bar.
 pub fn heartbeat_glyph(tick: u64) -> &'static str {
     const HEART: [&str; 2] = ["💓", "❤"];
-    crate::ui::animate::pulse(&HEART, tick)
+    const FALLBACK: [&str; 2] = ["<3", "<3"];
+    if crate::theme::icons::nerd_font_enabled() {
+        crate::ui::animate::pulse(&HEART, tick)
+    } else {
+        crate::ui::animate::pulse(&FALLBACK, tick)
+    }
 }
 


### PR DESCRIPTION
## Summary
- restore heartbeat pulse animation in the status bar
- fade heart in/out with BeamX breath style
- add ASCII fallback icons when Nerd Font is disabled
- use new fallback icons across the UI

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check` *(fails: `rustfmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a6fb8eabc832d97f9460c509ae1f6