### PR TITLE
patch-25.76e: unify symbol constants

### DIFF
--- a/src/render/module_icon.rs
+++ b/src/render/module_icon.rs
@@ -14,11 +14,11 @@ use unicode_width::UnicodeWidthStr;
 pub fn module_icon(mode: &str) -> &'static str {
     let nerd = icons::nerd_font_enabled();
     match mode {
-        "gemx" => if nerd { icons::ICON_GEMX } else { icons::FALLBACK_ICON_GEMX },
-        "zen" => if nerd { icons::ICON_ZEN } else { icons::FALLBACK_ICON_ZEN },
-        "triage" => if nerd { icons::ICON_TRIAGE } else { icons::FALLBACK_ICON_TRIAGE },
-        "spotlight" => if nerd { icons::ICON_SPOTLIGHT } else { icons::FALLBACK_ICON_SPOTLIGHT },
-        "settings" => if nerd { icons::ICON_SETTINGS } else { icons::FALLBACK_ICON_SETTINGS },
+        "gemx" => if nerd { icons::IC_GEMX } else { icons::FALLBACK_IC_GEMX },
+        "zen" => if nerd { icons::IC_ZEN_MODE } else { icons::FALLBACK_IC_ZEN_MODE },
+        "triage" => if nerd { icons::IC_TAG } else { icons::FALLBACK_IC_TAG },
+        "spotlight" => if nerd { icons::IC_SPOTLIGHT } else { icons::FALLBACK_IC_SPOTLIGHT },
+        "settings" => if nerd { icons::IC_SETTINGS } else { icons::FALLBACK_IC_SETTINGS },
         "plugin" => "🔌",
         _ => "❓",
     }

--- a/src/theme/icons.rs
+++ b/src/theme/icons.rs
@@ -3,37 +3,46 @@ pub const ROOT_NODE: &str = "\u{1F9E0}"; // 🧠
 pub const CHILD_NODE: &str = "└▶";
 pub const SIBLING_NODE: &str = "↔";
 
+// ───── Symbolic Icons ─────
+pub const IC_MINDMAP: &str = "🧠";
+pub const IC_NOTE: &str = "💭";
+pub const IC_ZEN: &str = "🧘";
+pub const IC_FIRE: &str = "🔥";
+pub const IC_DOC: &str = "📄";
+pub const IC_PEN: &str = "✍️";
+pub const IC_EDIT: &str = "✎";
+
 // ───── Module Icons ─────
-pub const ICON_GEMX: &str = "🧠";
-pub const ICON_ZEN: &str = "🧘";
-pub const ICON_TRIAGE: &str = "🏷️";
-pub const ICON_SETTINGS: &str = "⚙️";
-pub const ICON_SPOTLIGHT: &str = "🔍";
+pub const IC_GEMX: &str = IC_MINDMAP;
+pub const IC_ZEN_MODE: &str = IC_ZEN;
+pub const IC_TAG: &str = "🏷️";
+pub const IC_SETTINGS: &str = "⚙️";
+pub const IC_SPOTLIGHT: &str = "🔍";
 
 // Simple ASCII fallbacks when Nerd Font icons aren't available
-pub const FALLBACK_ICON_GEMX: &str = "[G]";
-pub const FALLBACK_ICON_ZEN: &str = "[Z]";
-pub const FALLBACK_ICON_TRIAGE: &str = "[T]";
-pub const FALLBACK_ICON_SETTINGS: &str = "[S]";
-pub const FALLBACK_ICON_SPOTLIGHT: &str = "[?]";
+pub const FALLBACK_IC_GEMX: &str = "[G]";
+pub const FALLBACK_IC_ZEN_MODE: &str = "[Z]";
+pub const FALLBACK_IC_TAG: &str = "[T]";
+pub const FALLBACK_IC_SETTINGS: &str = "[S]";
+pub const FALLBACK_IC_SPOTLIGHT: &str = "[?]";
 
 // ───── Status Icons ─────
