### PR TITLE
patch-25.76c: add floating debug overlay

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -58,6 +58,15 @@ pub fn toggle_zen_view(state: &mut AppState) {
     };
 }
 
+/// Toggle the floating debug overlay when `?` is pressed with no modifiers.
+pub fn toggle_debug_overlay_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
+    if code == KeyCode::Char('?') && mods.is_empty() {
+        state.debug_overlay = !state.debug_overlay;
+        return true;
+    }
+    false
+}
+
 /// Handle mouse input while in GemX/mindmap view.
 pub fn handle_gemx_mouse(state: &mut AppState, me: crossterm::event::MouseEvent) {
     use crossterm::event::{MouseButton, MouseEventKind};


### PR DESCRIPTION
## Summary
- implement floating debug overlay with module, scroll, node and grid info
- toggle overlay on `?` keypress

## Testing
- `cargo check --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683b30a3c74c832dae8308173b45190f