### PR TITLE
Patch 25.76x triage feed improvements

### DIFF
--- a/src/modules/triage/input.rs
+++ b/src/modules/triage/input.rs
@@ -1,4 +1,5 @@
 use crossterm::event::{KeyCode, KeyModifiers, MouseEvent, MouseEventKind, MouseButton};
+use crate::layout::clamp_scroll;
 use crate::state::AppState;
 
 pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bool {
@@ -49,11 +50,15 @@ pub fn handle_key(state: &mut AppState, code: KeyCode, mods: KeyModifiers) -> bo
         KeyCode::Up if mods.is_empty() => {
             state.triage_focus_prev();
             state.triage_recalc_counts();
+            state.scroll_y = state.scroll_y.saturating_sub(1);
+            clamp_scroll(state);
             true
         }
         KeyCode::Down if mods.is_empty() => {
             state.triage_focus_next();
             state.triage_recalc_counts();
+            state.scroll_y = state.scroll_y.saturating_add(1);
+            clamp_scroll(state);
             true
         }
         _ => false,

--- a/src/modules/triage/render.rs
+++ b/src/modules/triage/render.rs
@@ -70,6 +70,18 @@ fn tag_color(tags: &[String]) -> Color {
     }
 }
 
+fn tag_icon(tags: &[String]) -> &'static str {
+    if tags.iter().any(|t| t.eq_ignore_ascii_case("#now")) {
+        "🔥"
+    } else if tags.iter().any(|t| t.eq_ignore_ascii_case("#triton")) {
+        "🧠"
+    } else if tags.iter().any(|t| t.eq_ignore_ascii_case("#done")) {
+        "✅"
+    } else {
+        "🏷️"
+    }
+}
+
 /// Calculate consecutive days with at least one `#DONE` entry.
 pub fn completion_streak(entries: &[TriageEntry]) -> usize {
     let days: HashSet<_> = entries
@@ -251,6 +263,9 @@ pub fn render_grouped<B: Backend>(
 
                 let mut line = highlight_entry_line(&entry.text);
                 line.spans.insert(0, Span::raw(" "));
+                if show_icons {
+                    line.spans.insert(0, Span::raw(format!("{} ", tag_icon(&entry.tags))));
+                }
                 line.spans.insert(0, Span::styled(format!("[{}] {}", entry.id, src), entry_style));
                 line.patch_style(entry_style);
                 lines.push(line);


### PR DESCRIPTION
## Summary
- enable scrolling in triage feed
- show per-entry icons

## Testing
- `cargo test --locked`
- `bash scripts/verify-test-plans.sh`

------
https://chatgpt.com/codex/tasks/task_e_683c35cb5d74832d8d51141153936915