### PR TITLE
patch-25.77h: Render sample triage feed + feed count

### DIFF
--- a/src/modules/triage/feed.rs
+++ b/src/modules/triage/feed.rs
@@ -82,11 +82,13 @@ pub fn load_sample(state: &mut AppState) {
     }
 
     let samples = [
-        "Fix crash #now",
-        "Add tag @UX #todo",
-        "✓ Completed #done",
-        "Refactor module #todo",
-        "Design plugin @infra #triton",
+        "[🔥] #now Fix crash on startup",
+        "[🧠] #triton Refactor rendering engine",
+        "[✅] #done Write unit tests",
+        "[💡] #todo Research plugin API",
+        "[📝] #todo Update documentation",
+        "[🔍] #triton Investigate memory leak",
+        "[🚀] #now Optimize build pipeline",
     ];
 
     for text in samples.iter() {

--- a/src/triage/state.rs
+++ b/src/triage/state.rs
@@ -160,3 +160,8 @@ pub fn tag_counts(state: &AppState) -> (usize, usize, usize) {
     }
     (now, triton, done)
 }
+
+/// Return the number of non-archived triage entries.
+pub fn feed_count(state: &AppState) -> usize {
+    state.triage_entries.iter().filter(|e| !e.archived).count()
+}

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -49,6 +49,7 @@ pub fn status_line(state: &AppState) -> String {
         }
         "triage" => {
             let (now, triton, done) = crate::triage::state::tag_counts(state);
+            let feed_total = crate::triage::state::feed_count(state);
             let bar = progress_bar(now, triton, done);
             let streak = completion_streak(&state.triage_entries);
             let spark = done_sparkline(&state.triage_entries, 7);
@@ -59,7 +60,8 @@ pub fn status_line(state: &AppState) -> String {
                 .map(|e| e.text.clone())
                 .unwrap_or_default();
             format!(
-                "#NOW:{} #TRITON:{} #DONE:{} {} {}{} {} | {}",
+                "Triage Feed: {} | #NOW:{} #TRITON:{} #DONE:{} {} {}{} {} | {}",
+                feed_total,
                 now,
                 triton,
                 done,


### PR DESCRIPTION
## Summary
- add visible sample triage feed items
- count triage feed entries in status bar

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683c70c737b8832d98401f6d092e0255