### PR TITLE
Implement patch-25.76r mindmap connectors

### DIFF
--- a/src/layout/engine.rs
+++ b/src/layout/engine.rs
@@ -1,6 +1,7 @@
 use super::{connector, grid, nodes};
-use crate::layout::{label_bounds, subtree_span, MIN_CHILD_SPACING_Y, MIN_NODE_GAP};
+use crate::layout::{label_bounds, subtree_span, MIN_CHILD_SPACING_Y, MIN_NODE_GAP, SIBLING_SPACING_X};
 use crate::node::{NodeID, NodeMap};
+use crate::settings;
 use ratatui::layout::Rect;
 
 pub use grid::{
@@ -20,6 +21,15 @@ pub use nodes::{
 };
 
 pub use connector::{beam_y, parent_line, child_line};
+
+/// Horizontal spacing used between sibling connectors based on user settings.
+pub fn lane_spacing() -> i16 {
+    if settings::load_user_settings().mindmap_lanes {
+        SIBLING_SPACING_X
+    } else {
+        2
+    }
+}
 
 fn depth_offset(depth: usize) -> i16 {
     if depth > DEEP_BRANCH_THRESHOLD {
@@ -77,7 +87,7 @@ pub fn reflow_siblings(nodes: &mut NodeMap, parent: NodeID, spacing_y: i16) {
         child_w += offset;
         child_x += child_w;
         if i + 1 < len {
-            child_x += sibling_offset(i, len);
+            child_x += lane_spacing();
         }
     }
 }

--- a/src/modules/gemx/render.rs
+++ b/src/modules/gemx/render.rs
@@ -222,16 +222,16 @@ pub fn render<B: Backend>(
         display_map.insert(node.id, (lines, width));
     }
 
-    if debug || highlight {
-        for node in nodes.values() {
-            if node.children.is_empty() {
-                continue;
-            }
+    let lane_offset = if state.mindmap_lanes { 2 } else { 0 };
+    for node in nodes.values() {
+        if node.children.is_empty() {
+            continue;
+        }
 
-            let width_self = display_map.get(&node.id).map(|d| d.1 as i16).unwrap_or(0);
-            let px = scale_x(node.x + width_self / 2);
-            let beam_y = scale_y(node.y + (spacing_y - 1).max(1));
-            let on_path = focus_nodes.contains(&node.id);
+        let width_self = display_map.get(&node.id).map(|d| d.1 as i16).unwrap_or(0);
+        let px = scale_x(node.x + width_self / 2 + lane_offset);
+        let beam_y = scale_y(node.y + (spacing_y - 1).max(1));
+        let on_path = focus_nodes.contains(&node.id);
 
             // vertical beam from parent to sibling bar
             let parent_start = (px, scale_y(node.y + 1));
@@ -253,13 +253,13 @@ pub fn render<B: Backend>(
             );
 
             // collect child centers
-            let mut child_centers = Vec::new();
-            for cid in &node.children {
-                if let Some(child) = nodes.get(cid) {
-                    let w = display_map.get(cid).map(|d| d.1 as i16).unwrap_or(0);
-                    child_centers.push((cid, scale_x(child.x + w / 2)));
-                }
+        let mut child_centers = Vec::new();
+        for cid in &node.children {
+            if let Some(child) = nodes.get(cid) {
+                let w = display_map.get(cid).map(|d| d.1 as i16).unwrap_or(0);
+                child_centers.push((cid, scale_x(child.x + w / 2 + lane_offset)));
             }
+        }
             if child_centers.is_empty() {
                 continue;
             }
@@ -337,8 +337,7 @@ pub fn render<B: Backend>(
                 }
             }
         }
-    }
-
+    
     // Ghost trails showing multiple inbound references
     if state.ghost_link_trails {
         let refs = state.inbound_links();


### PR DESCRIPTION
## Summary
- restore drawing of mindmap parent connectors
- offset connector positions by lane distance
- use user setting for lane spacing when reflowing siblings

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683bd9ed888c832d83ec8b0477097471