### PR TITLE
Organize settings tab layout

### DIFF
--- a/src/settings/render.rs
+++ b/src/settings/render.rs
@@ -21,6 +21,9 @@ pub fn render_settings<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut App
     let category = SETTING_CATEGORIES[state.settings_selected_tab % SETTING_CATEGORIES.len()];
     let toggles = toggles_for_category(category);
     let mut lines: Vec<Line> = Vec::new();
+    let header_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
+    lines.push(Line::from(Span::styled(category.name(), header_style)));
+    lines.push(Line::default());
     let mut toggle_lines: Vec<usize> = Vec::new();
 
     for (display_idx, (_idx, t)) in toggles.iter().enumerate() {

--- a/src/settings/toggle.rs
+++ b/src/settings/toggle.rs
@@ -160,7 +160,7 @@ pub static SETTING_TOGGLES: &[SettingToggle] = &[
     SettingToggle { icon: "📌", label: "Sticky Notes", is_enabled: is_sticky_notes, toggle: toggle_sticky_notes, category: SettingCategory::Modules },
     SettingToggle { icon: "🖼", label: "Image Drop", is_enabled: is_image_drop, toggle: toggle_image_drop, category: SettingCategory::Modules },
     SettingToggle { icon: "⌨", label: "Shortcut Overlay", is_enabled: shortcut_overlay_enabled, toggle: toggle_shortcut_overlay, category: SettingCategory::Modules },
-    SettingToggle { icon: "✨", label: "Mindmap Lanes", is_enabled: is_mindmap_lanes, toggle: toggle_mindmap_lanes, category: SettingCategory::Modules },
+    SettingToggle { icon: "✨", label: "Mindmap Lanes", is_enabled: is_mindmap_lanes, toggle: toggle_mindmap_lanes, category: SettingCategory::Visuals },
     SettingToggle { icon: "🧠", label: "Hierarchy Icons", is_enabled: is_hierarchy_icons, toggle: toggle_hierarchy_icons, category: SettingCategory::Modules },
     SettingToggle { icon: "🐞", label: "Debug Input Mode", is_enabled: is_debug_mode, toggle: toggle_debug_mode, category: SettingCategory::UX },
     SettingToggle { icon: "⚠", label: "Allow Empty Nodes", is_enabled: is_allow_empty_nodes, toggle: toggle_allow_empty_nodes, category: SettingCategory::UX },


### PR DESCRIPTION
## Summary
- assign mindmap lanes toggle to Visuals category
- show tab header title inside each settings tab

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_683bb26f1bb0832da215f55492f48bcb