### PR TITLE
patch-25.76y: Reposition dock to right edge of status bar

### DIFF
--- a/src/ui/dock.rs
+++ b/src/ui/dock.rs
@@ -24,7 +24,9 @@ enum DockAlign {
     Right,
 }
 
-const DOCK_ALIGN: DockAlign = DockAlign::Left;
+// Draw dock icons starting from the right-most slot so the group is
+// right-aligned within the status bar.
+const DOCK_ALIGN: DockAlign = DockAlign::Right;
 
 pub fn render_dock<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppState) {
     if !state.favorite_dock_enabled {

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -109,6 +109,8 @@ pub fn render_status<B: Backend>(f: &mut Frame<B>, area: Rect, state: &mut AppSt
     let zoom_w = zoom_text.len() as u16 + 2;
     let icon_content = format!("{} {}", module_icon(&state.mode), module_label(&state.mode));
     let icon_w = UnicodeWidthStr::width(icon_content.as_str()) as u16 + 2;
+    // Reserve space for zoom level, module label, and the right-side HUD
+    // while keeping a single space padding between the dock and zoom text.
     let offset = RESERVED_ZONE_W as u16 + icon_w + zoom_w + 1;
     let available = width.saturating_sub(dock_width + heart_w + offset);
 


### PR DESCRIPTION
## Summary
- align dock icons to the right side of the status bar
- preserve padding next to module name and zoom text
- document reserved spacing logic

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_683c4053efe0832da2f132c8f4a47385