### PR TITLE
Patch 25.74r – Layout Debug Overlay for Node Zones

### DIFF
--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -19,7 +19,7 @@ use crate::theme::beam_color::{parent_line_color, sibling_line_color};
 use crate::beam_color::BeamColor;
 use crate::ui::beamx::{BeamXMode, BeamXStyle, InsertCursorKind, render_insert_cursor, trail_style, bright_color};
 use crate::ui::animate::scale_color;
-use crate::ui::overlay::render_node_tooltip;
+use crate::ui::overlay::{render_node_tooltip, render_layout_zones};
 use std::collections::{HashSet, HashMap};
 use crate::theme::layout::{node_max_width, NODE_WRAP_LABELS};
 use crate::theme::icons::{ROOT_NODE, CHILD_NODE, SIBLING_NODE};
@@ -92,6 +92,10 @@ pub fn render<B: Backend>(
     };
 
     enforce_viewport_bounds(nodes, area);
+
+    if debug {
+        render_layout_zones(f, area);
+    }
 
     let collision_nodes = if debug {
         detect_collisions(nodes)

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -80,3 +80,37 @@ pub fn render_node_tooltip<B: Backend>(
 
     f.render_widget(Paragraph::new(content), Rect::new(x + 1, y + 1, width - 2, 1));
 }
+
+/// Render visual layout zones for debugging mindmap placement.
+pub fn render_layout_zones<B: Backend>(f: &mut Frame<B>, area: Rect) {
+    use ratatui::style::{Color, Style};
+    use crate::layout::{GEMX_HEADER_HEIGHT, RESERVED_ZONE_W, RESERVED_ZONE_H};
+
+    let dock_h = 2u16;
+    let emblem_rect = Rect::new(
+        area.right().saturating_sub(RESERVED_ZONE_W as u16),
+        area.y,
+        RESERVED_ZONE_W as u16,
+        RESERVED_ZONE_H as u16,
+    );
+    let dock_rect = Rect::new(
+        area.x,
+        area.bottom().saturating_sub(dock_h),
+        area.width,
+        dock_h,
+    );
+    let allowed_rect = Rect::new(
+        area.x,
+        area.y + GEMX_HEADER_HEIGHT as u16,
+        area.width.saturating_sub(RESERVED_ZONE_W as u16),
+        area.height.saturating_sub(GEMX_HEADER_HEIGHT as u16 + dock_h),
+    );
+    let gray = Style::default().bg(Color::DarkGray);
+    let red = Style::default().bg(Color::Red);
+    f.render_widget(Block::default().style(red), emblem_rect);
+    f.render_widget(Block::default().style(gray), dock_rect);
+    let zone = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green));
+    f.render_widget(zone, allowed_rect);
+}


### PR DESCRIPTION
## Summary
- show layout zone overlay in debug mode to visualize where nodes can spawn
- color dock and emblem reserved UI zones

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683b1b1018c0832da2f1654e4bf4861f