-pub const ICON_SYNC: &str = "";    // nf-fa-wifi
-pub const ICON_SHELL: &str = "";   // nf-fa-terminal
-pub const ICON_SUCCESS: &str = ""; // nf-fa-check
-pub const ICON_LOG: &str = "";     // nf-fa-rss
-pub const ICON_CLOCK: &str = "";   // nf-fa-history
+pub const IC_SYNC: &str = "";    // nf-fa-wifi
+pub const IC_SHELL: &str = "";   // nf-fa-terminal
+pub const IC_SUCCESS: &str = ""; // nf-fa-check
+pub const IC_LOG: &str = "";     // nf-fa-rss
+pub const IC_CLOCK: &str = "";   // nf-fa-history
 
 // ───── Overlay Icons ─────
-pub const ICON_NODE: &str = "";    // nf-fa-sticky_note_o
-pub const ICON_TERMINAL: &str = ""; // nf-oct-terminal
-pub const ICON_DATE: &str = "";    // nf-oct-calendar
-pub const ICON_LINK: &str = "";    // nf-fa-link
+pub const IC_NODE: &str = "";    // nf-fa-sticky_note_o
+pub const IC_TERMINAL: &str = ""; // nf-oct-terminal
+pub const IC_DATE: &str = "";    // nf-oct-calendar
+pub const IC_LINK: &str = "";    // nf-fa-link
 
-pub const FALLBACK_ICON_NODE: &str = "[N]";
-pub const FALLBACK_ICON_TERMINAL: &str = "[T]";
-pub const FALLBACK_ICON_DATE: &str = "[D]";
-pub const FALLBACK_ICON_LINK: &str = "[L]";
+pub const FALLBACK_IC_NODE: &str = "[N]";
+pub const FALLBACK_IC_TERMINAL: &str = "[T]";
+pub const FALLBACK_IC_DATE: &str = "[D]";
+pub const FALLBACK_IC_LINK: &str = "[L]";
 
 /// Determine if Nerd Font icons should be used.
 pub fn nerd_font_enabled() -> bool {
@@ -41,6 +50,6 @@ pub fn nerd_font_enabled() -> bool {
 }
 
 pub fn terminal_icon() -> &'static str {
-    if nerd_font_enabled() { ICON_TERMINAL } else { FALLBACK_ICON_TERMINAL }
+    if nerd_font_enabled() { IC_TERMINAL } else { FALLBACK_IC_TERMINAL }
 }
 

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -3,6 +3,7 @@ use crate::ui::layout::Rect;
 use crate::state::AppState;
 use crate::ui::borders::draw_rounded_border;
 use crate::render::module_icon::{module_icon, module_label};
+use crate::theme::icons;
 use crate::ui::shortcuts::shortcuts_for;
 use crate::modules::triage::render::{completion_streak, done_sparkline, progress_bar};
 use crate::ui::dock::render_dock;
@@ -13,11 +14,16 @@ use unicode_width::UnicodeWidthStr;
 pub fn status_line(state: &AppState) -> String {
     match state.mode.as_str() {
         "zen" => {
-            let dirty = if state.zen_dirty { " ✎" } else { "" };
+            let dirty = if state.zen_dirty { format!(" {}", icons::IC_EDIT) } else { String::new() };
             let layout = format!("{:?}", state.zen_layout_mode);
             format!(
-                "📄 {} ✍️ {} words{} [{}]",
-                state.zen_current_filename, state.zen_word_count, dirty, layout
+                "{} {} {} {} words{} [{}]",
+                icons::IC_DOC,
+                state.zen_current_filename,
+                icons::IC_PEN,
+                state.zen_word_count,
+                dirty,
+                layout
             )
         }
         "gemx" => {
@@ -46,11 +52,12 @@ pub fn status_line(state: &AppState) -> String {
                 .map(|e| e.text.clone())
                 .unwrap_or_default();
             format!(
-                "#NOW:{} #TRITON:{} #DONE:{} {} 🔥{} {} | {}",
+                "#NOW:{} #TRITON:{} #DONE:{} {} {}{} {} | {}",
                 now,
                 triton,
                 done,
                 bar,
+                icons::IC_FIRE,
                 streak,
                 spark,
                 current


### PR DESCRIPTION
## Summary
- centralize symbols in icons module
- update status bar to use themed icons
- adjust module icon helper for new constants

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683b939e9354832daa5d6b79961c774e