### PR TITLE
Add WASM subcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ walkdir = "2"
 [features]
 default = ["std"]
 std = []
+
+[workspace]
+members = [".", "crates/prismx_macros", "wasm"]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prismx-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello from PrismX WASM".to_string()
+}


### PR DESCRIPTION
## Summary
- add new wasm subcrate with wasm-bindgen stub
- register new subcrate in workspace

## Testing
- `cargo build --release`
- `cargo check`
- `cargo build --manifest-path wasm/Cargo.toml` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683a9c8e8ba4832da8fa22cefd4c7105