### PR TITLE
patch-25.76d: add title bars per module

### DIFF
--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -1,4 +1,5 @@
-use ratatui::{prelude::*, widgets::{Paragraph, Wrap}, text::{Line, Span}};
+use ratatui::{prelude::*, widgets::{Paragraph, Wrap, Block, Borders}, text::{Line, Span}};
+use ratatui::style::{Style, Modifier};
 use regex::Regex;
 use crate::node::{NodeID, NodeMap};
 use crate::state::AppState;
@@ -19,7 +20,7 @@ use crate::ui::lines::{
 use crate::theme::beam_color::{parent_line_color, sibling_line_color};
 use crate::beam_color::BeamColor;
 use crate::ui::beamx::{BeamXMode, BeamXStyle, InsertCursorKind, render_insert_cursor, trail_style, bright_color};
-use crate::ui::animate::scale_color;
+use crate::ui::animate::{scale_color, shimmer};
 use crate::ui::overlay::{render_node_tooltip, render_layout_zones};
 use std::collections::{HashSet, HashMap};
 use crate::theme::layout::{node_max_width, NODE_WRAP_LABELS};
@@ -103,6 +104,18 @@ pub fn render<B: Backend>(
     state: &AppState,
     debug: bool,
 ) {
+    let style = state.beam_style_for_mode("gemx");
+    let tick = (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        / 300) as u64;
+    let title_style = shimmer(style.border_color, tick);
+    let block = Block::default()
+        .borders(Borders::NONE)
+        .title(Span::styled("GemX Mindmap", title_style.add_modifier(Modifier::BOLD)))
+        .title_alignment(Alignment::Center);
+    f.render_widget(block, area);
     let spacing_y = clamp_child_spacing(state, roots, area.height as i16);
     let mut focus_set: HashSet<NodeID> = HashSet::new();
     if let Some(mut current) = state.selected {

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -1,6 +1,7 @@
 use chrono::{Duration, Local};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
+use crate::ui::animate::shimmer;
 use ratatui::layout::{Layout, Constraint, Direction};
 use ratatui::text::{Line, Span};
 use ratatui::style::{Color, Modifier, Style};
@@ -143,6 +144,17 @@ pub fn render_grouped<B: Backend>(
 
     let style = state.beam_style_for_mode("triage");
     let block_style = Style::default().fg(style.border_color);
+    let tick = (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        / 300) as u64;
+    let title_style = shimmer(style.border_color, tick);
+    let block = Block::default()
+        .borders(Borders::NONE)
+        .title(Span::styled("Triage", title_style.add_modifier(Modifier::BOLD)))
+        .title_alignment(Alignment::Center);
+    f.render_widget(block, area);
 
     let zones = Layout::default()
         .direction(Direction::Vertical)

--- a/src/modules/zen/render.rs
+++ b/src/modules/zen/render.rs
@@ -1,6 +1,8 @@
 use ratatui::prelude::*;
 use ratatui::text::{Line, Span};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders};
+use crate::ui::animate::shimmer;
 use crate::canvas::prism::render_prism;
 use crate::state::AppState;
 use crate::state::view::ZenLayoutMode;
@@ -58,6 +60,18 @@ fn highlight_entry_line(text: &str) -> Line<'static> {
 
 /// Dispatches the correct Zen view mode renderer
 pub fn render_zen<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState) {
+    let style = state.beam_style_for_mode("zen");
+    let tick = (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        / 300) as u64;
+    let title_style = shimmer(style.border_color, tick);
+    let block = Block::default()
+        .borders(Borders::NONE)
+        .title(Span::styled("Zen Mode", title_style.add_modifier(Modifier::BOLD)))
+        .title_alignment(Alignment::Center);
+    f.render_widget(block, area);
     match state.zen_layout_mode {
         ZenLayoutMode::Journal => {
             render_zen_journal(f, area, state);

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -105,7 +105,7 @@ pub fn render_status<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppSt
     }
 
     let spans = Spans::from(vec![
-        Span::raw(module_icon(&state.mode)),
+        Span::styled(module_icon(&state.mode).to_string(), Style::default().fg(beam.border_color)),
         Span::raw(" "),
         Span::raw(msg_display),
     ]);


### PR DESCRIPTION
## Summary
- show module titles for GemX, Zen and Triage views
- highlight module icon in status bar

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683b35c6d110832dbfb058eaca7f6c1e