### PR TITLE
patch-25.74o: enforce dock right alignment and heartbeat pulse

### DIFF
--- a/src/ui/beamx.rs
+++ b/src/ui/beamx.rs
@@ -197,6 +197,12 @@ pub fn heartbeat_glyph(tick: u64) -> &'static str {
 
 /// Style used for animating the heartbeat icon.
 pub fn heartbeat_style(color: Color, tick: u64) -> Style {
-    crate::ui::animate::breath_style(color, tick)
+    use ratatui::style::Modifier;
+    let base = crate::ui::animate::breath_style(color, tick);
+    if tick % 2 == 0 {
+        base.add_modifier(Modifier::BOLD)
+    } else {
+        base
+    }
 }
 

--- a/src/ui/dock.rs
+++ b/src/ui/dock.rs
@@ -47,7 +47,8 @@ pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
     let icon_content = format!("{} {}", module_icon(&state.mode), module_label(&state.mode));
     let icon_w = UnicodeWidthStr::width(icon_content.as_str()) as u16 + 2;
     // leave extra padding so dock never collides with debug overlays
-    let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 2;
+    // align dock flush against the rightmost edge of the status bar
+    let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 1;
 
     let y = area.y + area.height.saturating_sub(2);
     let total_width = dock_width + heart_space;
@@ -60,8 +61,11 @@ pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppStat
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis()
-                / 600) as u64
+                / 2000) as u64
         };
+        if state.debug_input_mode {
+            println!("HEARTBEAT_TICK {tick}");
+        }
         let heart = heartbeat_glyph(tick / 2);
         let heart_style = crate::ui::beamx::heartbeat_style(beam.status_color, tick);
         let rect = Rect::new(x, y, 2, 1);

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -95,7 +95,7 @@ pub fn render_status<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppSt
     let zoom_w = zoom_text.len() as u16 + 2;
     let icon_content = format!("{} {}", module_icon(&state.mode), module_label(&state.mode));
     let icon_w = UnicodeWidthStr::width(icon_content.as_str()) as u16 + 2;
-    let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 2;
+    let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 1;
     let available = width.saturating_sub(dock_width + heart_w + offset);
 
     let prefix_len = prefix.len() + 1; // include trailing space


### PR DESCRIPTION
## Summary
- align dock flush with right edge of status bar
- slow heartbeat tick and debug print when enabled
- make heartbeat pulse with bold modifier

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683abd847904832d9c3b2171e6f5a49b