### PR TITLE
Patch 25.75a - Serde user config loader

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[ui]
+show_logs = false
+dock_layout = "vertical"
+
+[theme]
+dark_mode = true
+accent_color = "cyan"
+
+[behavior]
+auto_arrange = true

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -1,0 +1,55 @@
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    pub version: u32,
+    pub ui: Ui,
+    pub theme: Theme,
+    pub behavior: Behavior,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Ui {
+    pub show_logs: bool,
+    pub dock_layout: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Theme {
+    pub dark_mode: bool,
+    pub accent_color: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Behavior {
+    pub auto_arrange: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        toml::from_str(include_str!("../../config/default.toml")).expect("valid default config")
+    }
+}
+
+fn config_file_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("prismx")
+        .join("config.toml")
+}
+
+impl Config {
+    pub fn load() -> Self {
+        let path = config_file_path();
+        if let Ok(data) = fs::read_to_string(&path) {
+            if let Ok(cfg) = toml::from_str::<Config>(&data).or_else(|_| serde_json::from_str(&data)) {
+                if cfg.version == 1 {
+                    return cfg;
+                }
+            }
+        }
+        Config::default()
+    }
+}

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -9,6 +9,7 @@ use crate::modules::triage::sticky::StickyNote;
 use crate::ui::drag::DragState;
 
 use crate::hotkeys::load_hotkeys;
+use crate::state::config::Config as UserConfig;
 use serde::{Serialize, Deserialize};
 
 #[derive(Clone, PartialEq)]
@@ -254,6 +255,7 @@ pub struct AppState {
     pub plugin_tag_filter: crate::state::PluginTagFilter,
     pub plugin_registry_index: usize,
     pub show_plugin_preview: bool,
+    pub user_config: UserConfig,
 }
 
 impl AppState {
@@ -421,6 +423,7 @@ impl Default for AppState {
             plugin_tag_filter: crate::state::PluginTagFilter::default(),
             plugin_registry_index: 0,
             show_plugin_preview: false,
+            user_config: UserConfig::default(),
         };
 
         let config = crate::settings::load_user_settings();
@@ -452,6 +455,11 @@ impl Default for AppState {
         state.sticky_notes = config.sticky_notes;
         state.shortcut_overlay = config.shortcut_overlay;
         state.heartbeat_mode = config.heartbeat_mode;
+
+        let user_cfg = UserConfig::load();
+        state.user_config = user_cfg.clone();
+        state.show_logs = user_cfg.ui.show_logs;
+        state.auto_arrange = user_cfg.behavior.auto_arrange;
 
         for node in state.nodes.values_mut() {
             if node.label.starts_with("[F]") {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,6 +12,7 @@ pub mod links;
 pub mod init;
 mod triage;
 pub mod view;
+pub mod config;
 
 pub use core::*;
 pub mod serialize;


### PR DESCRIPTION
## Summary
- add Serde-based `Config` loader with version check
- load user config in `AppState` and store in `state.user_config`
- include config module in state tree
- provide embedded default configuration

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683a96550f28832d96a89c184a9c8556