### PR TITLE
Patch 25.77g – Zen: Restore Input Bar Visibility + Auto-Scroll

### DIFF
--- a/src/modules/zen/input.rs
+++ b/src/modules/zen/input.rs
@@ -157,6 +157,9 @@ pub fn handle_key(state: &mut AppState, key: KeyCode) {
                 state.append_journal_entry(&entry);
                 state.zen_draft.text.clear();
                 state.zen_draft.editing = None;
+                // Auto-scroll to show the newly added entry
+                state.scroll_offset = 0;
+                clamp_scroll_limit(state, state.zen_journal_entries.len());
             } else {
                 finalize_entry(state);
             }

--- a/src/modules/zen/render.rs
+++ b/src/modules/zen/render.rs
@@ -316,13 +316,16 @@ pub fn render_compose<B: Backend>(f: &mut Frame<B>, area: Rect, state: &AppState
     // Preserve manual scroll offset when reviewing history
 
     if state.zen_view_mode == ZenViewMode::Write {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(75), Constraint::Percentage(25)].as_ref())
-            .split(area);
-
-        render_history(f, chunks[0], state);
-        render_input(f, chunks[1], state, tick);
+        // Keep the input bar anchored to the bottom of the viewport
+        // while allowing history to scroll above it.
+        let history_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height.saturating_sub(2),
+        };
+        render_history(f, history_area, state);
+        render_input(f, area, state, tick);
     } else {
         render_history(f, area, state);
     }


### PR DESCRIPTION
## Summary
- keep zen compose input always visible at bottom
- auto-scroll to bottom after submitting new entry

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683c6eddb9c8832dac22224e5901f53d