### PR TITLE
Modularize TUI layer

### DIFF
--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,0 +1,10 @@
+use std::time::Duration;
+use crossterm::event::{self, Event};
+
+pub fn next_event(timeout: Duration) -> std::io::Result<Option<Event>> {
+    if event::poll(timeout)? {
+        Ok(Some(event::read()?))
+    } else {
+        Ok(None)
+    }
+}

--- a/src/tui/layout.rs
+++ b/src/tui/layout.rs
@@ -1,0 +1,3 @@
+pub fn rect_contains(rect: ratatui::layout::Rect, x: u16, y: u16) -> bool {
+    x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -1,0 +1,7 @@
+use ratatui::prelude::*;
+
+pub fn render_unknown_mode<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    use ratatui::widgets::Paragraph;
+    let fallback = Paragraph::new("Unknown mode");
+    f.render_widget(fallback, area);
+}


### PR DESCRIPTION
## Summary
- modularize TUI by adding `layout`, `widgets`, and `events` modules
- use new modules from `tui/mod.rs`
- provide helper to fetch next input event
- render unknown mode via widget helper

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683a8391e318832d9c6be092e46694be