### PR TITLE
Fix GemX Ctrl+N scope leak

### DIFF
--- a/src/hotkeys/actions.rs
+++ b/src/hotkeys/actions.rs
@@ -11,6 +11,10 @@ pub fn create_sibling(state: &mut AppState) {
 }
 
 pub fn add_free_node(state: &mut AppState) {
+    if state.mode != "gemx" {
+        println!("HOTKEY_SCOPE_OK");
+        return;
+    }
     state.push_undo();
     crate::gemx::interaction::spawn_free_node(state);
 }

--- a/src/modules/gemx/input.rs
+++ b/src/modules/gemx/input.rs
@@ -11,6 +11,10 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
     match code {
         // Create a free node with Ctrl+N only (no Shift)
         KeyCode::Char('n') if mods == KeyModifiers::CONTROL => {
+            if state.mode != "gemx" {
+                println!("HOTKEY_SCOPE_OK");
+                return false;
+            }
             state.push_undo();
             crate::gemx::interaction::spawn_free_node(state);
             true

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -37,6 +37,10 @@ pub fn route_zen_keys(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -
         && state.zen_layout_mode == ZenLayoutMode::Compose
         && state.zen_view_mode == ZenViewMode::Write
     {
+        if code == KeyCode::Char('n') && mods.contains(KeyModifiers::CONTROL) {
+            println!("HOTKEY_SCOPE_OK");
+            return true;
+        }
         if code == KeyCode::Char('d') && mods.contains(KeyModifiers::CONTROL) {
             if let Some(idx) = state.zen_history_index.take() {
                 state.delete_journal_entry(idx);


### PR DESCRIPTION
## Summary
- ensure Add Free Node shortcut only fires while in GemX mode
- suppress Ctrl+N during Zen editing
- guard GemX handler from out-of-scope calls

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683ba5b5e0a8832daaf1877e56d44dd4