### PR TITLE
Patch 25.74n – Restore triage header & sticky note toggle

### DIFF
--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -9,6 +9,7 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
         && mods.contains(KeyModifiers::SHIFT)
     {
         state.toggle_sticky_overlay();
+        println!("STICKY_NOTE_TOGGLED");
         return true;
     }
 

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -130,7 +130,7 @@ pub fn render_grouped<B: Backend>(
     };
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        format!("Filter: {}", filter_label),
+        format!("  Filter: {}", filter_label),
         Style::default().fg(Color::Yellow),
     )));
     lines.push(Line::from(""));


### PR DESCRIPTION
## Summary
- fix triage header display with left margin
- print notification when toggling sticky notes with `Alt+Shift+N`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683abb348364832d91abed4d5168709d