### PR TITLE
Implement settings policy enforcement

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct UserSettings {
     pub auto_arrange: bool,
     pub debug_input_mode: bool,

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -7,6 +7,9 @@ use crate::state::{
 };
 use crate::theme::fonts::FontStyle;
 use super::save_user_settings;
+
+// NOTE: When introducing a new visual feature, a corresponding toggle
+// must be defined here and surfaced in the Settings UI.
 use std::sync::atomic::{AtomicU8, Ordering};
 
 // Theme preset logic


### PR DESCRIPTION
## Summary
- note policy in toggles module requiring a setting for each visual feature
- enable serde default handling when loading user settings

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683ba3631ea4832d85e3f28aa981e45b