### PR TITLE
Patch 25.75e – Zen Mode Optional Image Drop Stub

### DIFF
--- a/src/modules/zen/image.rs
+++ b/src/modules/zen/image.rs
@@ -1,0 +1,23 @@
+use ratatui::prelude::*;
+use crate::state::AppState;
+use crate::theme::zen::zen_theme;
+
+/// Draw placeholder drop zone for images.
+pub fn render_drop_zone<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    use ratatui::{widgets::{Block, Borders, Paragraph}, text::Line, style::Style};
+
+    let palette = zen_theme();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default().bg(palette.background).fg(palette.text));
+    let widget = Paragraph::new(Line::from("Drop image here"))
+        .block(block)
+        .style(Style::default().fg(palette.text).bg(palette.background));
+
+    f.render_widget(widget, area);
+}
+
+/// Stub handler for future paste/image buffer support.
+pub fn handle_drop(_state: &mut AppState, _path: &str) {
+    // TODO: accept pasted images or dropped file paths
+}

--- a/src/modules/zen/mod.rs
+++ b/src/modules/zen/mod.rs
@@ -1,6 +1,7 @@
 pub mod render;
 pub mod input;
 pub mod output;
+pub mod image;
 
 pub use crate::zen::*;
 pub use render::{render_zen, render_classic, render_compose, render_input, ZenView};

--- a/src/modules/zen/render.rs
+++ b/src/modules/zen/render.rs
@@ -7,6 +7,7 @@ use crate::zen::journal::{render_zen_journal, render_history};
 use crate::beamx::render_full_border;
 use crate::render::traits::{Renderable, RenderFrame};
 use crate::theme::zen::zen_theme;
+use super::image::render_drop_zone;
 
 /// Dispatches the correct Zen view mode renderer
 pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
@@ -166,6 +167,11 @@ pub fn render_input<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState, 
 
     let widget = Paragraph::new(input).style(Style::default().fg(palette.text).bg(palette.background)).block(block);
     f.render_widget(widget, input_rect);
+
+    if state.enable_image_drop && state.zen_draft.text.is_empty() && state.zen_draft.editing.is_none() {
+        let drop_rect = Rect::new(area.x + padding, area.y + 1, usable_width, area.height.saturating_sub(3));
+        render_drop_zone(f, drop_rect);
+    }
 }
 
 /// Wrapper implementing [`Renderable`] for the Zen view.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -30,6 +30,7 @@ pub struct UserSettings {
     pub layout_style: LayoutStyle,
     pub zoom_grid: bool,
     pub sticky_notes: bool,
+    pub enable_image_drop: bool,
     pub shortcut_overlay: crate::state::ShortcutOverlayMode,
     pub heartbeat_mode: crate::state::HeartbeatMode,
 }
@@ -60,6 +61,7 @@ impl Default for UserSettings {
             layout_style: LayoutStyle::Compact,
             zoom_grid: false,
             sticky_notes: false,
+            enable_image_drop: false,
             shortcut_overlay: crate::state::ShortcutOverlayMode::Full,
             heartbeat_mode: crate::state::HeartbeatMode::Pulse,
         }
@@ -101,6 +103,7 @@ pub fn save_user_settings(state: &AppState) {
         layout_style: state.layout_style,
         zoom_grid: state.zoom_grid,
         sticky_notes: state.sticky_notes,
+        enable_image_drop: state.enable_image_drop,
         shortcut_overlay: state.shortcut_overlay,
         heartbeat_mode: state.heartbeat_mode,
     };

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -119,6 +119,9 @@ fn toggle_layout_style(s: &mut AppState) {
 fn is_sticky_notes(s: &AppState) -> bool { s.sticky_notes }
 fn toggle_sticky_notes(s: &mut AppState) { s.sticky_notes = !s.sticky_notes; save_user_settings(s); }
 
+fn is_image_drop(s: &AppState) -> bool { s.enable_image_drop }
+fn toggle_image_drop(s: &mut AppState) { s.enable_image_drop = !s.enable_image_drop; save_user_settings(s); }
+
 fn shortcut_overlay_enabled(s: &AppState) -> bool { matches!(s.shortcut_overlay, ShortcutOverlayMode::Full) }
 fn toggle_shortcut_overlay(s: &mut AppState) {
     s.shortcut_overlay = match s.shortcut_overlay {
@@ -152,6 +155,7 @@ pub static SETTING_TOGGLES: &[SettingToggle] = &[
     SettingToggle { icon: "🔒", label: "Lock Zoom Scale", is_enabled: is_zoom_locked, toggle: toggle_zoom_lock, category: SettingCategory::Interaction },
     SettingToggle { icon: "💠", label: "BeamX Panel", is_enabled: is_beamx_panel_visible, toggle: toggle_beamx_panel_visibility, category: SettingCategory::Modules },
     SettingToggle { icon: "📌", label: "Sticky Notes", is_enabled: is_sticky_notes, toggle: toggle_sticky_notes, category: SettingCategory::Modules },
+    SettingToggle { icon: "🖼", label: "Image Drop", is_enabled: is_image_drop, toggle: toggle_image_drop, category: SettingCategory::Modules },
     SettingToggle { icon: "⌨", label: "Shortcut Overlay", is_enabled: shortcut_overlay_enabled, toggle: toggle_shortcut_overlay, category: SettingCategory::Modules },
     SettingToggle { icon: "✨", label: "Mindmap Lanes", is_enabled: is_mindmap_lanes, toggle: toggle_mindmap_lanes, category: SettingCategory::Modules },
     SettingToggle { icon: "🧠", label: "Hierarchy Icons", is_enabled: is_hierarchy_icons, toggle: toggle_hierarchy_icons, category: SettingCategory::Modules },

--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -254,6 +254,8 @@ pub struct AppState {
     pub focus_changed_at: Option<Instant>,
     pub zoom_grid: bool,
     pub sticky_notes: bool,
+    /// If true, show drop zone in Zen compose view.
+    pub enable_image_drop: bool,
     pub sticky_overlay_visible: bool,
     pub sticky_notes_data: Vec<StickyNote>,
     pub sticky_focus: Option<usize>,
@@ -428,6 +430,7 @@ impl Default for AppState {
             focus_changed_at: None,
             zoom_grid: false,
             sticky_notes: false,
+            enable_image_drop: false,
             sticky_overlay_visible: false,
             sticky_notes_data: Vec::new(),
             sticky_focus: None,
@@ -469,6 +472,7 @@ impl Default for AppState {
         state.layout_style = config.layout_style;
         state.zoom_grid = config.zoom_grid;
         state.sticky_notes = config.sticky_notes;
+        state.enable_image_drop = config.enable_image_drop;
         state.shortcut_overlay = config.shortcut_overlay;
         state.heartbeat_mode = config.heartbeat_mode;
 


### PR DESCRIPTION
## Summary
- add optional image drop zone rendering
- support enabling via new Settings toggle
- stub future image drop handler

## Testing
- `cargo check`
- `scripts/ci/audit-integrity.sh` *(fails: load_plugins call missing)*

------
https://chatgpt.com/codex/tasks/task_e_683aa236d704832d9ac9e218a36e9fbd