### PR TITLE
Fix triage header spacing and sticky note hotkey

### DIFF
--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -2,8 +2,9 @@ use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseB
 use crate::state::AppState;
 
 pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
-    // Toggle sticky notes panel with Alt+Shift+N only while in Triage
-    if code == KeyCode::Char('n')
+    // Toggle sticky notes panel with Alt+Shift+N only while the Triage module is active
+    if state.mode == "triage"
+        && code == KeyCode::Char('n')
         && mods.contains(KeyModifiers::ALT)
         && mods.contains(KeyModifiers::SHIFT)
     {

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -128,8 +128,9 @@ pub fn render_grouped<B: Backend>(
         Some(tag) => tag.to_uppercase(),
         None => "ALL".to_string(),
     };
+    lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        format!(" Filter: {}", filter_label),
+        format!("Filter: {}", filter_label),
         Style::default().fg(Color::Yellow),
     )));
     lines.push(Line::from(""));


### PR DESCRIPTION
## Summary
- adjust padding for triage filter label so header aligns correctly
- ensure sticky note toggle uses Alt+Shift+N only in triage module

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_683aa9acfc94832da99c2e4821c79f84