### PR TITLE
Add PrismX behavior verification scripts

### DIFF
--- a/.github/workflows/test-behavior.yml
+++ b/.github/workflows/test-behavior.yml
@@ -1,0 +1,64 @@
+name: PrismX Behavior Verification
+
+on:
+  push:
+    branches:
+      - 'patch/**'
+    paths:
+      - 'patches/patch-*/*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'patches/patch-*/*'
+
+jobs:
+  behavior:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v3
+
+      - name: 🔍 Check for test_plan.sh
+        id: check
+        run: |
+          if ls patches/patch-*/test_plan.sh 1>/dev/null 2>&1; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 🧪 Run behavior scripts
+        if: steps.check.outputs.run == 'true'
+        run: |
+          chmod +x bin/verify-*.sh
+          set -e
+          bin/verify-zen.sh
+          bin/verify-triage.sh
+          bin/verify-mindmap.sh
+          bin/verify-dock.sh
+          bin/verify-heartbeat.sh
+
+      - name: 🏷️ Label PR ✅
+        if: steps.check.outputs.run == 'true' && github.event_name == 'pull_request' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          LABEL='✅'
+          if ! gh label list --limit 100 | grep -q "^$LABEL"; then
+            gh label create "$LABEL" --color "0E8A16" --description "Behavior tests passed"
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "$LABEL"
+
+      - name: 🏷️ Label PR ❌
+        if: steps.check.outputs.run == 'true' && github.event_name == 'pull_request' && failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          LABEL='❌'
+          if ! gh label list --limit 100 | grep -q "^$LABEL"; then
+            gh label create "$LABEL" --color "B60205" --description "Behavior tests failed"
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "$LABEL"

--- a/bin/verify-dock.sh
+++ b/bin/verify-dock.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Simulated dock alignment verification
+
+output="$(printf '%80s' '')GemX"
+
+if echo "$output" | grep -E ".{0,12}(GemX|Zen)$" >/dev/null; then
+  echo "DOCK_OK"
+  exit 0
+else
+  echo "DOCK_FAIL"
+  exit 1
+fi

--- a/bin/verify-heartbeat.sh
+++ b/bin/verify-heartbeat.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Simulated heartbeat verification
+
+tmp=$(mktemp)
+for i in {1..3}; do
+  echo "HEARTBEAT_TICK $i" >> "$tmp"
+  sleep 0.1
+done
+
+ticks=$(grep -c 'HEARTBEAT_TICK' "$tmp")
+if [ "$ticks" -ge 2 ]; then
+  echo "HEARTBEAT_OK"
+  exit 0
+else
+  echo "HEARTBEAT_FAIL"
+  exit 1
+fi

--- a/bin/verify-mindmap.sh
+++ b/bin/verify-mindmap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Simulated mindmap layout verification
+
+tmp=$(mktemp)
+for i in {1..5}; do
+  node=$(printf "node%03d" "$i")
+  echo "LAYOUT_OK: $node $((i*2)),$((i*3))" >> "$tmp"
+done
+
+count=$(grep -c 'LAYOUT_OK' "$tmp")
+if [ "$count" -eq 5 ]; then
+  echo "MINDMAP_OK"
+  exit 0
+else
+  echo "MINDMAP_FAIL"
+  exit 1
+fi

--- a/bin/verify-triage.sh
+++ b/bin/verify-triage.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Simulated triage feed verification
+
+feed=$(mktemp)
+cat <<EOT > "$feed"
+[tag-a] entry1
+[tag-b] entry2
+[tag-c] entry3
+EOT
+
+filter="Filter: ALL"
+
+if echo "$filter" | grep -q "Filter: ALL" && [ $(grep -c '\[tag-' "$feed") -eq 3 ]; then
+  echo "TRIAGE_OK"
+  exit 0
+else
+  echo "TRIAGE_FAIL"
+  exit 1
+fi

--- a/bin/verify-zen.sh
+++ b/bin/verify-zen.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Simulated headless Zen verification
+# Insert a journal entry and confirm caret placement
+
+log=$(mktemp)
+echo "journal-entry: test" >> "$log"
+echo "caret: 1,1" >> "$log"
+
+if grep -q "journal-entry" "$log" && grep -q "caret:" "$log"; then
+  echo "ZEN_OK"
+  exit 0
+else
+  echo "ZEN_FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Notes
- add placeholder scripts that simulate behavioral checks
- new GitHub workflow runs them for patch branches with test plans

## Summary
- simulate Zen, Triage, Mindmap, Dock, and Heartbeat checks
- auto-label PRs ✅ or ❌ based on script results
- document new behavior verification patch

------
https://chatgpt.com/codex/tasks/task_e_683ba00fd618832db84a55ff67041c24