### PR TITLE
Implement layout status validator

### DIFF
--- a/src/state/core.rs
+++ b/src/state/core.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 #[cfg(not(feature = "std"))]
 use core::time::Duration as Instant;
 use crate::node::{Node, NodeID, NodeMap};
-use crate::layout::{GEMX_HEADER_HEIGHT, LayoutRole};
+use crate::layout::{engine::LayoutStatus, GEMX_HEADER_HEIGHT, LayoutRole};
 use crate::plugin::{loader, PluginHost};
 use crate::zen::image::JournalEntry;
 pub use crate::zen::state::*;
@@ -190,6 +190,7 @@ pub struct AppState {
     pub layout_warning_logged: bool,
     pub layout_fail_count: u8,
     pub layout_key: (usize, u64),
+    pub layout_status: LayoutStatus,
     pub debug_input_mode: bool,
     pub debug_allow_empty_nodes: bool,
     pub debug_border: bool,
@@ -363,6 +364,7 @@ impl Default for AppState {
             layout_warning_logged: false,
             layout_fail_count: 0,
             layout_key: (0, 0),
+            layout_status: LayoutStatus::Valid,
             debug_input_mode: true,
             debug_allow_empty_nodes: false,
             debug_border: {

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -8,6 +8,7 @@ use crate::ui::shortcuts::shortcuts_for;
 use crate::modules::triage::render::{completion_streak, done_sparkline, progress_bar};
 use crate::ui::dock::render_dock;
 use crate::layout::RESERVED_ZONE_W;
+use crate::layout::engine::LayoutStatus;
 use unicode_width::UnicodeWidthStr;
 
 /// Utility to generate a default status string for the current mode.
@@ -33,11 +34,17 @@ pub fn status_line(state: &AppState) -> String {
                 .and_then(|id| state.nodes.get(&id))
                 .map(|n| n.label.clone())
                 .unwrap_or_default();
+            let status = match state.layout_status {
+                LayoutStatus::Valid => "VALID",
+                LayoutStatus::Overlap => "\u{26A0} OVERLAP",
+                LayoutStatus::OutOfBounds => "\u{274C} OUT OF BOUNDS",
+            };
             format!(
-                "Nodes: {} Layout: {} Focus: {}",
+                "Nodes: {} Layout: {} Focus: {} [{}]",
                 state.nodes.len(),
                 layout,
-                focus
+                focus,
+                status
             )
         }
         "triage" => {


### PR DESCRIPTION
## Summary
- add `LayoutStatus` enum and validator in the layout engine
- store latest layout status in `AppState`
- show layout status in GemX status line
- validate layout during mindmap rendering

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683bceed002c832db3c1ac60d7b95d98